### PR TITLE
Remove incorrect repo-id check

### DIFF
--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -37,13 +37,6 @@ jobs:
           else
             echo "skip=true" >> $GITHUB_OUTPUT
           fi
-      - name: "Check that repo-id is present"
-        run: |
-          KERNEL="${{ steps.validate.outputs.kernel }}"
-          if ! nix run nixpkgs#dasel -- -f "$KERNEL/build.toml" -r toml 'general.hub.repo-id' &> /dev/null ; then
-            echo "Mandatory repo-id is missing in $KERNEL/build.toml"
-            exit 1
-          fi
       - name: Install Metal toolchain
         if: steps.validate.outputs.skip == 'false'
         run: xcodebuild -downloadComponent MetalToolchain


### PR DESCRIPTION
This check should not be in release builds, plus the command is outdated.