### PR TITLE
activation: add metal implemenation

### DIFF
--- a/activation/activation_metal/activation.metal
+++ b/activation/activation_metal/activation.metal
@@ -1,0 +1,995 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// A&S 7.1.26 polynomial (~1.5e-7 max error), replaces CUDA's built-in erf()
+inline float erf_approx(float x) {
+    float sign = (x >= 0.0f) ? 1.0f : -1.0f;
+    x = metal::abs(x);
+
+    constexpr float a1 =  0.254829592f;
+    constexpr float a2 = -0.284496736f;
+    constexpr float a3 =  1.421413741f;
+    constexpr float a4 = -1.453152027f;
+    constexpr float a5 =  1.061405429f;
+    constexpr float p  =  0.3275911f;
+
+    float t = 1.0f / metal::fma(p, x, 1.0f);
+
+    float poly = metal::fma(a5, t, a4);
+    poly = metal::fma(poly, t, a3);
+    poly = metal::fma(poly, t, a2);
+    poly = metal::fma(poly, t, a1);
+    poly = poly * t;
+
+    float y = metal::fma(-poly, metal::exp(-x * x), 1.0f);
+    return sign * y;
+}
+
+inline float4 erf_approx4(float4 x) {
+    float4 sign = select(float4(-1.0f), float4(1.0f), x >= 0.0f);
+    x = metal::abs(x);
+
+    constexpr float a1 =  0.254829592f;
+    constexpr float a2 = -0.284496736f;
+    constexpr float a3 =  1.421413741f;
+    constexpr float a4 = -1.453152027f;
+    constexpr float a5 =  1.061405429f;
+    constexpr float p  =  0.3275911f;
+
+    float4 t = 1.0f / metal::fma(float4(p), x, float4(1.0f));
+
+    float4 poly = metal::fma(float4(a5), t, float4(a4));
+    poly = metal::fma(poly, t, float4(a3));
+    poly = metal::fma(poly, t, float4(a2));
+    poly = metal::fma(poly, t, float4(a1));
+    poly = poly * t;
+
+    float4 y = metal::fma(-poly, metal::exp(-x * x), float4(1.0f));
+    return sign * y;
+}
+
+// Matches CUDA silu_kernel: x * sigmoid(x)
+// activation/activation_kernels.cu:35
+inline float silu_f(float x) {
+    return x / (1.0f + metal::exp(-x));
+}
+
+// Matches CUDA gelu_kernel: 0.5x(1 + erf(x/sqrt(2))), uses erf_approx
+// activation/activation_kernels.cu:41
+inline float gelu_f(float x) {
+    constexpr float INV_SQRT2 = 0.7071067811865475f;
+    return 0.5f * x * metal::fma(erf_approx(x * INV_SQRT2), 1.0f, 1.0f);
+}
+
+// Matches CUDA gelu_tanh_kernel: 0.5x(1 + tanh(sqrt(2/pi)(x + 0.044715x^3)))
+// activation/activation_kernels.cu:51
+inline float gelu_tanh_f(float x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float x2 = x * x;
+    float inner = SQRT_2_OVER_PI * metal::fma(KAPPA * x2, x, x);
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+// Matches CUDA fatrelu_kernel
+// activation/activation_kernels.cu:122
+inline float fatrelu_f(float x, float threshold) {
+    return (x > threshold) ? x : 0.0f;
+}
+
+// Matches CUDA gelu_new_kernel, same formula as gelu_tanh with different eval order
+// activation/activation_kernels.cu:198
+inline float gelu_new_f(float x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float x2 = x * x;
+    float inner = SQRT_2_OVER_PI * metal::fma(KAPPA * x2, x, x);
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+// Matches CUDA gelu_fast_kernel: 0.5x(1 + tanh(x*sqrt(2/pi)*(1 + 0.044715x^2)))
+// activation/activation_kernels.cu:205
+inline float gelu_fast_f(float x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float x2 = x * x;
+    float inner = x * SQRT_2_OVER_PI * metal::fma(KAPPA, x2, 1.0f);
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+// Matches CUDA gelu_quick_kernel: x * sigmoid(1.702x)
+// activation/activation_kernels.cu:213
+inline float gelu_quick_f(float x) {
+    return x / (1.0f + metal::exp(-1.702f * x));
+}
+
+inline float4 silu_f4(float4 x) {
+    return x / (1.0f + metal::exp(-x));
+}
+
+inline float4 gelu_f4(float4 x) {
+    constexpr float INV_SQRT2 = 0.7071067811865475f;
+    return 0.5f * x * metal::fma(erf_approx4(x * INV_SQRT2), float4(1.0f), float4(1.0f));
+}
+
+inline float4 gelu_tanh_f4(float4 x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float4 x2 = x * x;
+    float4 inner = SQRT_2_OVER_PI * metal::fma(float4(KAPPA) * x2, x, x);
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+inline float4 fatrelu_f4(float4 x, float threshold) {
+    return select(float4(0.0f), x, x > threshold);
+}
+
+inline float4 gelu_new_f4(float4 x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float4 x2 = x * x;
+    float4 inner = SQRT_2_OVER_PI * metal::fma(float4(KAPPA) * x2, x, x);
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+inline float4 gelu_fast_f4(float4 x) {
+    constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
+    constexpr float KAPPA = 0.044715f;
+    float4 x2 = x * x;
+    float4 inner = x * SQRT_2_OVER_PI * metal::fma(float4(KAPPA), x2, float4(1.0f));
+    return 0.5f * x * (1.0f + metal::tanh(inner));
+}
+
+inline float4 gelu_quick_f4(float4 x) {
+    return x / (1.0f + metal::exp(-1.702f * x));
+}
+
+kernel void silu_and_mul_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx + 4]);
+        float4 y0 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        float4 y1 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx + 4]);
+
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = silu_f4(x0) * y0;
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx + 4]) = silu_f4(x1) * y1;
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 y = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = silu_f4(x) * y;
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = silu_f(xi) * yi;
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = silu_f(xi) * yi;
+        }
+    }
+}
+
+kernel void silu_and_mul_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx + 4]));
+        float4 y0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        float4 y1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx + 4]));
+
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(silu_f4(x0) * y0);
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx + 4]) = half4(silu_f4(x1) * y1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 y = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(silu_f4(x) * y);
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(silu_f(xi) * yi);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(silu_f(xi) * yi);
+        }
+    }
+}
+
+kernel void mul_and_silu_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx + 4]);
+        float4 y0 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        float4 y1 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx + 4]);
+
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = x0 * silu_f4(y0);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx + 4]) = x1 * silu_f4(y1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 y = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = x * silu_f4(y);
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = xi * silu_f(yi);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = xi * silu_f(yi);
+        }
+    }
+}
+
+kernel void mul_and_silu_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx + 4]));
+        float4 y0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        float4 y1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx + 4]));
+
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(x0 * silu_f4(y0));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx + 4]) = half4(x1 * silu_f4(y1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 y = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(x * silu_f4(y));
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(xi * silu_f(yi));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(xi * silu_f(yi));
+        }
+    }
+}
+
+kernel void gelu_and_mul_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx + 4]);
+        float4 y0 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        float4 y1 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx + 4]);
+
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = gelu_f4(x0) * y0;
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx + 4]) = gelu_f4(x1) * y1;
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 y = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = gelu_f4(x) * y;
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = gelu_f(xi) * yi;
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = gelu_f(xi) * yi;
+        }
+    }
+}
+
+kernel void gelu_and_mul_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx + 4]));
+        float4 y0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        float4 y1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx + 4]));
+
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(gelu_f4(x0) * y0);
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx + 4]) = half4(gelu_f4(x1) * y1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 y = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(gelu_f4(x) * y);
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(gelu_f(xi) * yi);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(gelu_f(xi) * yi);
+        }
+    }
+}
+
+kernel void gelu_tanh_and_mul_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx + 4]);
+        float4 y0 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        float4 y1 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx + 4]);
+
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = gelu_tanh_f4(x0) * y0;
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx + 4]) = gelu_tanh_f4(x1) * y1;
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 y = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = gelu_tanh_f4(x) * y;
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = gelu_tanh_f(xi) * yi;
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = gelu_tanh_f(xi) * yi;
+        }
+    }
+}
+
+kernel void gelu_tanh_and_mul_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx + 4]));
+        float4 y0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        float4 y1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx + 4]));
+
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(gelu_tanh_f4(x0) * y0);
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx + 4]) = half4(gelu_tanh_f4(x1) * y1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 y = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(gelu_tanh_f4(x) * y);
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(gelu_tanh_f(xi) * yi);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(gelu_tanh_f(xi) * yi);
+        }
+    }
+}
+
+kernel void fatrelu_and_mul_f32(
+    device float*       out       [[buffer(0)]],
+    device const float* input     [[buffer(1)]],
+    constant uint&      d         [[buffer(2)]],
+    constant float&     threshold [[buffer(3)]],
+    uint2 gid                     [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[in_base + base_idx + 4]);
+        float4 y0 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        float4 y1 = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx + 4]);
+
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = fatrelu_f4(x0, threshold) * y0;
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx + 4]) = fatrelu_f4(x1, threshold) * y1;
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[in_base + base_idx]);
+        float4 y = *reinterpret_cast<device const float4*>(&input[in_base + d + base_idx]);
+        *reinterpret_cast<device float4*>(&out[out_base + base_idx]) = fatrelu_f4(x, threshold) * y;
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = fatrelu_f(xi, threshold) * yi;
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = input[in_base + i];
+            float yi = input[in_base + d + i];
+            out[out_base + i] = fatrelu_f(xi, threshold) * yi;
+        }
+    }
+}
+
+kernel void fatrelu_and_mul_f16(
+    device half*        out       [[buffer(0)]],
+    device const half*  input     [[buffer(1)]],
+    constant uint&      d         [[buffer(2)]],
+    constant float&     threshold [[buffer(3)]],
+    uint2 gid                     [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint in_base = tok * 2u * d;
+    uint out_base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx + 4]));
+        float4 y0 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        float4 y1 = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx + 4]));
+
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(fatrelu_f4(x0, threshold) * y0);
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx + 4]) = half4(fatrelu_f4(x1, threshold) * y1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[in_base + base_idx]));
+        float4 y = float4(*reinterpret_cast<device const half4*>(&input[in_base + d + base_idx]));
+        *reinterpret_cast<device half4*>(&out[out_base + base_idx]) = half4(fatrelu_f4(x, threshold) * y);
+
+        for (uint i = base_idx + 4; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(fatrelu_f(xi, threshold) * yi);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            float xi = float(input[in_base + i]);
+            float yi = float(input[in_base + d + i]);
+            out[out_base + i] = half(fatrelu_f(xi, threshold) * yi);
+        }
+    }
+}
+
+kernel void silu_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = silu_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = silu_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = silu_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = silu_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = silu_f(input[base + i]);
+        }
+    }
+}
+
+kernel void silu_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(silu_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(silu_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(silu_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(silu_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(silu_f(float(input[base + i])));
+        }
+    }
+}
+
+kernel void gelu_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = gelu_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = gelu_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = gelu_f(input[base + i]);
+        }
+    }
+}
+
+kernel void gelu_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(gelu_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(gelu_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(gelu_f(float(input[base + i])));
+        }
+    }
+}
+
+kernel void gelu_tanh_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_tanh_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = gelu_tanh_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_tanh_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = gelu_tanh_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = gelu_tanh_f(input[base + i]);
+        }
+    }
+}
+
+kernel void gelu_tanh_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_tanh_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(gelu_tanh_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_tanh_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(gelu_tanh_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(gelu_tanh_f(float(input[base + i])));
+        }
+    }
+}
+
+kernel void gelu_new_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_new_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = gelu_new_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_new_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = gelu_new_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = gelu_new_f(input[base + i]);
+        }
+    }
+}
+
+kernel void gelu_new_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_new_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(gelu_new_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_new_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(gelu_new_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(gelu_new_f(float(input[base + i])));
+        }
+    }
+}
+
+kernel void gelu_fast_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_fast_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = gelu_fast_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_fast_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = gelu_fast_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = gelu_fast_f(input[base + i]);
+        }
+    }
+}
+
+kernel void gelu_fast_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_fast_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(gelu_fast_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_fast_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(gelu_fast_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(gelu_fast_f(float(input[base + i])));
+        }
+    }
+}
+
+kernel void gelu_quick_f32(
+    device float*       out   [[buffer(0)]],
+    device const float* input [[buffer(1)]],
+    constant uint&      d     [[buffer(2)]],
+    uint2 gid                 [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        float4 x1 = *reinterpret_cast<device const float4*>(&input[base + base_idx + 4]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_quick_f4(x0);
+        *reinterpret_cast<device float4*>(&out[base + base_idx + 4]) = gelu_quick_f4(x1);
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = *reinterpret_cast<device const float4*>(&input[base + base_idx]);
+        *reinterpret_cast<device float4*>(&out[base + base_idx]) = gelu_quick_f4(x);
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = gelu_quick_f(input[base + i]);
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = gelu_quick_f(input[base + i]);
+        }
+    }
+}
+
+kernel void gelu_quick_f16(
+    device half*       out   [[buffer(0)]],
+    device const half* input [[buffer(1)]],
+    constant uint&     d     [[buffer(2)]],
+    uint2 gid                [[thread_position_in_grid]]
+) {
+    uint idx8 = gid.x;
+    uint tok = gid.y;
+    uint base_idx = idx8 * 8;
+
+    if (base_idx >= d) return;
+
+    uint base = tok * d;
+
+    if (base_idx + 8 <= d) {
+        float4 x0 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        float4 x1 = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx + 4]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_quick_f4(x0));
+        *reinterpret_cast<device half4*>(&out[base + base_idx + 4]) = half4(gelu_quick_f4(x1));
+    }
+    else if (base_idx + 4 <= d) {
+        float4 x = float4(*reinterpret_cast<device const half4*>(&input[base + base_idx]));
+        *reinterpret_cast<device half4*>(&out[base + base_idx]) = half4(gelu_quick_f4(x));
+        for (uint i = base_idx + 4; i < d; i++) {
+            out[base + i] = half(gelu_quick_f(float(input[base + i])));
+        }
+    }
+    else {
+        for (uint i = base_idx; i < d; i++) {
+            out[base + i] = half(gelu_quick_f(float(input[base + i])));
+        }
+    }
+}

--- a/activation/activation_metal/activation.mm
+++ b/activation/activation_metal/activation.mm
@@ -1,0 +1,272 @@
+#include <torch/torch.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+// Include the auto-generated header with embedded metallib
+#ifdef EMBEDDED_METALLIB_HEADER
+#include EMBEDDED_METALLIB_HEADER
+#else
+#error "EMBEDDED_METALLIB_HEADER not defined"
+#endif
+
+static inline id<MTLBuffer> getMTLBufferStorage(const torch::Tensor &tensor) {
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
+static void dispatchGatedKernel(const std::string &kernelName,
+                                torch::Tensor &out,
+                                torch::Tensor const &input) {
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+
+    const uint32_t d = static_cast<uint32_t>(input.size(-1) / 2);
+    const uint32_t numTokens =
+        static_cast<uint32_t>(input.numel() / input.size(-1));
+
+    if (numTokens == 0 || d == 0) return;
+
+    NSError *error = nil;
+    id<MTLLibrary> library =
+        EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+    TORCH_CHECK(library, "Failed to create Metal library: ",
+                error.localizedDescription.UTF8String);
+
+    std::string kernel_name =
+        kernelName + (input.scalar_type() == torch::kFloat ? "_f32" : "_f16");
+    id<MTLFunction> function = [library
+        newFunctionWithName:[NSString stringWithUTF8String:kernel_name.c_str()]];
+    TORCH_CHECK(function, "Failed to create function: ", kernel_name.c_str());
+
+    id<MTLComputePipelineState> pso =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    TORCH_CHECK(pso, "Failed to create pipeline state: ",
+                error.localizedDescription.UTF8String);
+
+    id<MTLCommandBuffer> commandBuffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(commandBuffer, "Failed to get command buffer");
+
+    dispatch_queue_t serialQueue = torch::mps::get_dispatch_queue();
+
+    dispatch_sync(serialQueue, ^() {
+      id<MTLComputeCommandEncoder> encoder =
+          [commandBuffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create compute encoder");
+
+      [encoder setComputePipelineState:pso];
+      [encoder setBuffer:getMTLBufferStorage(out)
+                  offset:out.storage_offset() * out.element_size()
+                 atIndex:0];
+      [encoder setBuffer:getMTLBufferStorage(input)
+                  offset:input.storage_offset() * input.element_size()
+                 atIndex:1];
+      [encoder setBytes:&d length:sizeof(uint32_t) atIndex:2];
+
+      uint32_t numChunks = (d + 7) / 8;
+      MTLSize gridSize = MTLSizeMake(numChunks, numTokens, 1);
+      NSUInteger threadGroupWidth =
+          std::min<NSUInteger>(numChunks, pso.maxTotalThreadsPerThreadgroup);
+      MTLSize threadGroupSize = MTLSizeMake(threadGroupWidth, 1, 1);
+
+      [encoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
+      [encoder endEncoding];
+
+      torch::mps::commit();
+    });
+  }
+}
+
+static void dispatchGatedKernelWithThreshold(const std::string &kernelName,
+                                             torch::Tensor &out,
+                                             torch::Tensor const &input,
+                                             float threshold) {
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+
+    const uint32_t d = static_cast<uint32_t>(input.size(-1) / 2);
+    const uint32_t numTokens =
+        static_cast<uint32_t>(input.numel() / input.size(-1));
+
+    if (numTokens == 0 || d == 0) return;
+
+    NSError *error = nil;
+    id<MTLLibrary> library =
+        EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+    TORCH_CHECK(library, "Failed to create Metal library: ",
+                error.localizedDescription.UTF8String);
+
+    std::string kernel_name =
+        kernelName + (input.scalar_type() == torch::kFloat ? "_f32" : "_f16");
+    id<MTLFunction> function = [library
+        newFunctionWithName:[NSString stringWithUTF8String:kernel_name.c_str()]];
+    TORCH_CHECK(function, "Failed to create function: ", kernel_name.c_str());
+
+    id<MTLComputePipelineState> pso =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    TORCH_CHECK(pso, "Failed to create pipeline state: ",
+                error.localizedDescription.UTF8String);
+
+    id<MTLCommandBuffer> commandBuffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(commandBuffer, "Failed to get command buffer");
+
+    dispatch_queue_t serialQueue = torch::mps::get_dispatch_queue();
+
+    dispatch_sync(serialQueue, ^() {
+      id<MTLComputeCommandEncoder> encoder =
+          [commandBuffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create compute encoder");
+
+      [encoder setComputePipelineState:pso];
+      [encoder setBuffer:getMTLBufferStorage(out)
+                  offset:out.storage_offset() * out.element_size()
+                 atIndex:0];
+      [encoder setBuffer:getMTLBufferStorage(input)
+                  offset:input.storage_offset() * input.element_size()
+                 atIndex:1];
+      [encoder setBytes:&d length:sizeof(uint32_t) atIndex:2];
+      [encoder setBytes:&threshold length:sizeof(float) atIndex:3];
+
+      uint32_t numChunks = (d + 7) / 8;
+      MTLSize gridSize = MTLSizeMake(numChunks, numTokens, 1);
+      NSUInteger threadGroupWidth =
+          std::min<NSUInteger>(numChunks, pso.maxTotalThreadsPerThreadgroup);
+      MTLSize threadGroupSize = MTLSizeMake(threadGroupWidth, 1, 1);
+
+      [encoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
+      [encoder endEncoding];
+
+      torch::mps::commit();
+    });
+  }
+}
+
+static void dispatchElementwiseKernel(const std::string &kernelName,
+                                      torch::Tensor &out,
+                                      torch::Tensor const &input) {
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+
+    const uint32_t d = static_cast<uint32_t>(input.size(-1));
+    const uint32_t numTokens =
+        static_cast<uint32_t>(input.numel() / input.size(-1));
+
+    if (numTokens == 0 || d == 0) return;
+
+    NSError *error = nil;
+    id<MTLLibrary> library =
+        EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+    TORCH_CHECK(library, "Failed to create Metal library: ",
+                error.localizedDescription.UTF8String);
+
+    std::string kernel_name =
+        kernelName + (input.scalar_type() == torch::kFloat ? "_f32" : "_f16");
+    id<MTLFunction> function = [library
+        newFunctionWithName:[NSString stringWithUTF8String:kernel_name.c_str()]];
+    TORCH_CHECK(function, "Failed to create function: ", kernel_name.c_str());
+
+    id<MTLComputePipelineState> pso =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    TORCH_CHECK(pso, "Failed to create pipeline state: ",
+                error.localizedDescription.UTF8String);
+
+    id<MTLCommandBuffer> commandBuffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(commandBuffer, "Failed to get command buffer");
+
+    dispatch_queue_t serialQueue = torch::mps::get_dispatch_queue();
+
+    dispatch_sync(serialQueue, ^() {
+      id<MTLComputeCommandEncoder> encoder =
+          [commandBuffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create compute encoder");
+
+      [encoder setComputePipelineState:pso];
+      [encoder setBuffer:getMTLBufferStorage(out)
+                  offset:out.storage_offset() * out.element_size()
+                 atIndex:0];
+      [encoder setBuffer:getMTLBufferStorage(input)
+                  offset:input.storage_offset() * input.element_size()
+                 atIndex:1];
+      [encoder setBytes:&d length:sizeof(uint32_t) atIndex:2];
+
+      uint32_t numChunks = (d + 7) / 8;
+      MTLSize gridSize = MTLSizeMake(numChunks, numTokens, 1);
+      NSUInteger threadGroupWidth =
+          std::min<NSUInteger>(numChunks, pso.maxTotalThreadsPerThreadgroup);
+      MTLSize threadGroupSize = MTLSizeMake(threadGroupWidth, 1, 1);
+
+      [encoder dispatchThreads:gridSize threadsPerThreadgroup:threadGroupSize];
+      [encoder endEncoding];
+
+      torch::mps::commit();
+    });
+  }
+}
+
+static void checkInputs(torch::Tensor &out, torch::Tensor const &input) {
+  TORCH_CHECK(input.device().is_mps(), "input must be a MPS tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(out.device().is_mps(), "output must be a MPS tensor");
+  TORCH_CHECK(out.is_contiguous(), "output must be contiguous");
+  TORCH_CHECK(input.scalar_type() == torch::kFloat ||
+                  input.scalar_type() == torch::kHalf,
+              "Unsupported data type: ", input.scalar_type());
+  TORCH_CHECK(input.scalar_type() == out.scalar_type(),
+              "Input and output must have the same dtype");
+}
+
+void silu_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchGatedKernel("silu_and_mul", out, input);
+}
+
+void mul_and_silu(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchGatedKernel("mul_and_silu", out, input);
+}
+
+void gelu_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchGatedKernel("gelu_and_mul", out, input);
+}
+
+void gelu_tanh_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchGatedKernel("gelu_tanh_and_mul", out, input);
+}
+
+void fatrelu_and_mul(torch::Tensor &out, torch::Tensor &input,
+                     double threshold) {
+  checkInputs(out, input);
+  dispatchGatedKernelWithThreshold("fatrelu_and_mul", out, input,
+                                   static_cast<float>(threshold));
+}
+
+void silu(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("silu", out, input);
+}
+
+void gelu(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("gelu", out, input);
+}
+
+void gelu_tanh(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("gelu_tanh", out, input);
+}
+
+void gelu_new(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("gelu_new", out, input);
+}
+
+void gelu_fast(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("gelu_fast", out, input);
+}
+
+void gelu_quick(torch::Tensor &out, torch::Tensor &input) {
+  checkInputs(out, input);
+  dispatchElementwiseKernel("gelu_quick", out, input);
+}

--- a/activation/build.toml
+++ b/activation/build.toml
@@ -1,7 +1,7 @@
 [general]
 name = "activation"
 version = 1
-backends = ["cuda"]
+backends = ["cuda", "metal"]
 
 [torch]
 src = [
@@ -16,4 +16,12 @@ src = [
     "activation/activation_kernels.cu",
     "activation/cuda_compat.h",
     "activation/dispatch_utils.h",
+]
+
+[kernel.activation_metal]
+backend = "metal"
+depends = ["torch"]
+src = [
+    "activation_metal/activation.mm",
+    "activation_metal/activation.metal",
 ]

--- a/activation/torch-ext/torch_binding.cpp
+++ b/activation/torch-ext/torch_binding.cpp
@@ -7,46 +7,90 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("silu_and_mul", torch::kCUDA, &silu_and_mul);
+#elif defined(METAL_KERNEL)
+  ops.impl("silu_and_mul", torch::kMPS, &silu_and_mul);
+#endif
 
   ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("mul_and_silu", torch::kCUDA, &mul_and_silu);
+#elif defined(METAL_KERNEL)
+  ops.impl("mul_and_silu", torch::kMPS, &mul_and_silu);
+#endif
 
   // Activation function used in GeGLU with `none` approximation.
   ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_and_mul", torch::kCUDA, &gelu_and_mul);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_and_mul", torch::kMPS, &gelu_and_mul);
+#endif
 
   // Activation function used in GeGLU with `tanh` approximation.
   ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_tanh_and_mul", torch::kCUDA, &gelu_tanh_and_mul);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_tanh_and_mul", torch::kMPS, &gelu_tanh_and_mul);
+#endif
 
   // FATReLU implementation.
   ops.def("fatrelu_and_mul(Tensor! out, Tensor input, float threshold) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("fatrelu_and_mul", torch::kCUDA, &fatrelu_and_mul);
+#elif defined(METAL_KERNEL)
+  ops.impl("fatrelu_and_mul", torch::kMPS, &fatrelu_and_mul);
+#endif
 
   // GELU implementation used in GPT-2.
   ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_new", torch::kCUDA, &gelu_new);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_new", torch::kMPS, &gelu_new);
+#endif
 
   // Approximate GELU implementation.
   ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_fast", torch::kCUDA, &gelu_fast);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_fast", torch::kMPS, &gelu_fast);
+#endif
 
   // Quick GELU implementation.
   ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_quick", torch::kCUDA, &gelu_quick);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_quick", torch::kMPS, &gelu_quick);
+#endif
 
   // GELU with `tanh` approximation.
   ops.def("gelu_tanh(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu_tanh", torch::kCUDA, &gelu_tanh);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu_tanh", torch::kMPS, &gelu_tanh);
+#endif
 
   // SiLU implementation.
   ops.def("silu(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("silu", torch::kCUDA, &silu);
+#elif defined(METAL_KERNEL)
+  ops.impl("silu", torch::kMPS, &silu);
+#endif
 
   // GELU with none approximation.
   ops.def("gelu(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL)
   ops.impl("gelu", torch::kCUDA, &gelu);
+#elif defined(METAL_KERNEL)
+  ops.impl("gelu", torch::kMPS, &gelu);
+#endif
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)


### PR DESCRIPTION
This PR adds a metal implementation of various activation functions that are comparable with the cuda version. 

This should helps make the current basic usage example work on osx https://huggingface.co/docs/kernels/en/basic-usage and in general enable osx users to use activation kernels