### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-pr-mac.yaml
+++ b/.github/workflows/build-pr-mac.yaml
@@ -11,7 +11,7 @@ jobs:
   build-kernel:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v20
         with:
           extra-conf: |

--- a/.github/workflows/build-pr-windows.yaml
+++ b/.github/workflows/build-pr-windows.yaml
@@ -24,7 +24,7 @@ jobs:
 
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Validate kernel directory
         id: validate
         shell: pwsh
@@ -65,7 +65,7 @@ jobs:
 
       - name: Setup Python
         if: steps.validate.outputs.skip == 'false'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout kernel-builder
         if: steps.validate.outputs.skip == 'false'
         id: checkout-kernel-builder
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: huggingface/kernel-builder
           ref: "${{ steps.extract-builder-version.outputs.revision }}"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Cache Rust build
         if: steps.validate.outputs.skip == 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             kernel-builder/build2cmake/target

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on:
       group: aws-highmemory-32-plus-nix
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |

--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v20
         with:
           extra-conf: |

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on:
       group: aws-highmemory-32-plus-nix
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |

--- a/.github/workflows/manual-build-upload.yaml
+++ b/.github/workflows/manual-build-upload.yaml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Checkout selected branch
         if: ${{ inputs.pr_number == '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout PR branch
         if: ${{ inputs.pr_number != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ inputs.pr_number }}/head
           fetch-depth: 0

--- a/.github/workflows/nightly_kernel_check.yml
+++ b/.github/workflows/nightly_kernel_check.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/nix_fmt.yaml
+++ b/.github/workflows/nix_fmt.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Check Nix formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | build-pr-windows.yaml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4), [`v5`](https://github.com/actions/checkout/releases/tag/v5) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build-pr-mac.yaml, build-pr-windows.yaml, build-pr.yaml, build-release-mac.yaml, build-release.yaml, manual-build-upload.yaml, nightly_kernel_check.yml, nix_fmt.yaml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build-pr-windows.yaml, nightly_kernel_check.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
