### PR TITLE
utilities to sync kernel repos with model repos

### DIFF
--- a/.github/scripts/sync_kernel_to_model.py
+++ b/.github/scripts/sync_kernel_to_model.py
@@ -1,11 +1,3 @@
-"""Syncs a kernel repo to its model repo counterpart using huggingface_hub.
-
-Usage: python sync_kernel_to_model.py <repo_id> <branch>
-Example: python sync_kernel_to_model.py kernels-community/flash-attn3 v1
-
-Requires: HF_TOKEN env var, huggingface_hub installed
-"""
-
 import sys
 
 from huggingface_hub import HfApi

--- a/.github/scripts/sync_kernel_to_model.py
+++ b/.github/scripts/sync_kernel_to_model.py
@@ -1,0 +1,47 @@
+"""Syncs a kernel repo to its model repo counterpart using huggingface_hub.
+
+Usage: python sync_kernel_to_model.py <repo_id> <branch>
+Example: python sync_kernel_to_model.py kernels-community/flash-attn3 v1
+
+Requires: HF_TOKEN env var, huggingface_hub installed
+"""
+
+import sys
+
+from huggingface_hub import HfApi
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <repo_id> <branch>")
+        print(f"Example: {sys.argv[0]} kernels-community/flash-attn3 v1")
+        sys.exit(1)
+
+    repo_id = sys.argv[1]
+    branch = sys.argv[2]
+
+    print(f"Syncing kernel repo '{repo_id}' branch '{branch}' -> model repo...")
+
+    api = HfApi()
+
+    # Download snapshot from "kernel" repo type
+    local_dir = api.snapshot_download(
+        repo_id=repo_id,
+        repo_type="kernel",
+        revision=branch,
+    )
+
+    # Upload the same tree to "model" repo type
+    api.upload_folder(
+        folder_path=local_dir,
+        repo_id=repo_id,
+        repo_type="model",
+        revision=branch,
+        commit_message=f"sync: mirror kernel repo ({branch})",
+    )
+
+    print(f"Successfully synced {repo_id} ({branch}) from kernel -> model repo type.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/manual-build-upload.yaml
+++ b/.github/workflows/manual-build-upload.yaml
@@ -121,3 +121,15 @@ jobs:
           set -eu
           KERNEL="${{ steps.validate.outputs.kernel }}"
           ( cd "$KERNEL" && nix run .#kernels -- upload --repo-id "kernels-community/$KERNEL" --branch "$TARGET_BRANCH" . )
+
+      - name: Sync kernel repo to model repo
+        if: ${{ inputs.upload == 'true' }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -eu
+          KERNEL="${{ steps.validate.outputs.kernel }}"
+          pip install -U huggingface_hub
+          python3 .github/scripts/sync_kernel_to_model.py \
+            "kernels-community/$KERNEL" "$TARGET_BRANCH"

--- a/.github/workflows/sync-kernel-model.yaml
+++ b/.github/workflows/sync-kernel-model.yaml
@@ -1,0 +1,124 @@
+name: Sync Kernel to Model Repo
+on:
+  workflow_run:
+    workflows:
+      - "Build Release"
+      - "Build Release (macOS)"
+      - "Build Release (Windows)"
+    types: [completed]
+
+jobs:
+  sync:
+    # Only proceed if the triggering workflow was for a merged PR and succeeded.
+    # The build-release workflows themselves gate on `github.event.pull_request.merged == true`,
+    # so a successful conclusion already implies the PR was merged. We additionally verify
+    # via the GitHub API below to be explicit.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify PR was merged (not just closed)
+        id: verify-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Find the PR associated with this head SHA and confirm it was merged
+          MERGED=$(gh pr list --state merged --search "$HEAD_SHA" \
+            --json merged --jq '.[0].merged // false')
+
+          if [ "$MERGED" != "true" ]; then
+            echo "PR was not merged, skipping sync."
+            echo "merged=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "merged=true" >> $GITHUB_OUTPUT
+
+      - name: Check if all platform workflows have completed
+        if: steps.verify-merge.outputs.merged == 'true'
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Get the status of all three build-release workflows for this commit.
+          # Each workflow creates check runs tied to the head SHA of the PR.
+          WORKFLOWS=("Build Release" "Build Release (macOS)" "Build Release (Windows)")
+          ALL_DONE=true
+
+          for wf in "${WORKFLOWS[@]}"; do
+            # Find the most recent run for this workflow + commit
+            STATUS=$(gh run list \
+              --workflow "$wf" \
+              --commit "$HEAD_SHA" \
+              --limit 1 \
+              --json status,conclusion \
+              --jq '.[0].status // "not_found"')
+
+            echo "$wf: $STATUS"
+
+            if [ "$STATUS" != "completed" ]; then
+              ALL_DONE=false
+              break
+            fi
+          done
+
+          echo "all_done=$ALL_DONE" >> $GITHUB_OUTPUT
+
+      - name: Extract kernel name from triggering PR
+        if: >-
+          steps.verify-merge.outputs.merged == 'true' &&
+          steps.check.outputs.all_done == 'true'
+        id: kernel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Look up the merged PR by head SHA to get its title
+          PR_TITLE=$(gh pr list --state merged --search "$HEAD_SHA" \
+            --json title --jq '.[0].title // empty')
+
+          if [ -z "$PR_TITLE" ]; then
+            echo "Could not determine PR title, skipping sync."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          KERNEL=$(python3 .github/workflows/validate-kernel-pr.py \
+            "release" "$PR_TITLE") || {
+            echo "Not a release PR, skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          }
+
+          VERSION=$(grep -oP 'version\s*=\s*\K\d+' \
+            "$KERNEL/build.toml" | head -1)
+
+          echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Sync kernel repo to model repo
+        if: >-
+          steps.verify-merge.outputs.merged == 'true' &&
+          steps.check.outputs.all_done == 'true' &&
+          steps.kernel.outputs.skip == 'false'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          pip install -U huggingface_hub
+          KERNEL="${{ steps.kernel.outputs.kernel }}"
+          VERSION="${{ steps.kernel.outputs.version }}"
+
+          echo "All platform builds done. Syncing kernels-community/$KERNEL..."
+          python3 .github/scripts/sync_kernel_to_model.py \
+            "kernels-community/$KERNEL" "v$VERSION"
+
+          if [ "$VERSION" = "1" ]; then
+            python3 .github/scripts/sync_kernel_to_model.py \
+              "kernels-community/$KERNEL" "main"
+          fi

--- a/scripts/backfill-sync.sh
+++ b/scripts/backfill-sync.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# One-time backfill script to sync all existing kernel repos to their model repo counterparts.
+# Run from the root of the kernels-community repo checkout:
+#   cd /path/to/kernels-community && bash scripts/backfill-sync.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+pip install -U huggingface_hub
+
+# Find all directories containing a build.toml — these are kernel directories.
+# This skips .github, .claude, scripts, and any other non-kernel directories.
+for build_toml in */build.toml; do
+  [ -f "$build_toml" ] || continue  # guard against no matches
+
+  kernel=$(dirname "$build_toml")
+  repo_id="kernels-community/$kernel"
+  version=$(grep -oP 'version\s*=\s*\K\d+' "$build_toml" | head -1)
+
+  echo "==> Syncing $repo_id (v$version)..."
+  python3 "$REPO_ROOT/.github/scripts/sync_kernel_to_model.py" "$repo_id" "v$version"
+
+  if [ "$version" = "1" ]; then
+    echo "    Also syncing $repo_id main branch..."
+    python3 "$REPO_ROOT/.github/scripts/sync_kernel_to_model.py" "$repo_id" "main"
+  fi
+
+  echo ""
+done
+
+echo "Backfill complete."


### PR DESCRIPTION
Until we fully remove the support to load "model" repo types in kernels, we should ensure that the kernel builds are synced for both the repo types ("kernel" and "model") under `kernels-community`. 

This PR adds utilities to do so.

- `scripts/backfill-sync.sh` — One-time script to run locally, iterates over all */build.toml directories (this should be run first, locally)
- `.github/scripts/sync_kernel_to_model.py` — Sync script (Linux/macOS) that downloads from kernel repo type and uploads to model repo type
- `.github/workflows/sync-kernel-model.yaml` — The `workflow_run` orchestrator that watches all three build-release workflows and syncs only after all have completed for the same commit