### PR TITLE
relu: prefer kernel builder cli in ci

### DIFF
--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -66,6 +66,6 @@ jobs:
             VERSION=$(grep -E '^\s*version\s*=\s*1\s*$' build.toml || true)
             if [ -n "$VERSION" ]; then
               nix build -L
-              nix run -L .#kernels -- upload --repo-id kernels-community/$KERNEL --branch main result
+              nix run -L .#kernel-builder -- upload --repo-id kernels-community/$KERNEL --branch main result
             fi
           fi

--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -47,13 +47,20 @@ jobs:
       - name: Install Metal toolchain
         if: steps.validate.outputs.skip == 'false'
         run: xcodebuild -downloadComponent MetalToolchain
-      - name: Build and upload kernel
+      - name: Build kernel
+        if: steps.validate.outputs.skip == 'false'
+        run: |
+          KERNEL="${{ steps.validate.outputs.kernel }}"
+          ( cd "$KERNEL" && nix build -L )
+      - name: Upload kernel to Hub
         if: steps.validate.outputs.skip == 'false'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           KERNEL="${{ steps.validate.outputs.kernel }}"
-          ( cd "$KERNEL" && nix run -L .#build-and-upload )
+          cd "$KERNEL"
+          nix run -L .#kernel-builder -- upload --repo-type model --repo-id "kernels-community/$KERNEL" result
+          nix run -L .#kernel-builder -- upload --repo-type kernel --repo-id "kernels-community/$KERNEL" result
       - name: Upload v1 kernels to main
         if: steps.validate.outputs.skip == 'false'
         env:
@@ -65,7 +72,7 @@ jobs:
           if [ -f "build.toml" ]; then
             VERSION=$(grep -E '^\s*version\s*=\s*1\s*$' build.toml || true)
             if [ -n "$VERSION" ]; then
-              nix build -L
-              nix run -L .#kernel-builder -- upload --repo-id kernels-community/$KERNEL --branch main result
+              nix run -L .#kernel-builder -- upload --repo-type model --repo-id "kernels-community/$KERNEL" --branch main result
+              nix run -L .#kernel-builder -- upload --repo-type kernel --repo-id "kernels-community/$KERNEL" --branch main result
             fi
           fi

--- a/.github/workflows/build-release-windows.yaml
+++ b/.github/workflows/build-release-windows.yaml
@@ -226,14 +226,11 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           KERNEL_SOURCE: ${{ steps.validate.outputs.kernel }}
-          PYTHONUTF8: 1
-          PYTHONIOENCODING: utf-8
         run: |
-          # Install kernels package for upload
-          pip install -U kernels --no-cache-dir
+          $KB = "$env:GITHUB_WORKSPACE\kernels\kernel-builder\target\debug\kernel-builder.exe"
 
-          # Upload using the kernels CLI (branchless - uploads to version branch like v1, v2, etc.)
-          kernels upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE"
+          # Upload using kernel-builder (branchless - uploads to version branch like v1, v2, etc.)
+          & $KB upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE"
 
       - name: Upload v1 kernels to main
         if: steps.validate.outputs.skip == 'false' && steps.check-backend.outputs.supported == 'true'
@@ -241,16 +238,16 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           KERNEL_SOURCE: ${{ steps.validate.outputs.kernel }}
-          PYTHONUTF8: 1
-          PYTHONIOENCODING: utf-8
         run: |
+          $KB = "$env:GITHUB_WORKSPACE\kernels\kernel-builder\target\debug\kernel-builder.exe"
+
           # Check if build.toml exists and has version = 1
           $buildTomlPath = "$env:KERNEL_SOURCE\build.toml"
           if (Test-Path $buildTomlPath) {
             $content = Get-Content $buildTomlPath -Raw
             if ($content -match '(?m)^\s*version\s*=\s*1\s*(\r)?$') {
               Write-Host "Kernel version is 1, uploading to main branch..."
-              kernels upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE" --branch main
+              & $KB upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE" --branch main
             } else {
               Write-Host "Kernel version is not 1, skipping main branch upload"
             }

--- a/.github/workflows/build-release-windows.yaml
+++ b/.github/workflows/build-release-windows.yaml
@@ -229,8 +229,9 @@ jobs:
         run: |
           $KB = "$env:GITHUB_WORKSPACE\kernels\kernel-builder\target\debug\kernel-builder.exe"
 
-          # Upload using kernel-builder (branchless - uploads to version branch like v1, v2, etc.)
-          & $KB upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE"
+          # Upload to both model and kernel repo types
+          & $KB upload "$env:KERNEL_SOURCE\build" --repo-type model --repo-id "kernels-community/$env:KERNEL_SOURCE"
+          & $KB upload "$env:KERNEL_SOURCE\build" --repo-type kernel --repo-id "kernels-community/$env:KERNEL_SOURCE"
 
       - name: Upload v1 kernels to main
         if: steps.validate.outputs.skip == 'false' && steps.check-backend.outputs.supported == 'true'
@@ -247,7 +248,8 @@ jobs:
             $content = Get-Content $buildTomlPath -Raw
             if ($content -match '(?m)^\s*version\s*=\s*1\s*(\r)?$') {
               Write-Host "Kernel version is 1, uploading to main branch..."
-              & $KB upload "$env:KERNEL_SOURCE\build" --repo-id "kernels-community/$env:KERNEL_SOURCE" --branch main
+              & $KB upload "$env:KERNEL_SOURCE\build" --repo-type model --repo-id "kernels-community/$env:KERNEL_SOURCE" --branch main
+              & $KB upload "$env:KERNEL_SOURCE\build" --repo-type kernel --repo-id "kernels-community/$env:KERNEL_SOURCE" --branch main
             } else {
               Write-Host "Kernel version is not 1, skipping main branch upload"
             }

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -47,13 +47,20 @@ jobs:
           else
             echo "skip=true" >> $GITHUB_OUTPUT
           fi
-      - name: Build and upload kernel
+      - name: Build kernel
+        if: steps.validate.outputs.skip == 'false'
+        run: |
+          KERNEL="${{ steps.validate.outputs.kernel }}"
+          ( cd "$KERNEL" && nix build -L )
+      - name: Upload kernel to Hub
         if: steps.validate.outputs.skip == 'false'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           KERNEL="${{ steps.validate.outputs.kernel }}"
-          ( cd "$KERNEL" && nix run -L .#build-and-upload )
+          cd "$KERNEL"
+          nix run -L .#kernel-builder -- upload --repo-type model --repo-id "kernels-community/$KERNEL" result
+          nix run -L .#kernel-builder -- upload --repo-type kernel --repo-id "kernels-community/$KERNEL" result
       - name: Upload v1 kernels to main
         if: steps.validate.outputs.skip == 'false'
         env:
@@ -66,7 +73,7 @@ jobs:
           if [ -f "build.toml" ]; then
             VERSION=$(grep -E '^\s*version\s*=\s*1\s*$' build.toml || true)
             if [ -n "$VERSION" ]; then
-              nix build -L
-              nix run -L .#kernel-builder -- upload --repo-id kernels-community/$KERNEL --branch main result
+              nix run -L .#kernel-builder -- upload --repo-type model --repo-id "kernels-community/$KERNEL" --branch main result
+              nix run -L .#kernel-builder -- upload --repo-type kernel --repo-id "kernels-community/$KERNEL" --branch main result
             fi
           fi

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -67,6 +67,6 @@ jobs:
             VERSION=$(grep -E '^\s*version\s*=\s*1\s*$' build.toml || true)
             if [ -n "$VERSION" ]; then
               nix build -L
-              nix run -L .#kernels -- upload --repo-id kernels-community/$KERNEL --branch main result
+              nix run -L .#kernel-builder -- upload --repo-id kernels-community/$KERNEL --branch main result
             fi
           fi

--- a/.github/workflows/manual-build-upload.yaml
+++ b/.github/workflows/manual-build-upload.yaml
@@ -120,4 +120,4 @@ jobs:
         run: |
           set -eu
           KERNEL="${{ steps.validate.outputs.kernel }}"
-          ( cd "$KERNEL" && nix run .#kernels -- upload --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )
+          ( cd "$KERNEL" && nix run .#kernel-builder -- upload --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )

--- a/.github/workflows/manual-build-upload.yaml
+++ b/.github/workflows/manual-build-upload.yaml
@@ -120,4 +120,5 @@ jobs:
         run: |
           set -eu
           KERNEL="${{ steps.validate.outputs.kernel }}"
-          ( cd "$KERNEL" && nix run .#kernel-builder -- upload --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )
+          ( cd "$KERNEL" && nix run .#kernel-builder -- upload --repo-type model --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )
+          ( cd "$KERNEL" && nix run .#kernel-builder -- upload --repo-type kernel --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )


### PR DESCRIPTION
This PR bumps CI to use the kernel-builder CLI and to push to both kernel and model repo types