### PR TITLE
relu: get PR title from env var in `validate-kernel-pr.py`

### DIFF
--- a/.github/workflows/build-pr-mac.yaml
+++ b/.github/workflows/build-pr-mac.yaml
@@ -30,7 +30,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "pr" "$PR_TITLE"); then
+          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "pr"); then
             echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
             echo "skip=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-pr-windows.yaml
+++ b/.github/workflows/build-pr-windows.yaml
@@ -41,10 +41,10 @@ jobs:
         id: validate
         shell: pwsh
         env:
-          PRTITLE: ${{ github.event.pull_request.title }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           $ErrorActionPreference = "Continue"
-          $KERNEL = python .github/workflows/validate-kernel-pr.py "pr" "$Env:PRTITLE" 2>&1
+          $KERNEL = python .github/workflows/validate-kernel-pr.py "pr" 2>&1
           if ($LASTEXITCODE -eq 0) {
             echo "kernel=$KERNEL" >> $env:GITHUB_OUTPUT
             echo "skip=false" >> $env:GITHUB_OUTPUT
@@ -193,13 +193,13 @@ jobs:
             $setvarsPath = "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
             if (Test-Path $setvarsPath) {
               Write-Host "Initializing Intel oneAPI environment for XPU build..." -ForegroundColor Cyan
-              
+
               # Create a temporary file to capture environment variables
               $tempFile = [System.IO.Path]::GetTempFileName()
-              
+
               # Run setvars.bat and capture all environment variables
               cmd.exe /c "`"$setvarsPath`" && set > `"$tempFile`""
-              
+
               # Parse and set each environment variable in PowerShell
               Get-Content $tempFile | ForEach-Object {
                 if ($_ -match "^(.*?)=(.*)$") {
@@ -208,9 +208,9 @@ jobs:
                   [System.Environment]::SetEnvironmentVariable($varName, $varValue, [System.EnvironmentVariableTarget]::Process)
                 }
               }
-              
+
               Remove-Item $tempFile -ErrorAction SilentlyContinue
-              
+
               # Verify Intel compiler is now in PATH
               $icxPath = (Get-Command icx-cl -ErrorAction SilentlyContinue).Path
               if ($icxPath) {

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "pr" "$PR_TITLE"); then
+          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "pr"); then
             echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
             echo "skip=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release" "$PR_TITLE"); then
+          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release"); then
             echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
             echo "skip=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build-release-windows.yaml
+++ b/.github/workflows/build-release-windows.yaml
@@ -44,10 +44,10 @@ jobs:
         id: validate
         shell: pwsh
         env:
-          PRTITLE: ${{ github.event.pull_request.title }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           $ErrorActionPreference = "Continue"
-          $KERNEL = python .github/workflows/validate-kernel-pr.py "release" "$Env:PRTITLE" 2>&1
+          $KERNEL = python .github/workflows/validate-kernel-pr.py "release" 2>&1
           if ($LASTEXITCODE -eq 0) {
             echo "kernel=$KERNEL" >> $env:GITHUB_OUTPUT
             echo "skip=false" >> $env:GITHUB_OUTPUT
@@ -182,13 +182,13 @@ jobs:
             $setvarsPath = "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
             if (Test-Path $setvarsPath) {
               Write-Host "Initializing Intel oneAPI environment for XPU build..." -ForegroundColor Cyan
-              
+
               # Create a temporary file to capture environment variables
               $tempFile = [System.IO.Path]::GetTempFileName()
-              
+
               # Run setvars.bat and capture all environment variables
               cmd.exe /c "`"$setvarsPath`" && set > `"$tempFile`""
-              
+
               # Parse and set each environment variable in PowerShell
               Get-Content $tempFile | ForEach-Object {
                 if ($_ -match "^(.*?)=(.*)$") {
@@ -197,9 +197,9 @@ jobs:
                   [System.Environment]::SetEnvironmentVariable($varName, $varValue, [System.EnvironmentVariableTarget]::Process)
                 }
               }
-              
+
               Remove-Item $tempFile -ErrorAction SilentlyContinue
-              
+
               # Verify Intel compiler is now in PATH
               $icxPath = (Get-Command icx-cl -ErrorAction SilentlyContinue).Path
               if ($icxPath) {

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release" "${PR_TITLE}"); then
+          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release"); then
             echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
             echo "skip=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/manual-build-upload.yaml
+++ b/.github/workflows/manual-build-upload.yaml
@@ -91,6 +91,7 @@ jobs:
         id: validate
         env:
           KERNEL_INPUT: ${{ inputs.kernel_name }}
+          PR_TITLE: "${{ inputs.kernel_name }}: manual dispatch"
         run: |
           set -eu
           case "$KERNEL_INPUT" in
@@ -99,7 +100,7 @@ jobs:
               exit 1
               ;;
           esac
-          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release" "${KERNEL_INPUT}: manual dispatch"); then
+          if KERNEL=$(python3 .github/workflows/validate-kernel-pr.py "release"); then
             echo "kernel=$KERNEL" >> "$GITHUB_OUTPUT"
           else
             echo "Kernel validation failed."

--- a/.github/workflows/validate-kernel-pr.py
+++ b/.github/workflows/validate-kernel-pr.py
@@ -3,9 +3,10 @@
 Validate kernel build request and directory structure.
 """
 
-import sys
-import re
 import argparse
+import os
+import re
+import sys
 from pathlib import Path
 
 
@@ -27,22 +28,23 @@ def validate_kernel_name(kernel_name: str) -> bool:
 def main():
     parser = argparse.ArgumentParser(
         description="Validate kernel build request and directory structure",
-        epilog="Returns exit code 0 if valid, 1 if invalid, and outputs kernel name to stdout"
+        epilog="Returns exit code 0 if valid, 1 if invalid, and outputs kernel name to stdout",
     )
     parser.add_argument(
-        "build_type",
-        choices=["pr", "release"],
-        help="Type of build to validate for"
+        "build_type", choices=["pr", "release"], help="Type of build to validate for"
     )
-    parser.add_argument(
-        "pr_title",
-        help="Title of the pull request containing kernel name"
-    )
-    
+
     args = parser.parse_args()
-    
+
     build_type = args.build_type
-    pr_title = args.pr_title
+    pr_title = os.environ.get("PR_TITLE", "")
+
+    if not pr_title:
+        print(
+            "PR_TITLE environment variable is not set or empty, skipping build",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if ":" not in pr_title:
         print("No colon found in PR title, skipping build", file=sys.stderr)
@@ -62,7 +64,10 @@ def main():
     # Check for build-type specific skip-ci file
     skip_ci_file = kernel_path / f".skip-{build_type}-ci"
     if skip_ci_file.exists():
-        print(f"Kernel '{kernel_name}' has .skip-{build_type}-ci file, skipping build", file=sys.stderr)
+        print(
+            f"Kernel '{kernel_name}' has .skip-{build_type}-ci file, skipping build",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     flake_nix = kernel_path / "flake.nix"


### PR DESCRIPTION
This avoids having to pass the title as an argument, which opens up the possibility of command injection when not done carefully.