### PR TITLE
flash-attn2: Add torch.compile support for XPU

### DIFF
--- a/flash-attn2/flash_attn_xpu/flash_api.cpp
+++ b/flash-attn2/flash_attn_xpu/flash_api.cpp
@@ -496,6 +496,36 @@ mha_fwd(
 }
 
 std::vector<torch::Tensor>
+mha_varlen_bwd(
+        const torch::Tensor &dout,
+        const torch::Tensor &q,
+        const torch::Tensor &k,
+        const torch::Tensor &v,
+        const torch::Tensor &out,
+        const torch::Tensor &softmax_lse,
+        const c10::optional<torch::Tensor> &dq_,
+        const c10::optional<torch::Tensor> &dk_,
+        const c10::optional<torch::Tensor> &dv_,
+        const torch::Tensor &cu_seqlens_q,
+        const torch::Tensor &cu_seqlens_k,
+        const c10::optional<torch::Tensor> &alibi_slopes_,
+        const int64_t max_seqlen_q,
+        const int64_t max_seqlen_k,
+        const double p_dropout,
+        const double softmax_scale,
+        const bool zero_tensors,
+        const bool is_causal,
+        const int64_t window_size_left,
+        const int64_t window_size_right,
+        const double softcap,
+        const bool deterministic,
+        c10::optional<at::Generator> gen_,
+        const c10::optional<torch::Tensor> &rng_state) {
+    TORCH_CHECK(false, "FlashAttention varlen backward is not supported on XPU yet.");
+    return {};
+}
+
+std::vector<torch::Tensor>
 mha_varlen_fwd(
     torch::Tensor &q,  // total_q x num_heads x head_size, total_q := \sum_{i=0}^{b} s_i
     const torch::Tensor &k,  // total_k x num_heads_k x head_size, total_k := \sum_{i=0}^{b} s_i or num_blocks x page_block_size x num_heads_k x head_size if there's a block_table.

--- a/flash-attn2/torch-ext/flash_attn2/flash_attn_interface.py
+++ b/flash-attn2/torch-ext/flash_attn2/flash_attn_interface.py
@@ -31,8 +31,6 @@ def _get_device():
     else:
         return "cpu"
 
-_XPU_AVAILABLE = torch.xpu.is_available() if hasattr(torch, "xpu") else False # TODO remove hasattr check when bwd is supported on XPU
-
 
 def _get_block_size_n(device, head_dim, is_dropout, is_causal):
     # This should match the block sizes in the CUDA kernel
@@ -1285,7 +1283,7 @@ def flash_attn_varlen_qkvpacked_func(
         alibi_slopes,
         deterministic,
         return_attn_probs,
-        False if _XPU_AVAILABLE else torch.is_grad_enabled(),
+        torch.is_grad_enabled(),
     )
 
 
@@ -1377,7 +1375,7 @@ def flash_attn_varlen_kvpacked_func(
         alibi_slopes,
         deterministic,
         return_attn_probs,
-        False if _XPU_AVAILABLE else torch.is_grad_enabled(),
+        torch.is_grad_enabled(),
     )
 
 
@@ -1471,7 +1469,7 @@ def flash_attn_varlen_func(
         deterministic,
         return_attn_probs,
         block_table,
-        False if _XPU_AVAILABLE or q.device.type == "cpu" else torch.is_grad_enabled(),
+        False if q.device.type == "cpu" else torch.is_grad_enabled(),
     )
 
 

--- a/flash-attn2/torch-ext/torch_binding.cpp
+++ b/flash-attn2/torch-ext/torch_binding.cpp
@@ -117,6 +117,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
     "Tensor? rng_state) -> Tensor[]");
 #if defined(CUDA_KERNEL)
   ops.impl("varlen_bwd", torch::kCUDA, &mha_varlen_bwd);
+#elif defined(XPU_KERNEL)
+  ops.impl("varlen_bwd", torch::kXPU, &mha_varlen_bwd);
 #endif
 
   ops.def("fwd_kvcache("


### PR DESCRIPTION
This PR targets XPU:

1. Enables `torch.compile` to handle the FA2 kernel.
2. Adds an error reporting mechanism for `varlen backward` pass (the full feature support will be completed in a future release).