### PR TITLE
[Windows] Fix the way we retrieve PR_TITLE from the environment

### DIFF
--- a/.github/workflows/build-pr-windows.yaml
+++ b/.github/workflows/build-pr-windows.yaml
@@ -29,9 +29,9 @@ jobs:
         id: validate
         shell: pwsh
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PRTITLE: ${{ github.event.pull_request.title }}
         run: |
-          $KERNEL = python .github/workflows/validate-kernel-pr.py "pr" "$PR_TITLE"
+          $KERNEL = python .github/workflows/validate-kernel-pr.py "pr" "$Env:PRTITLE"
           if ($LASTEXITCODE -eq 0) {
             echo "kernel=$KERNEL" >> $env:GITHUB_OUTPUT
             echo "skip=false" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Use proper powershell syntax to retrieve `PRTITLE` environment variable instead of the Unix way