### PR TITLE
deformable-detr: build for Torch 2.10 RC4

### DIFF
--- a/deformable-detr/build.toml
+++ b/deformable-detr/build.toml
@@ -1,5 +1,6 @@
 [general]
 name = "deformable-detr"
+version = 1
 backends = ["cuda"]
 
 [torch]

--- a/deformable-detr/flake.lock
+++ b/deformable-detr/flake.lock
@@ -40,15 +40,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1767868662,
-        "narHash": "sha256-ApVGObjNyB6lga3vkd6yCCuFekPKsTCXaDVvQ+NU07o=",
+        "lastModified": 1768319565,
+        "narHash": "sha256-HLdzfYg3C/diFIMQp8erL7yqrTjjy7qw3wH/EQyPPU8=",
         "owner": "huggingface",
         "repo": "kernel-builder",
-        "rev": "c6c83df374ba0f43b53883ed3a4eeb94709706ee",
+        "rev": "0f5b327b4c5e6c0c8cd3ea6c58ecc2a3bd98a057",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
+        "ref": "version-option",
         "repo": "kernel-builder",
         "type": "github"
       }

--- a/deformable-detr/flake.nix
+++ b/deformable-detr/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for deformable_detr kernels";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernel-builder";
+    kernel-builder.url = "github:huggingface/kernel-builder/version-option";
   };
 
   outputs =


### PR DESCRIPTION
Automated update to target kernel-builder torch-2.10 branch.