### PR TITLE
rotary: Remove The Unused Parameter

### DIFF
--- a/rotary/torch-ext/rotary/__init__.py
+++ b/rotary/torch-ext/rotary/__init__.py
@@ -21,7 +21,6 @@ def apply_rotary_transformers(
     k: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
-    position_ids: Optional[torch.Tensor] = None,
     unsqueeze_dim: int = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """


### PR DESCRIPTION
Remove the unused `position_ids` parameter to adapt to the latest `transformers`.