### PR TITLE
flash-attn3: fixes + build for CUDA >= 12.8

### DIFF
--- a/flash-attn3/build.toml
+++ b/flash-attn3/build.toml
@@ -1,8 +1,7 @@
 [general]
-name = "flash_attn3"
+name = "flash-attn3"
 universal = false
-cuda-minver = "12.4"
-cuda-maxver = "12.4"
+cuda-minver = "12.8"
 
 [torch]
 src = [
@@ -19,11 +18,11 @@ cuda-flags = [
   "-std=c++17",
   "--ftemplate-backtrace-limit=0",              # To debug template code
   "--use_fast_math",
+  #"--resource-usage",
+  #"-lineinfo",
   "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED",
   "-DCUTLASS_ENABLE_GDC_FOR_SM90",
-  "--expt-relaxed-constexpr",
-  "--expt-extended-lambda",
-  "--use_fast_math",
+  "-DCUTLASS_DEBUG_TRACE_LEVEL=0",
   "-DNDEBUG",
 ]
 
@@ -45,17 +44,17 @@ depends = ["torch", "cutlass_3_9"]
 
 [kernel.flash_attn_sm80]
 backend = "cuda"
-cuda-capabilities = ["8.0", "9.0a"]
+cuda-capabilities = ["8.0"]
 cuda-flags = [
   "-O3",
   "-std=c++17",
   "--ftemplate-backtrace-limit=0",              # To debug template code
   "--use_fast_math",
+  #"--resource-usage",
+  #"-lineinfo",
   "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED",
   "-DCUTLASS_ENABLE_GDC_FOR_SM90",
-  "--expt-relaxed-constexpr",
-  "--expt-extended-lambda",
-  "--use_fast_math",
+  "-DCUTLASS_DEBUG_TRACE_LEVEL=0",
   "-DNDEBUG",
 ]
 src = [
@@ -193,17 +192,17 @@ depends = ["torch", "cutlass_3_9"]
 
 [kernel.flash_attn_sm90]
 backend = "cuda"
-cuda-capabilities = ["8.0", "9.0a"]
+cuda-capabilities = ["9.0a"]
 cuda-flags = [
   "-O3",
   "-std=c++17",
   "--ftemplate-backtrace-limit=0",              # To debug template code
   "--use_fast_math",
+  #"--resource-usage",
+  #"-lineinfo",
   "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED",
   "-DCUTLASS_ENABLE_GDC_FOR_SM90",
-  "--expt-relaxed-constexpr",
-  "--expt-extended-lambda",
-  "--use_fast_math",
+  "-DCUTLASS_DEBUG_TRACE_LEVEL=0",
   "-DNDEBUG",
 ]
 src = [
@@ -547,11 +546,11 @@ depends = ["torch", "cutlass_3_9"]
 #   "-std=c++17",
 #   "--ftemplate-backtrace-limit=0",              # To debug template code
 #   "--use_fast_math",
+#   "--resource-usage",
+#   "-lineinfo",
 #   "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED",
 #   "-DCUTLASS_ENABLE_GDC_FOR_SM90",
-#   "--expt-relaxed-constexpr",
-#   "--expt-extended-lambda",
-#   "--use_fast_math",
+#   "-DCUTLASS_DEBUG_TRACE_LEVEL=0",
 #   "-DNDEBUG",
 # ]
 # src = [

--- a/flash-attn3/flake.lock
+++ b/flash-attn3/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1760814603,
-        "narHash": "sha256-i5uuhnJPxOrd0dC8+btp31WMfzPDL8Uwz0TPG2n6nHE=",
+        "lastModified": 1762504832,
+        "narHash": "sha256-PIxh2ZFqq3CAkQNtupT0AfxA1n3raM/3enDLHn4a21k=",
         "owner": "huggingface",
         "repo": "hf-nix",
-        "rev": "c0b62ec3d0abb11dd2d960e3dfee3a46fc46d111",
+        "rev": "3267e738faafa71bed7de9b75d74f6a90ec1bc57",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761645431,
-        "narHash": "sha256-Ns3m/L+FMAYnmKhwt4vlIf8lq6dOJWHAocFL23HasTM=",
+        "lastModified": 1762885614,
+        "narHash": "sha256-9EQ+4YAh+iCUkTDKBMJyA1SjZihS/f1DnVSMUSOO5LQ=",
         "owner": "huggingface",
         "repo": "kernel-builder",
-        "rev": "289788986c318e6ccb92608f011c49d61b25b5b6",
+        "rev": "49b78f0d0b43b911e95e692b3326e25ebdb20620",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755963616,
-        "narHash": "sha256-6yD0ww/S8n+U2uPYcJZ3DRURP8Kx036GRpR2uPNZroE=",
+        "lastModified": 1762168314,
+        "narHash": "sha256-+DX6mIF47gRGoK0mqkTg1Jmcjcup0CAXJFHVkdUx8YA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73e96df7cff5783f45e21342a75a1540c4eddce4",
+        "rev": "94fc102d2c15d9c1a861e59de550807c65358e1b",
         "type": "github"
       },
       "original": {

--- a/flash-attn3/flake.nix
+++ b/flash-attn3/flake.nix
@@ -13,23 +13,5 @@
     kernel-builder.lib.genFlakeOutputs {
       inherit self;
       path = ./.;
-      # Building with CUDA later than 12.4 fails with:
-      #
-      # error: 'ptxas' died due to signal 11 (Invalid memory reference)
-      #
-      # So, build for 12.4 only and copy to all the other build variants
-      # by hand (which works fine thanks to backward compat).
-      torchVersions = _: [
-        {
-          torchVersion = "2.9";
-          cudaVersion = "12.4";
-          cxx11Abi = true;
-          systems = [
-            "x86_64-linux"
-            "aarch64-linux"
-          ];
-          bundleBuild = true;
-        }
-      ];
     };
 }


### PR DESCRIPTION
- Set project name `flash_attn3` -> `flash-attn3`.
- Sync compiler flags with upstream.
- Build on CUDA => 12.8. 12.6 still fails with an internal compiler error, but 12.8 is the default for Torch now anyway + this will enable CUDA 13.