### PR TITLE
rmsnorm: build for Torch 2.10 RC3

### DIFF
--- a/rmsnorm/build.toml
+++ b/rmsnorm/build.toml
@@ -1,46 +1,17 @@
 [general]
 name = "rmsnorm"
-universal = false
+backends = [
+    "cpu",
+    "xpu",
+]
 
 [torch]
 src = ["torch-ext/torch_binding.cpp"]
 
-[kernel.rmsnorm_cpu]
-backend = "cpu"
-depends = ["torch"]
-src = [
-    "rmsnorm_cpu/rmsnorm_cpu_torch.cpp",
-    "rmsnorm_cpu/rmsnorm_cpu.cpp",
-    "rmsnorm_cpu/rmsnorm_cpu.hpp",
-    "rmsnorm_cpu/cpu_features.hpp",
-]
-include = ["rmsnorm_cpu"]
-
-[kernel.rmsnorm_cpu_avx512]
-backend = "cpu"
-depends = ["torch"]
-src = [
-    "rmsnorm_cpu/rmsnorm_avx512.cpp",
-    "rmsnorm_cpu/rmsnorm_avx512.hpp",
-    "rmsnorm_cpu/cpu_types_avx512.hpp",
-]
-include = ["rmsnorm_cpu"]
-cxx-flags = ["-mfma", "-fopenmp", "-mf16c", "-mavx512f", "-mavx512bf16", "-mavx512vl"]
-
-[kernel.rmsnorm_cpu_avx2]
-backend = "cpu"
-depends = ["torch"]
-src = [
-    "rmsnorm_cpu/rmsnorm_avx2.cpp",
-    "rmsnorm_cpu/rmsnorm_avx2.hpp",
-    "rmsnorm_cpu/cpu_types_avx2.hpp",
-]
-include = ["rmsnorm_cpu"]
-cxx-flags = ["-mavx2", "-mfma", "-fopenmp", "-mf16c"]
-
 [kernel.rmsnorm_xpu]
 backend = "xpu"
 depends = ["torch"]
+include = ["rmsnorm_xpu/dpcpp"]
 src = [
     "rmsnorm_xpu/rmsnorm_xpu.cpp",
     "rmsnorm_xpu/RMSNorm.hpp",
@@ -80,5 +51,48 @@ src = [
     "rmsnorm_xpu/dpcpp/oneDNN/Runtime.h",
     "rmsnorm_xpu/dpcpp/oneDNN/Utils.h",
 ]
-include = ["rmsnorm_xpu/dpcpp"]
 
+[kernel.rmsnorm_cpu_avx2]
+backend = "cpu"
+cxx-flags = [
+    "-mavx2",
+    "-mfma",
+    "-fopenmp",
+    "-mf16c",
+]
+depends = ["torch"]
+include = ["rmsnorm_cpu"]
+src = [
+    "rmsnorm_cpu/rmsnorm_avx2.cpp",
+    "rmsnorm_cpu/rmsnorm_avx2.hpp",
+    "rmsnorm_cpu/cpu_types_avx2.hpp",
+]
+
+[kernel.rmsnorm_cpu]
+backend = "cpu"
+depends = ["torch"]
+include = ["rmsnorm_cpu"]
+src = [
+    "rmsnorm_cpu/rmsnorm_cpu_torch.cpp",
+    "rmsnorm_cpu/rmsnorm_cpu.cpp",
+    "rmsnorm_cpu/rmsnorm_cpu.hpp",
+    "rmsnorm_cpu/cpu_features.hpp",
+]
+
+[kernel.rmsnorm_cpu_avx512]
+backend = "cpu"
+cxx-flags = [
+    "-mfma",
+    "-fopenmp",
+    "-mf16c",
+    "-mavx512f",
+    "-mavx512bf16",
+    "-mavx512vl",
+]
+depends = ["torch"]
+include = ["rmsnorm_cpu"]
+src = [
+    "rmsnorm_cpu/rmsnorm_avx512.cpp",
+    "rmsnorm_cpu/rmsnorm_avx512.hpp",
+    "rmsnorm_cpu/cpu_types_avx512.hpp",
+]

--- a/rmsnorm/flake.lock
+++ b/rmsnorm/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -40,32 +40,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1763649391,
-        "narHash": "sha256-XM5ptF3zZ9ZOTMjWOQxD502Jc/46Y2k/nrgDf4i3bxA=",
+        "lastModified": 1767616147,
+        "narHash": "sha256-0rQI29rwgbNwVXkqsGMdkGBZcjSaCAbz1APpY2FqXfQ=",
         "owner": "huggingface",
         "repo": "kernel-builder",
-        "rev": "7987361891c46a9e3cfe07eba9aa3e52638906fe",
+        "rev": "8d35e7246070841d59a0b328f2aba3f4e0b168eb",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
+        "ref": "torch-2.10",
         "repo": "kernel-builder",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763291491,
-        "narHash": "sha256-eEYvm+45PPmy+Qe+nZDpn1uhoMUjJwx3PwVVQoO9ksA=",
+        "lastModified": 1766341660,
+        "narHash": "sha256-4yG6vx7Dddk9/zh45Y2KM82OaRD4jO3HA9r98ORzysA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c543a59edf25ada193719764f3bc0c6ba835f94d",
+        "rev": "26861f5606e3e4d1400771b513cc63e5f70151a6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
-        "rev": "c543a59edf25ada193719764f3bc0c6ba835f94d",
         "type": "github"
       }
     },

--- a/rmsnorm/flake.nix
+++ b/rmsnorm/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Flake for Torch kernel extension";
   inputs = {
-    kernel-builder.url = "github:huggingface/kernel-builder";
+    kernel-builder.url = "github:huggingface/kernel-builder/torch-2.10";
   };
   outputs =
     { self, kernel-builder }:


### PR DESCRIPTION
Automated update to target kernel-builder torch-2.10 branch.