### PR TITLE
fp8-fbgemm: build for Torch 2.10 RC3

### DIFF
--- a/fp8-fbgemm/flake.lock
+++ b/fp8-fbgemm/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -40,32 +40,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1765373725,
-        "narHash": "sha256-bMZUewjVTRqUN0r0kcUJwm3vCiqhGXFpxo3xbaHiNS8=",
+        "lastModified": 1766513118,
+        "narHash": "sha256-Sn6jSn5wQw4ZQKNTaLtkMGVIvEp0RjgcLc8bmSkfaQ8=",
         "owner": "huggingface",
         "repo": "kernel-builder",
-        "rev": "d7aa2703fd2df7b07d24d4a61b134c3b2d1e00aa",
+        "rev": "8fa73526576583a3fbcb8d30660d67c4e9dc5159",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
+        "ref": "torch-2.10",
         "repo": "kernel-builder",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763291491,
-        "narHash": "sha256-eEYvm+45PPmy+Qe+nZDpn1uhoMUjJwx3PwVVQoO9ksA=",
+        "lastModified": 1766341660,
+        "narHash": "sha256-4yG6vx7Dddk9/zh45Y2KM82OaRD4jO3HA9r98ORzysA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c543a59edf25ada193719764f3bc0c6ba835f94d",
+        "rev": "26861f5606e3e4d1400771b513cc63e5f70151a6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
-        "rev": "c543a59edf25ada193719764f3bc0c6ba835f94d",
         "type": "github"
       }
     },

--- a/fp8-fbgemm/flake.nix
+++ b/fp8-fbgemm/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for fp8-fbgemm kernels";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernel-builder";
+    kernel-builder.url = "github:huggingface/kernel-builder/torch-2.10";
   };
 
   outputs =


### PR DESCRIPTION
Automated update to target kernel-builder torch-2.10 branch.