### PR TITLE
gpt-oss-triton-kernels: add CPU backend

### DIFF
--- a/gpt-oss-triton-kernels/build.toml
+++ b/gpt-oss-triton-kernels/build.toml
@@ -5,7 +5,7 @@ backends = [
     "cuda",
     "rocm",
     "xpu",
-    "universal",
+    "cpu",
 ]
 
 [general.hub]

--- a/gpt-oss-triton-kernels/torch-ext/gpt_oss_triton_kernels/__init__.py
+++ b/gpt-oss-triton-kernels/torch-ext/gpt_oss_triton_kernels/__init__.py
@@ -1,8 +1,8 @@
 # Make sure to add this in the build folder as this won't build if we put that here
 
-# from . import matmul_ogs, tensor_details, numerics_details, tensor, swiglu, routing
+from . import matmul_ogs, tensor_details, numerics_details, tensor, swiglu, routing
 
-# __all__ = ["matmul_ogs" , "tensor_details", "numerics_details", "tensor", "swiglu", "routing"]
+__all__ = ["matmul_ogs" , "tensor_details", "numerics_details", "tensor", "swiglu", "routing"]
 
 # Then, run the following code to build the kernels: 
 # docker run --rm \


### PR DESCRIPTION
This PR enables CPU build for gpt-oss-triton-kernels, where align with the original triton kernel [torch-universal](https://huggingface.co/kernels-community/triton_kernels/tree/main/build).

Original PR: #353