### PR TITLE
metal-int4-sdpa: fused int4 SDPA kernel for Apple Silicon

### DIFF
--- a/metal-int4-sdpa/README.md
+++ b/metal-int4-sdpa/README.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - metal
+  - attention
+  - quantization
+  - int4
+  - apple-silicon
+  - sdpa
+  - kv-cache
+library_name: kernels
+---
+
+# Fused int4 SDPA for Apple Silicon
+
+Fused int4 Scaled Dot-Product Attention Metal kernel for Apple Silicon (M1/M2/M3/M4).
+
+Computes `softmax(Q @ dequant(K_int4)^T * scale) @ dequant(V_int4)` in a single
+kernel dispatch with online softmax — never materializing full K/V or score matrices.
+
+## Performance
+
+Benchmarked on M1 Max (32 GPU cores, 64GB unified memory).
+
+### vs MLX native FP32 SDPA
+
+| Config | N | Fused int4 | MLX FP32 | Speedup |
+|---|---|---|---|---|
+| Gemma 4 sliding (sw=1024) | 4096 | **0.34ms** | 2.71ms | **7.9x** |
+| Gemma 4 sliding (sw=1024) | 8192 | **0.40ms** | 4.64ms | **11.5x** |
+| Gemma 4 full (D=512) | 8192 | **0.98ms** | 7.87ms | **8.1x** |
+| Llama 3.1 (D=128) | 8192 | **0.89ms** | 2.56ms | **2.9x** |
+
+### vs PyTorch MPS dequant+SDPA
+
+| N | Fused int4 | MPS Deq+SDPA | Speedup |
+|---|---|---|---|
+| 2048 | 0.36ms | 1.05ms | **2.9x** |
+| 4096 | 0.54ms | 1.56ms | **2.9x** |
+| 8192 | 0.67ms | 2.26ms | **3.4x** |
+
+**6.4x KV cache compression** across all configurations (int4 vs FP32).
+
+## Features
+
+- **Online softmax** — O(1) memory in sequence length
+- **qdot pattern** — eliminates per-nibble shift operations in K dot product
+- **Adaptive split-K** — doubles GPU utilization for models with few attention heads
+- **Sliding window** — fast-skip for sliding attention layers (e.g., Gemma 4)
+- **GQA support** — grouped-query attention with arbitrary factors
+- **D = 128, 256, 512** — common head dimensions
+
+## int4 Format
+
+- uint32 packs 8 x 4-bit nibbles
+- Per-group (64 elements) asymmetric quantization: `value = scale * nibble + bias`
+- 6.4x compression vs FP32
+
+## Usage
+
+```python
+import kernels
+
+sdpa_int4 = kernels.get_kernel("zyan1deOG/metal-int4-sdpa", "sdpa_int4")
+
+# Single-token decode
+output = sdpa_int4.sdpa_int4(
+    queries,       # (num_heads, D) float32, MPS
+    k_quant,       # (num_kv_heads, N, D//8) uint32, MPS
+    k_scales,      # (num_kv_heads, N, D//64) float32, MPS
+    k_biases,      # (num_kv_heads, N, D//64) float32, MPS
+    v_quant,       # (num_kv_heads, N, D//8) uint32, MPS
+    v_scales,      # (num_kv_heads, N, D//64) float32, MPS
+    v_biases,      # (num_kv_heads, N, D//64) float32, MPS
+    gqa_factor=4,  # num_heads // num_kv_heads
+    N=2048,        # sequence length
+    scale=0.0625,  # 1/sqrt(D)
+    sliding_window=0,  # 0 = full attention
+)
+```
+
+## Tested Models
+
+- Gemma 4 31B (32 heads, 16 KV heads, D=256/512, sliding window)
+- Llama 3.1 architecture (32 heads, 8 KV heads, D=128)
+
+## Origin
+
+Ported from TurboQuant's `sdpa_int4_vector` kernel.
+
+Paper: [TurboQuant (arxiv.org/abs/2504.19874)](https://arxiv.org/abs/2504.19874), ICLR 2026.

--- a/metal-int4-sdpa/build.toml
+++ b/metal-int4-sdpa/build.toml
@@ -1,0 +1,22 @@
+[general]
+backends = ["metal"]
+name = "sdpa_int4"
+license = "Apache-2.0"
+version = 1
+
+[general.hub]
+repo-id = "kernels-community/metal-int4-sdpa"
+
+[torch]
+src = [
+  "torch-ext/torch_binding.cpp",
+  "torch-ext/torch_binding.h",
+]
+
+[kernel.sdpa_int4_metal]
+backend = "metal"
+src = [
+  "sdpa_int4_metal/sdpa_int4.mm",
+  "sdpa_int4_metal/sdpa_int4.metal",
+]
+depends = ["torch"]

--- a/metal-int4-sdpa/flake.nix
+++ b/metal-int4-sdpa/flake.nix
@@ -1,0 +1,14 @@
+{
+  description = "Flake for metal-int4-sdpa kernel";
+
+  inputs = {
+    kernel-builder.url = "github:huggingface/kernels";
+  };
+
+  outputs =
+    { self, kernel-builder }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/metal-int4-sdpa/sdpa_int4_metal/sdpa_int4.metal
+++ b/metal-int4-sdpa/sdpa_int4_metal/sdpa_int4.metal
@@ -1,0 +1,510 @@
+// Fused int4 SDPA Metal kernel for Apple Silicon
+//
+// Computes: output = softmax(Q @ dequant(K_int4)^T / sqrt(d)) @ dequant(V_int4)
+// in a single kernel dispatch with online softmax — no intermediate score
+// matrix is ever materialized.
+//
+// Architecture (adapted from MLX sdpa_vector):
+//   - BN simdgroups per threadgroup, each processes a different key token
+//   - BD=32 SIMD lanes per simdgroup, each handles D/32 elements
+//   - Online softmax with running max + sum_exp, reduced across simdgroups
+//
+// int4 format (MLX-compatible):
+//   - uint32 packs 8 x 4-bit values
+//   - group_size=64: every 64 elements share one (scale, bias) pair
+//   - dequantize: value = scale * nibble + bias
+//
+// Key optimization: "qdot" pattern — pre-scale query elements by
+// {1, 1/16, 1/256, 1/4096} so that dot product with raw packed nibbles
+// (without shifting) gives the correct result. This eliminates per-nibble
+// shift operations in the inner loop.
+
+#include <metal_stdlib>
+using namespace metal;
+
+// ---------------------------------------------------------------------------
+// Fused int4 SDPA — single-token decode (vector query)
+// ---------------------------------------------------------------------------
+// Template parameters:
+//   D:  head dimension (256 or 512)
+//   BN: number of simdgroups per threadgroup (32 for D=256, 16 for D=512)
+//
+// Buffers:
+//   queries:     (num_heads, D) float32
+//   k_quant:     (num_kv_heads, N, D/8) uint32  — packed int4 keys
+//   k_scales:    (num_kv_heads, N, D/64) float32 — per-group scale
+//   k_biases:    (num_kv_heads, N, D/64) float32 — per-group bias
+//   v_quant:     (num_kv_heads, N, D/8) uint32  — packed int4 values
+//   v_scales:    (num_kv_heads, N, D/64) float32
+//   v_biases:    (num_kv_heads, N, D/64) float32
+//   out:         (num_heads, D) float32
+//   gqa_factor:  num_heads / num_kv_heads
+//   N:           sequence length (number of KV cache entries)
+//   scale:       attention scale (typically 1/sqrt(D))
+//   sliding_window: if > 0, only attend to last `sliding_window` tokens
+
+template <int D, int BN = 32>
+[[kernel]] void sdpa_int4_vector(
+    const device float* queries        [[buffer(0)]],
+    const device uint32_t* k_quant     [[buffer(1)]],
+    const device float* k_scales       [[buffer(2)]],
+    const device float* k_biases       [[buffer(3)]],
+    const device uint32_t* v_quant     [[buffer(4)]],
+    const device float* v_scales       [[buffer(5)]],
+    const device float* v_biases       [[buffer(6)]],
+    device float* out                  [[buffer(7)]],
+    const constant int& gqa_factor     [[buffer(8)]],
+    const constant int& N              [[buffer(9)]],
+    const constant float& scale        [[buffer(10)]],
+    const constant int& sliding_window [[buffer(11)]],
+    const constant int& num_heads      [[buffer(12)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]
+) {
+    constexpr int BD = 32;
+    constexpr int elems_per_lane = D / BD;
+
+    const int head_idx = tid.x;
+    // For batched decode: head_idx may exceed num_heads, use modulo for KV mapping
+    const int kv_head_idx = (head_idx % num_heads) / gqa_factor;
+
+    const int k_packed_dim = D / 8;
+    const int k_scale_dim = D / 64;
+
+    // Base pointers for this KV head
+    const device uint32_t* k_q_base = k_quant + kv_head_idx * N * k_packed_dim;
+    const device float* k_s_base = k_scales + kv_head_idx * N * k_scale_dim;
+    const device float* k_b_base = k_biases + kv_head_idx * N * k_scale_dim;
+    const device uint32_t* v_q_base = v_quant + kv_head_idx * N * k_packed_dim;
+    const device float* v_s_base = v_scales + kv_head_idx * N * k_scale_dim;
+    const device float* v_b_base = v_biases + kv_head_idx * N * k_scale_dim;
+
+    int lane_start = simd_lid * elems_per_lane;
+
+    // qdot pattern: pre-scale query so dot with raw nibbles works
+    // q_scaled[i+j] = q[i+j] / 16^j, then:
+    //   q_scaled[i] * (w & 0xF) + q_scaled[i+1] * (w & 0xF0) + ...
+    //   = q[i]*nib0 + q[i+1]*nib1 + q[i+2]*nib2 + q[i+3]*nib3
+    thread float q_scaled[D / BD];
+    for (int i = 0; i < elems_per_lane; i += 4) {
+        q_scaled[i]     = scale * queries[head_idx * D + lane_start + i];
+        q_scaled[i + 1] = scale * queries[head_idx * D + lane_start + i + 1] / 16.0f;
+        q_scaled[i + 2] = scale * queries[head_idx * D + lane_start + i + 2] / 256.0f;
+        q_scaled[i + 3] = scale * queries[head_idx * D + lane_start + i + 3] / 4096.0f;
+    }
+
+    // Pre-compute qsum (bias dot-product term) per group — constant across all tokens
+    constexpr int groups_per_lane = elems_per_lane / 4;
+    thread float qsum_precomp[groups_per_lane];
+    thread int group_indices[groups_per_lane];
+    for (int g = 0; g < groups_per_lane; g++) {
+        int i = g * 4;
+        qsum_precomp[g] = q_scaled[i] + q_scaled[i+1]*16.0f
+                        + q_scaled[i+2]*256.0f + q_scaled[i+3]*4096.0f;
+        group_indices[g] = (lane_start + i) / 64;
+    }
+
+    // Accumulator for weighted values
+    thread float o[D / BD];
+    for (int i = 0; i < elems_per_lane; i++) o[i] = 0.0f;
+
+    float max_score = -1e30f;
+    float sum_exp = 0.0f;
+
+    // Fast-skip for sliding window: jump directly to first valid token
+    int ki_start = simd_gid;
+    if (sliding_window > 0) {
+        int first_valid = N - sliding_window;
+        if (first_valid > 0) {
+            // Align to this simdgroup's stride
+            int aligned = first_valid - (first_valid % BN) + int(simd_gid);
+            if (aligned < first_valid) aligned += BN;
+            ki_start = aligned;
+        }
+    }
+
+    // Main loop: each simdgroup processes tokens ki, ki+BN, ki+2*BN, ...
+    for (int ki = ki_start; ki < N; ki += BN) {
+
+        // --- Score: Q · dequant(K[ki]) via qdot ---
+        float score = 0.0f;
+        const device uint16_t* kw = (const device uint16_t*)(k_q_base + ki * k_packed_dim)
+                                    + lane_start / 4;
+        int k_row_offset = ki * k_scale_dim;
+        for (int g = 0; g < groups_per_lane; g++) {
+            int i = g * 4;
+            float s = k_s_base[k_row_offset + group_indices[g]];
+            float b = k_b_base[k_row_offset + group_indices[g]];
+            uint16_t w = kw[g];
+
+            float accum = q_scaled[i]     * float(w & 0x000Fu)
+                        + q_scaled[i + 1] * float(w & 0x00F0u)
+                        + q_scaled[i + 2] * float(w & 0x0F00u)
+                        + q_scaled[i + 3] * float(w & 0xF000u);
+
+            score += s * accum + b * qsum_precomp[g];
+        }
+        score = simd_sum(score);
+
+        // --- Online softmax ---
+        float new_max = max(max_score, score);
+        float factor = metal::fast::exp2(1.4426950408889634f * (max_score - new_max));
+        float exp_score = metal::fast::exp2(1.4426950408889634f * (score - new_max));
+        max_score = new_max;
+        sum_exp = sum_exp * factor + exp_score;
+
+        // --- Dequantize V[ki] + weighted accumulation ---
+        const device uint16_t* vw = (const device uint16_t*)(v_q_base + ki * k_packed_dim)
+                                    + lane_start / 4;
+        int v_row_offset = ki * k_scale_dim;
+        for (int g = 0; g < groups_per_lane; g++) {
+            int i = g * 4;
+            float evs = exp_score * v_s_base[v_row_offset + group_indices[g]];
+            float evb = exp_score * v_b_base[v_row_offset + group_indices[g]];
+            uint16_t w = vw[g];
+
+            o[i]     = o[i]     * factor + evs * float(w & 0x000Fu) + evb;
+            o[i + 1] = o[i + 1] * factor + evs * float((w >> 4) & 0xFu) + evb;
+            o[i + 2] = o[i + 2] * factor + evs * float((w >> 8) & 0xFu) + evb;
+            o[i + 3] = o[i + 3] * factor + evs * float((w >> 12) & 0xFu) + evb;
+        }
+    }
+
+    // --- Cross-simdgroup reduction ---
+
+    // Step 1: find global max and sum across all simdgroups
+    threadgroup float tg_max_arr[BN];
+    threadgroup float tg_sum_arr[BN];
+    if (simd_lid == 0) {
+        tg_max_arr[simd_gid] = max_score;
+        tg_sum_arr[simd_gid] = sum_exp;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float sg_max = (simd_lid < uint(BN)) ? tg_max_arr[simd_lid] : -1e30f;
+    float new_max = simd_max(sg_max);
+    float sg_factor = metal::fast::exp2(1.4426950408889634f * (sg_max - new_max));
+    float sg_sum_val = (simd_lid < uint(BN)) ? tg_sum_arr[simd_lid] : 0.0f;
+    float global_sum = simd_sum(sg_sum_val * sg_factor);
+
+    // Step 2: rescale this simdgroup's partial output
+    float my_factor = metal::fast::exp2(1.4426950408889634f * (max_score - new_max));
+    for (int i = 0; i < elems_per_lane; i++) {
+        o[i] *= my_factor;
+    }
+
+    // Step 3: tree reduction of partial outputs — O(log2(BN)) barriers instead of O(BN)
+    threadgroup float tg_stage[(BN / 2) * D];
+
+    for (int step = 1; step < BN; step *= 2) {
+        if (int(simd_gid % (2 * step)) == step) {
+            int slot = simd_gid / (2 * step);
+            for (int i = 0; i < elems_per_lane; i++) {
+                tg_stage[slot * D + simd_lid * elems_per_lane + i] = o[i];
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if ((simd_gid % (2 * step)) == 0 && (simd_gid + step < BN)) {
+            int slot = simd_gid / (2 * step);
+            for (int i = 0; i < elems_per_lane; i++) {
+                o[i] += tg_stage[slot * D + simd_lid * elems_per_lane + i];
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Step 4: simdgroup 0 now holds the fully-reduced output — normalize and write
+    if (simd_gid == 0) {
+        for (int i = 0; i < elems_per_lane; i++) {
+            int elem = simd_lid * elems_per_lane + i;
+            out[head_idx * D + elem] = global_sum == 0 ? 0.0f : (o[i] / global_sum);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Split-K variant: each threadgroup processes a chunk of tokens
+// Writes partial (output, max_score, sum_exp) to device memory
+// A second kernel reduces across splits
+// ---------------------------------------------------------------------------
+template <int D, int BN = 16>
+[[kernel]] void sdpa_int4_splitk(
+    const device float* queries        [[buffer(0)]],
+    const device uint32_t* k_quant     [[buffer(1)]],
+    const device float* k_scales       [[buffer(2)]],
+    const device float* k_biases       [[buffer(3)]],
+    const device uint32_t* v_quant     [[buffer(4)]],
+    const device float* v_scales       [[buffer(5)]],
+    const device float* v_biases       [[buffer(6)]],
+    device float* partial_out          [[buffer(7)]],   // (num_heads, num_splits, D)
+    device float* partial_max          [[buffer(8)]],   // (num_heads, num_splits)
+    device float* partial_sum          [[buffer(9)]],   // (num_heads, num_splits)
+    const constant int& gqa_factor     [[buffer(10)]],
+    const constant int& N              [[buffer(11)]],
+    const constant float& scale        [[buffer(12)]],
+    const constant int& sliding_window [[buffer(13)]],
+    const constant int& num_splits     [[buffer(14)]],
+    const constant int& num_heads      [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]
+) {
+    constexpr int BD = 32;
+    constexpr int elems_per_lane = D / BD;
+
+    const int head_idx = tid.x;
+    const int split_idx = tid.y;
+    const int kv_head_idx = (head_idx % num_heads) / gqa_factor;
+
+    const int k_packed_dim = D / 8;
+    const int k_scale_dim = D / 64;
+
+    // Token range for this split
+    int tokens_per_split = (N + num_splits - 1) / num_splits;
+    int ki_start = split_idx * tokens_per_split;
+    int ki_end = min(ki_start + tokens_per_split, N);
+
+    const device uint32_t* k_q_base = k_quant + kv_head_idx * N * k_packed_dim;
+    const device float* k_s_base = k_scales + kv_head_idx * N * k_scale_dim;
+    const device float* k_b_base = k_biases + kv_head_idx * N * k_scale_dim;
+    const device uint32_t* v_q_base = v_quant + kv_head_idx * N * k_packed_dim;
+    const device float* v_s_base = v_scales + kv_head_idx * N * k_scale_dim;
+    const device float* v_b_base = v_biases + kv_head_idx * N * k_scale_dim;
+
+    int lane_start = simd_lid * elems_per_lane;
+
+    thread float q_scaled[D / BD];
+    for (int i = 0; i < elems_per_lane; i += 4) {
+        q_scaled[i]     = scale * queries[head_idx * D + lane_start + i];
+        q_scaled[i + 1] = scale * queries[head_idx * D + lane_start + i + 1] / 16.0f;
+        q_scaled[i + 2] = scale * queries[head_idx * D + lane_start + i + 2] / 256.0f;
+        q_scaled[i + 3] = scale * queries[head_idx * D + lane_start + i + 3] / 4096.0f;
+    }
+
+    constexpr int groups_per_lane = elems_per_lane / 4;
+    thread float qsum_precomp[groups_per_lane];
+    thread int group_indices[groups_per_lane];
+    for (int g = 0; g < groups_per_lane; g++) {
+        int i = g * 4;
+        qsum_precomp[g] = q_scaled[i] + q_scaled[i+1]*16.0f
+                        + q_scaled[i+2]*256.0f + q_scaled[i+3]*4096.0f;
+        group_indices[g] = (lane_start + i) / 64;
+    }
+
+    thread float o[D / BD];
+    for (int i = 0; i < elems_per_lane; i++) o[i] = 0.0f;
+    float max_score = -1e30f;
+    float sum_exp = 0.0f;
+
+    // Fast-skip for sliding window in split-K
+    int loop_start = ki_start + int(simd_gid);
+    if (sliding_window > 0) {
+        int first_valid = N - sliding_window;
+        if (first_valid > loop_start) {
+            int aligned = first_valid - ((first_valid - loop_start) % BN);
+            if (aligned < first_valid) aligned += BN;
+            loop_start = max(loop_start, aligned);
+        }
+    }
+
+    // Process only this split's token range
+    for (int ki = loop_start; ki < ki_end; ki += BN) {
+
+        float score = 0.0f;
+        const device uint16_t* kw = (const device uint16_t*)(k_q_base + ki * k_packed_dim)
+                                    + lane_start / 4;
+        int k_row_offset = ki * k_scale_dim;
+        for (int g = 0; g < groups_per_lane; g++) {
+            int i = g * 4;
+            float s = k_s_base[k_row_offset + group_indices[g]];
+            float b = k_b_base[k_row_offset + group_indices[g]];
+            uint16_t w = kw[g];
+            float accum = q_scaled[i]     * float(w & 0x000Fu)
+                        + q_scaled[i + 1] * float(w & 0x00F0u)
+                        + q_scaled[i + 2] * float(w & 0x0F00u)
+                        + q_scaled[i + 3] * float(w & 0xF000u);
+            score += s * accum + b * qsum_precomp[g];
+        }
+        score = simd_sum(score);
+
+        float new_max = max(max_score, score);
+        float factor = metal::fast::exp2(1.4426950408889634f * (max_score - new_max));
+        float exp_score = metal::fast::exp2(1.4426950408889634f * (score - new_max));
+        max_score = new_max;
+        sum_exp = sum_exp * factor + exp_score;
+
+        const device uint16_t* vw = (const device uint16_t*)(v_q_base + ki * k_packed_dim)
+                                    + lane_start / 4;
+        int v_row_offset = ki * k_scale_dim;
+        for (int g = 0; g < groups_per_lane; g++) {
+            int i = g * 4;
+            float evs = exp_score * v_s_base[v_row_offset + group_indices[g]];
+            float evb = exp_score * v_b_base[v_row_offset + group_indices[g]];
+            uint16_t w = vw[g];
+            o[i]     = o[i]     * factor + evs * float(w & 0x000Fu) + evb;
+            o[i + 1] = o[i + 1] * factor + evs * float((w >> 4) & 0xFu) + evb;
+            o[i + 2] = o[i + 2] * factor + evs * float((w >> 8) & 0xFu) + evb;
+            o[i + 3] = o[i + 3] * factor + evs * float((w >> 12) & 0xFu) + evb;
+        }
+    }
+
+    // Cross-simdgroup reduction (same as main kernel)
+    threadgroup float tg_max_arr[BN];
+    threadgroup float tg_sum_arr[BN];
+    if (simd_lid == 0) {
+        tg_max_arr[simd_gid] = max_score;
+        tg_sum_arr[simd_gid] = sum_exp;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float sg_max = (simd_lid < uint(BN)) ? tg_max_arr[simd_lid] : -1e30f;
+    float new_max = simd_max(sg_max);
+    float sg_factor = metal::fast::exp2(1.4426950408889634f * (sg_max - new_max));
+    float sg_sum_val = (simd_lid < uint(BN)) ? tg_sum_arr[simd_lid] : 0.0f;
+    float global_sum = simd_sum(sg_sum_val * sg_factor);
+
+    float my_factor = metal::fast::exp2(1.4426950408889634f * (max_score - new_max));
+    for (int i = 0; i < elems_per_lane; i++) o[i] *= my_factor;
+
+    threadgroup float tg_stage[(BN / 2) * D];
+    for (int step = 1; step < BN; step *= 2) {
+        if (int(simd_gid % (2 * step)) == step) {
+            int slot = simd_gid / (2 * step);
+            for (int i = 0; i < elems_per_lane; i++)
+                tg_stage[slot * D + simd_lid * elems_per_lane + i] = o[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if ((simd_gid % (2 * step)) == 0 && (simd_gid + step < BN)) {
+            int slot = simd_gid / (2 * step);
+            for (int i = 0; i < elems_per_lane; i++)
+                o[i] += tg_stage[slot * D + simd_lid * elems_per_lane + i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Write partial results to device memory (unnormalized)
+    if (simd_gid == 0) {
+        int out_offset = (head_idx * num_splits + split_idx) * D;
+        for (int i = 0; i < elems_per_lane; i++) {
+            partial_out[out_offset + simd_lid * elems_per_lane + i] = o[i];
+        }
+        if (simd_lid == 0) {
+            partial_max[head_idx * num_splits + split_idx] = new_max;
+            partial_sum[head_idx * num_splits + split_idx] = global_sum;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reduction kernel: combine split-K partials
+// One threadgroup per head, single simdgroup
+// ---------------------------------------------------------------------------
+template <int D>
+[[kernel]] void sdpa_int4_reduce(
+    const device float* partial_out   [[buffer(0)]],   // (num_heads, num_splits, D)
+    const device float* partial_max   [[buffer(1)]],   // (num_heads, num_splits)
+    const device float* partial_sum   [[buffer(2)]],   // (num_heads, num_splits)
+    device float* out                 [[buffer(3)]],   // (num_heads, D)
+    const constant int& num_splits    [[buffer(4)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]
+) {
+    constexpr int BD = 32;
+    constexpr int elems_per_lane = D / BD;
+    const int head_idx = tid.x;
+
+    // Find global max across splits
+    float global_max = -1e30f;
+    for (int s = 0; s < num_splits; s++) {
+        global_max = max(global_max, partial_max[head_idx * num_splits + s]);
+    }
+
+    // Accumulate rescaled outputs and sums
+    thread float acc[D / BD];
+    for (int i = 0; i < elems_per_lane; i++) acc[i] = 0.0f;
+    float total_sum = 0.0f;
+
+    for (int s = 0; s < num_splits; s++) {
+        float split_max = partial_max[head_idx * num_splits + s];
+        float split_sum = partial_sum[head_idx * num_splits + s];
+        float factor = metal::fast::exp2(1.4426950408889634f * (split_max - global_max));
+        total_sum += split_sum * factor;
+
+        int in_offset = (head_idx * num_splits + s) * D;
+        for (int i = 0; i < elems_per_lane; i++) {
+            acc[i] += partial_out[in_offset + simd_lid * elems_per_lane + i] * factor;
+        }
+    }
+
+    // Normalize and write
+    for (int i = 0; i < elems_per_lane; i++) {
+        int elem = simd_lid * elems_per_lane + i;
+        out[head_idx * D + elem] = total_sum == 0 ? 0.0f : (acc[i] / total_sum);
+    }
+}
+
+// Instantiate for common head dimensions
+// Default BN values (production)
+template [[host_name("sdpa_int4_128")]] [[kernel]]
+void sdpa_int4_vector<128, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, uint3, uint, uint);
+
+template [[host_name("sdpa_int4_256")]] [[kernel]]
+void sdpa_int4_vector<256, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, uint3, uint, uint);
+
+template [[host_name("sdpa_int4_512")]] [[kernel]]
+void sdpa_int4_vector<512, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, uint3, uint, uint);
+
+// Split-K instantiations
+template [[host_name("sdpa_int4_splitk_128")]] [[kernel]]
+void sdpa_int4_splitk<128, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, device float*, device float*,
+    const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, const constant int&, uint3, uint, uint);
+
+template [[host_name("sdpa_int4_splitk_256")]] [[kernel]]
+void sdpa_int4_splitk<256, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, device float*, device float*,
+    const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, const constant int&, uint3, uint, uint);
+
+template [[host_name("sdpa_int4_splitk_512")]] [[kernel]]
+void sdpa_int4_splitk<512, 16>(
+    const device float*, const device uint32_t*, const device float*, const device float*,
+    const device uint32_t*, const device float*, const device float*,
+    device float*, device float*, device float*,
+    const constant int&, const constant int&, const constant float&,
+    const constant int&, const constant int&, const constant int&, uint3, uint, uint);
+
+// Reduction instantiations
+template [[host_name("sdpa_int4_reduce_128")]] [[kernel]]
+void sdpa_int4_reduce<128>(
+    const device float*, const device float*, const device float*,
+    device float*, const constant int&, uint3, uint);
+
+template [[host_name("sdpa_int4_reduce_256")]] [[kernel]]
+void sdpa_int4_reduce<256>(
+    const device float*, const device float*, const device float*,
+    device float*, const constant int&, uint3, uint);
+
+template [[host_name("sdpa_int4_reduce_512")]] [[kernel]]
+void sdpa_int4_reduce<512>(
+    const device float*, const device float*, const device float*,
+    device float*, const constant int&, uint3, uint);

--- a/metal-int4-sdpa/sdpa_int4_metal/sdpa_int4.mm
+++ b/metal-int4-sdpa/sdpa_int4_metal/sdpa_int4.mm
@@ -1,0 +1,259 @@
+// Objective-C++ binding for sdpa_int4 Metal kernel
+// Bridges PyTorch MPS tensors to the Metal compute pipeline
+
+#include <torch/torch.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/native/mps/OperationUtils.h>
+#include <unordered_map>
+
+// Metal library embedded by kernel-builder
+#include EMBEDDED_METALLIB_HEADER
+
+// Forward declarations
+torch::Tensor sdpa_int4_splitk(
+    torch::Tensor queries, torch::Tensor k_quant, torch::Tensor k_scales,
+    torch::Tensor k_biases, torch::Tensor v_quant, torch::Tensor v_scales,
+    torch::Tensor v_biases, int64_t gqa_factor, int64_t N, double scale,
+    int64_t sliding_window, int64_t num_splits);
+
+// Cache pipeline states to avoid redundant Metal library/pipeline creation
+static std::unordered_map<int, id<MTLComputePipelineState>> pso_cache;
+
+static id<MTLComputePipelineState> getPipelineState(
+    id<MTLDevice> device,
+    int head_dim
+) {
+    auto it = pso_cache.find(head_dim);
+    if (it != pso_cache.end()) return it->second;
+
+    NSError* error = nil;
+    id<MTLLibrary> library = EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+    TORCH_CHECK(library, "Failed to create Metal library: ",
+                error ? [[error localizedDescription] UTF8String] : "unknown");
+
+    NSString* kernelName;
+    switch (head_dim) {
+        case 128: kernelName = @"sdpa_int4_128"; break;
+        case 256: kernelName = @"sdpa_int4_256"; break;
+        case 512: kernelName = @"sdpa_int4_512"; break;
+        default:
+            TORCH_CHECK(false, "Unsupported head_dim: ", head_dim,
+                       ". Must be 128, 256, or 512.");
+    }
+
+    id<MTLFunction> function = [library newFunctionWithName:kernelName];
+    TORCH_CHECK(function, "Failed to find kernel: ", [kernelName UTF8String]);
+
+    id<MTLComputePipelineState> pso =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    TORCH_CHECK(pso, "Failed to create pipeline state: ",
+                error ? [[error localizedDescription] UTF8String] : "unknown");
+
+    pso_cache[head_dim] = pso;
+    return pso;
+}
+
+torch::Tensor sdpa_int4(
+    torch::Tensor queries,      // (num_heads, D) float32
+    torch::Tensor k_quant,      // (num_kv_heads, N, D/8) uint32
+    torch::Tensor k_scales,     // (num_kv_heads, N, D/64) float32
+    torch::Tensor k_biases,     // (num_kv_heads, N, D/64) float32
+    torch::Tensor v_quant,      // (num_kv_heads, N, D/8) uint32
+    torch::Tensor v_scales,     // (num_kv_heads, N, D/64) float32
+    torch::Tensor v_biases,     // (num_kv_heads, N, D/64) float32
+    int64_t gqa_factor,
+    int64_t N,
+    double scale,
+    int64_t sliding_window
+) {
+    TORCH_CHECK(queries.device().is_mps(), "queries must be on MPS device");
+    TORCH_CHECK(queries.dim() == 2, "queries must be 2D (num_heads, D)");
+
+    int total_heads = queries.size(0);  // May be batch * num_heads for batched decode
+    int D = queries.size(1);
+    int n = static_cast<int>(N);
+    int num_kv_heads = k_quant.size(0);
+    int num_heads = num_kv_heads * static_cast<int>(gqa_factor);  // Per-batch num_heads
+
+    // Adaptive split-K: use when we need more GPU parallelism
+    // Split-K doubles threadgroups but only helps when heads < GPU cores.
+    int sw = static_cast<int>(sliding_window);
+    int effective_n = (sw > 0 && sw < n) ? sw : n;
+    if (effective_n >= 2048 && total_heads <= 16) {
+        return sdpa_int4_splitk(queries, k_quant, k_scales, k_biases,
+                                v_quant, v_scales, v_biases,
+                                gqa_factor, N, scale, sliding_window, 2);
+    }
+
+    // Regular single-dispatch path for smaller N
+    auto output = torch::empty({total_heads, D}, queries.options());
+
+    @autoreleasepool {
+        auto stream = at::mps::getCurrentMPSStream();
+        auto device = stream->device();
+
+        auto pso = getPipelineState(device, D);
+
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+
+        [encoder setComputePipelineState:pso];
+
+        using at::native::mps::getMTLBufferStorage;
+        [encoder setBuffer:getMTLBufferStorage(queries)  offset:queries.storage_offset() * sizeof(float)     atIndex:0];
+        [encoder setBuffer:getMTLBufferStorage(k_quant)  offset:k_quant.storage_offset() * sizeof(uint32_t)  atIndex:1];
+        [encoder setBuffer:getMTLBufferStorage(k_scales) offset:k_scales.storage_offset() * sizeof(float)    atIndex:2];
+        [encoder setBuffer:getMTLBufferStorage(k_biases) offset:k_biases.storage_offset() * sizeof(float)    atIndex:3];
+        [encoder setBuffer:getMTLBufferStorage(v_quant)  offset:v_quant.storage_offset() * sizeof(uint32_t)  atIndex:4];
+        [encoder setBuffer:getMTLBufferStorage(v_scales) offset:v_scales.storage_offset() * sizeof(float)    atIndex:5];
+        [encoder setBuffer:getMTLBufferStorage(v_biases) offset:v_biases.storage_offset() * sizeof(float)    atIndex:6];
+        [encoder setBuffer:getMTLBufferStorage(output)   offset:0                                            atIndex:7];
+
+        int gqa = static_cast<int>(gqa_factor);
+        float s = static_cast<float>(scale);
+        int sw = static_cast<int>(sliding_window);
+        int nh = num_heads;
+        [encoder setBytes:&gqa length:sizeof(int)   atIndex:8];
+        [encoder setBytes:&n   length:sizeof(int)   atIndex:9];
+        [encoder setBytes:&s   length:sizeof(float) atIndex:10];
+        [encoder setBytes:&sw  length:sizeof(int)   atIndex:11];
+        [encoder setBytes:&nh  length:sizeof(int)   atIndex:12];
+
+        int BN = 16;
+        MTLSize gridSize = MTLSizeMake(total_heads, 1, 1);
+        MTLSize groupSize = MTLSizeMake(BN * 32, 1, 1);
+        [encoder dispatchThreadgroups:gridSize threadsPerThreadgroup:groupSize];
+
+        stream->synchronize(at::mps::SyncType::COMMIT_AND_CONTINUE);
+    }
+
+    return output;
+}
+
+// Split-K variant for improved GPU utilization
+torch::Tensor sdpa_int4_splitk(
+    torch::Tensor queries, torch::Tensor k_quant, torch::Tensor k_scales,
+    torch::Tensor k_biases, torch::Tensor v_quant, torch::Tensor v_scales,
+    torch::Tensor v_biases, int64_t gqa_factor, int64_t N, double scale,
+    int64_t sliding_window, int64_t num_splits
+) {
+    TORCH_CHECK(queries.device().is_mps(), "queries must be on MPS device");
+    TORCH_CHECK(queries.dim() == 2, "queries must be 2D (num_heads, D)");
+
+    int total_heads = queries.size(0);
+    int D = queries.size(1);
+    int ns = static_cast<int>(num_splits);
+    int num_kv_heads = k_quant.size(0);
+    int num_heads = num_kv_heads * static_cast<int>(gqa_factor);
+
+    // Persistent scratch buffers
+    static torch::Tensor s_partial_out, s_partial_max, s_partial_sum;
+    static int s_nh = 0, s_ns = 0, s_D = 0;
+
+    if (total_heads != s_nh || ns != s_ns || D != s_D) {
+        s_partial_out = torch::empty({total_heads, ns, D}, queries.options());
+        s_partial_max = torch::empty({total_heads, ns}, queries.options());
+        s_partial_sum = torch::empty({total_heads, ns}, queries.options());
+        s_nh = total_heads; s_ns = ns; s_D = D;
+    }
+
+    // No initialization needed — kernel writes all elements
+    auto& partial_out = s_partial_out;
+    auto& partial_max = s_partial_max;
+    auto& partial_sum = s_partial_sum;
+    auto output = torch::empty({total_heads, D}, queries.options());
+
+    @autoreleasepool {
+        auto stream = at::mps::getCurrentMPSStream();
+        auto device = stream->device();
+
+        // Get cached split-K pipeline states
+        static std::unordered_map<int, std::pair<id<MTLComputePipelineState>, id<MTLComputePipelineState>>> splitk_cache;
+        auto sk_it = splitk_cache.find(D);
+        id<MTLComputePipelineState> splitk_pso, reduce_pso;
+        if (sk_it != splitk_cache.end()) {
+            splitk_pso = sk_it->second.first;
+            reduce_pso = sk_it->second.second;
+        } else {
+            NSError* error = nil;
+            id<MTLLibrary> library = EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+            TORCH_CHECK(library, "Failed to create Metal library");
+
+            NSString* splitk_name;
+            NSString* reduce_name;
+            switch (D) {
+                case 128: splitk_name = @"sdpa_int4_splitk_128"; reduce_name = @"sdpa_int4_reduce_128"; break;
+                case 256: splitk_name = @"sdpa_int4_splitk_256"; reduce_name = @"sdpa_int4_reduce_256"; break;
+                case 512: splitk_name = @"sdpa_int4_splitk_512"; reduce_name = @"sdpa_int4_reduce_512"; break;
+                default:
+                    TORCH_CHECK(false, "Unsupported head_dim for split-K: ", D);
+            }
+
+            id<MTLFunction> splitk_fn = [library newFunctionWithName:splitk_name];
+            TORCH_CHECK(splitk_fn, "Failed to find splitk kernel");
+            splitk_pso = [device newComputePipelineStateWithFunction:splitk_fn error:&error];
+            TORCH_CHECK(splitk_pso, "Failed to create splitk pipeline");
+
+            id<MTLFunction> reduce_fn = [library newFunctionWithName:reduce_name];
+            TORCH_CHECK(reduce_fn, "Failed to find reduce kernel");
+            reduce_pso = [device newComputePipelineStateWithFunction:reduce_fn error:&error];
+            TORCH_CHECK(reduce_pso, "Failed to create reduce pipeline");
+
+            splitk_cache[D] = {splitk_pso, reduce_pso};
+        }
+
+        // Use stream's shared encoder — supports multiple dispatches
+        // Both split-K and reduction kernels encode on the same encoder
+        id<MTLComputeCommandEncoder> encoder = stream->commandEncoder();
+
+        // --- Kernel 1: Split-K main computation ---
+        [encoder setComputePipelineState:splitk_pso];
+
+        using at::native::mps::getMTLBufferStorage;
+        [encoder setBuffer:getMTLBufferStorage(queries)      offset:queries.storage_offset() * sizeof(float)     atIndex:0];
+        [encoder setBuffer:getMTLBufferStorage(k_quant)      offset:k_quant.storage_offset() * sizeof(uint32_t)  atIndex:1];
+        [encoder setBuffer:getMTLBufferStorage(k_scales)     offset:k_scales.storage_offset() * sizeof(float)    atIndex:2];
+        [encoder setBuffer:getMTLBufferStorage(k_biases)     offset:k_biases.storage_offset() * sizeof(float)    atIndex:3];
+        [encoder setBuffer:getMTLBufferStorage(v_quant)      offset:v_quant.storage_offset() * sizeof(uint32_t)  atIndex:4];
+        [encoder setBuffer:getMTLBufferStorage(v_scales)     offset:v_scales.storage_offset() * sizeof(float)    atIndex:5];
+        [encoder setBuffer:getMTLBufferStorage(v_biases)     offset:v_biases.storage_offset() * sizeof(float)    atIndex:6];
+        [encoder setBuffer:getMTLBufferStorage(partial_out)  offset:0 atIndex:7];
+        [encoder setBuffer:getMTLBufferStorage(partial_max)  offset:0 atIndex:8];
+        [encoder setBuffer:getMTLBufferStorage(partial_sum)  offset:0 atIndex:9];
+
+        int gqa = static_cast<int>(gqa_factor);
+        int n = static_cast<int>(N);
+        float s = static_cast<float>(scale);
+        int sw = static_cast<int>(sliding_window);
+        int nh = num_heads;
+        [encoder setBytes:&gqa length:sizeof(int)   atIndex:10];
+        [encoder setBytes:&n   length:sizeof(int)   atIndex:11];
+        [encoder setBytes:&s   length:sizeof(float) atIndex:12];
+        [encoder setBytes:&sw  length:sizeof(int)   atIndex:13];
+        [encoder setBytes:&ns  length:sizeof(int)   atIndex:14];
+        [encoder setBytes:&nh  length:sizeof(int)   atIndex:15];
+
+        int BN = 16;
+        MTLSize splitk_grid = MTLSizeMake(total_heads, ns, 1);
+        MTLSize splitk_group = MTLSizeMake(BN * 32, 1, 1);
+        [encoder dispatchThreadgroups:splitk_grid threadsPerThreadgroup:splitk_group];
+
+        // --- Kernel 2: Reduction ---
+        [encoder setComputePipelineState:reduce_pso];
+        [encoder setBuffer:getMTLBufferStorage(partial_out) offset:0 atIndex:0];
+        [encoder setBuffer:getMTLBufferStorage(partial_max) offset:0 atIndex:1];
+        [encoder setBuffer:getMTLBufferStorage(partial_sum) offset:0 atIndex:2];
+        [encoder setBuffer:getMTLBufferStorage(output)      offset:0 atIndex:3];
+        [encoder setBytes:&ns length:sizeof(int) atIndex:4];
+
+        MTLSize reduce_grid = MTLSizeMake(total_heads, 1, 1);
+        MTLSize reduce_group = MTLSizeMake(32, 1, 1);  // Single simdgroup per head
+        [encoder dispatchThreadgroups:reduce_grid threadsPerThreadgroup:reduce_group];
+
+        // End kernel coalescing to ensure split-K and reduction execute sequentially
+        stream->endKernelCoalescing();
+        stream->synchronize(at::mps::SyncType::COMMIT_AND_CONTINUE);
+    }
+
+    return output;
+}
+

--- a/metal-int4-sdpa/tests/reference.py
+++ b/metal-int4-sdpa/tests/reference.py
@@ -1,0 +1,359 @@
+"""
+Pure PyTorch reference implementation of fused int4 SDPA.
+
+This implements scaled dot-product attention where K and V are stored
+in int4 format (4-bit quantized with per-group scale+bias). The key
+insight is that we dequantize K/V on-the-fly during attention computation,
+never materializing the full fp32/fp16 K/V matrices.
+
+int4 format:
+  - uint32 packs 8 x 4-bit values
+  - group_size=64: every 64 elements share one (scale, bias) pair
+  - dequantize: value = scale * nibble + bias
+
+Attention:
+  score_i = (Q * scale) @ dequantize(K_i)
+  output = softmax(scores) @ dequantize(V)
+
+Uses online softmax (Milakov & Gimelshein 2018) to avoid materializing
+the full score matrix — O(1) memory in sequence length.
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def quantize_int4(
+    x: torch.Tensor, group_size: int = 64
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize fp32 tensor to int4 with per-group scale+bias.
+
+    Args:
+        x: (..., D) float tensor where D is divisible by group_size
+        group_size: number of elements per quantization group
+
+    Returns:
+        packed: (..., D//8) uint32 tensor, 8 nibbles per uint32
+        scales: (..., D//group_size) float tensor
+        biases: (..., D//group_size) float tensor
+    """
+    shape = x.shape
+    D = shape[-1]
+    assert D % group_size == 0
+    assert D % 8 == 0
+
+    # Reshape into groups
+    x_grouped = x.reshape(*shape[:-1], D // group_size, group_size)
+
+    # Per-group min/max
+    x_min = x_grouped.min(dim=-1).values
+    x_max = x_grouped.max(dim=-1).values
+
+    # Scale and bias: value = scale * nibble + bias
+    # nibble in [0, 15], so: scale = (max - min) / 15, bias = min
+    scale = (x_max - x_min) / 15.0
+    scale = scale.clamp(min=1e-8)
+    bias = x_min
+
+    # Quantize to [0, 15]
+    x_scaled = (x_grouped - bias.unsqueeze(-1)) / scale.unsqueeze(-1)
+    x_clamped = x_scaled.round().clamp(0, 15).to(torch.uint8)
+
+    # Pack 8 nibbles into int32 (PyTorch doesn't support uint32 bitops)
+    x_flat = x_clamped.reshape(*shape[:-1], D // 8, 8)
+    packed = torch.zeros(*shape[:-1], D // 8, dtype=torch.int32, device=x.device)
+    for i in range(8):
+        packed |= x_flat[..., i].to(torch.int32) << (4 * i)
+
+    return packed, scale, bias
+
+
+def dequantize_int4(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    biases: torch.Tensor,
+    group_size: int = 64,
+) -> torch.Tensor:
+    """Dequantize int4 packed tensor back to float.
+
+    Args:
+        packed: (..., D//8) uint32 tensor
+        scales: (..., D//group_size) float tensor
+        biases: (..., D//group_size) float tensor
+        group_size: quantization group size
+
+    Returns:
+        (..., D) float tensor
+    """
+    shape = packed.shape
+    D = shape[-1] * 8
+
+    # Unpack 8 nibbles from each uint32
+    nibbles = torch.zeros(*shape, 8, dtype=torch.float32, device=packed.device)
+    for i in range(8):
+        nibbles[..., i] = ((packed >> (4 * i)) & 0xF).float()
+
+    nibbles = nibbles.reshape(*shape[:-1], D)
+
+    # Apply scale + bias per group
+    nibbles_grouped = nibbles.reshape(*shape[:-1], D // group_size, group_size)
+    result = scales.unsqueeze(-1) * nibbles_grouped + biases.unsqueeze(-1)
+    return result.reshape(*shape[:-1], D)
+
+
+def sdpa_int4_reference(
+    queries: torch.Tensor,
+    k_packed: torch.Tensor,
+    k_scales: torch.Tensor,
+    k_biases: torch.Tensor,
+    v_packed: torch.Tensor,
+    v_scales: torch.Tensor,
+    v_biases: torch.Tensor,
+    scale: float,
+    gqa_factor: int = 1,
+    sliding_window: int = 0,
+) -> torch.Tensor:
+    """Reference: dequantize everything, then standard SDPA.
+
+    This is the naive baseline that materializes full K and V.
+
+    Args:
+        queries: (num_heads, D) float — single-token decode query
+        k_packed: (num_kv_heads, N, D//8) uint32
+        k_scales: (num_kv_heads, N, D//group_size) float
+        k_biases: (num_kv_heads, N, D//group_size) float
+        v_packed: (num_kv_heads, N, D//8) uint32
+        v_scales: (num_kv_heads, N, D//group_size) float
+        v_biases: (num_kv_heads, N, D//group_size) float
+        scale: attention scale factor (typically 1/sqrt(D))
+        gqa_factor: num_heads // num_kv_heads for grouped-query attention
+        sliding_window: if > 0, only attend to last `sliding_window` tokens
+
+    Returns:
+        (num_heads, D) float — attention output
+    """
+    num_heads, D = queries.shape
+    num_kv_heads = k_packed.shape[0]
+    N = k_packed.shape[1]
+
+    # Full dequantization
+    K = dequantize_int4(k_packed, k_scales, k_biases)  # (num_kv_heads, N, D)
+    V = dequantize_int4(v_packed, v_scales, v_biases)  # (num_kv_heads, N, D)
+
+    # GQA: expand KV heads to match query heads
+    if gqa_factor > 1:
+        K = K.repeat_interleave(gqa_factor, dim=0)  # (num_heads, N, D)
+        V = V.repeat_interleave(gqa_factor, dim=0)
+
+    # Scores: (num_heads, N)
+    scores = scale * torch.einsum("hd,hnd->hn", queries, K)
+
+    # Sliding window mask
+    if sliding_window > 0:
+        mask = torch.arange(N, device=queries.device)
+        mask = (N - 1 - mask) >= sliding_window
+        scores = scores.masked_fill(mask.unsqueeze(0), float("-inf"))
+
+    # Softmax + weighted sum
+    attn = F.softmax(scores, dim=-1)  # (num_heads, N)
+    output = torch.einsum("hn,hnd->hd", attn, V)  # (num_heads, D)
+
+    return output
+
+
+def sdpa_int4_fused(
+    queries: torch.Tensor,
+    k_packed: torch.Tensor,
+    k_scales: torch.Tensor,
+    k_biases: torch.Tensor,
+    v_packed: torch.Tensor,
+    v_scales: torch.Tensor,
+    v_biases: torch.Tensor,
+    scale: float,
+    gqa_factor: int = 1,
+    sliding_window: int = 0,
+) -> torch.Tensor:
+    """Fused: dequantize K/V on-the-fly with online softmax.
+
+    This is the PyTorch equivalent of what the Metal kernel does:
+    iterate over tokens one at a time, dequantize K/V in registers,
+    and maintain running softmax statistics.
+
+    Same interface as sdpa_int4_reference.
+    """
+    num_heads, D = queries.shape
+    num_kv_heads = k_packed.shape[0]
+    N = k_packed.shape[1]
+    group_size = 64
+    k_packed_dim = D // 8
+    k_scale_dim = D // group_size
+
+    output = torch.zeros(num_heads, D, device=queries.device, dtype=queries.dtype)
+
+    for h in range(num_heads):
+        kv_h = h // gqa_factor
+        q = queries[h] * scale  # (D,)
+
+        max_score = torch.tensor(float("-inf"), device=queries.device)
+        sum_exp = torch.tensor(0.0, device=queries.device)
+        acc = torch.zeros(D, device=queries.device)
+
+        for ki in range(N):
+            # Sliding window
+            if sliding_window > 0 and (N - 1 - ki) >= sliding_window:
+                continue
+
+            # Dequantize K[ki] on the fly
+            k_packed_row = k_packed[kv_h, ki]  # (D//8,)
+            k_s = k_scales[kv_h, ki]  # (D//group_size,)
+            k_b = k_biases[kv_h, ki]
+
+            k_vec = torch.zeros(D, device=queries.device)
+            for g in range(k_scale_dim):
+                for j in range(group_size // 8):
+                    w_idx = g * (group_size // 8) + j
+                    w = k_packed_row[w_idx].item()
+                    for n in range(8):
+                        nibble = (w >> (4 * n)) & 0xF
+                        elem_idx = g * group_size + j * 8 + n
+                        k_vec[elem_idx] = k_s[g] * nibble + k_b[g]
+
+            # Score
+            score = torch.dot(q, k_vec)
+
+            # Online softmax update
+            new_max = torch.maximum(max_score, score)
+            factor = torch.exp(max_score - new_max)
+            exp_score = torch.exp(score - new_max)
+            max_score = new_max
+            sum_exp = sum_exp * factor + exp_score
+
+            # Dequantize V[ki] on the fly
+            v_packed_row = v_packed[kv_h, ki]
+            v_s = v_scales[kv_h, ki]
+            v_b = v_biases[kv_h, ki]
+
+            v_vec = torch.zeros(D, device=queries.device)
+            for g in range(k_scale_dim):
+                for j in range(group_size // 8):
+                    w_idx = g * (group_size // 8) + j
+                    w = v_packed_row[w_idx].item()
+                    for n in range(8):
+                        nibble = (w >> (4 * n)) & 0xF
+                        elem_idx = g * group_size + j * 8 + n
+                        v_vec[elem_idx] = v_s[g] * nibble + v_b[g]
+
+            # Accumulate
+            acc = acc * factor + exp_score * v_vec
+
+        # Normalize
+        output[h] = acc / (sum_exp + 1e-8)
+
+    return output
+
+
+def sdpa_int4_fused_vectorized(
+    queries: torch.Tensor,
+    k_packed: torch.Tensor,
+    k_scales: torch.Tensor,
+    k_biases: torch.Tensor,
+    v_packed: torch.Tensor,
+    v_scales: torch.Tensor,
+    v_biases: torch.Tensor,
+    scale: float,
+    gqa_factor: int = 1,
+    sliding_window: int = 0,
+) -> torch.Tensor:
+    """Vectorized fused SDPA — processes all tokens at once per head.
+
+    This is the practical PyTorch implementation: still fused (no full K/V
+    materialization across heads), but vectorized over the sequence dimension
+    for each head. Matches Metal kernel semantics but uses PyTorch ops.
+    """
+    num_heads, D = queries.shape
+    num_kv_heads = k_packed.shape[0]
+    N = k_packed.shape[1]
+    group_size = 64
+    k_scale_dim = D // group_size
+
+    output = torch.zeros(num_heads, D, device=queries.device, dtype=queries.dtype)
+
+    for kv_h in range(num_kv_heads):
+        # Batch-dequantize K for this KV head: (N, D)
+        K = dequantize_int4(
+            k_packed[kv_h], k_scales[kv_h], k_biases[kv_h]
+        )
+        V = dequantize_int4(
+            v_packed[kv_h], v_scales[kv_h], v_biases[kv_h]
+        )
+
+        # Process all query heads that map to this KV head
+        h_start = kv_h * gqa_factor
+        h_end = h_start + gqa_factor
+
+        for h in range(h_start, h_end):
+            q = queries[h] * scale  # (D,)
+            scores = K @ q  # (N,)
+
+            if sliding_window > 0:
+                mask = torch.arange(N, device=queries.device)
+                scores[(N - 1 - mask) >= sliding_window] = float("-inf")
+
+            attn = F.softmax(scores, dim=0)  # (N,)
+            output[h] = attn @ V  # (D,)
+
+    return output
+
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+
+    # Test configuration matching Gemma 4 sliding attention layer
+    num_heads = 8
+    num_kv_heads = 4
+    gqa_factor = num_heads // num_kv_heads
+    D = 256
+    N = 128
+    group_size = 64
+
+    device = "cpu"
+
+    # Generate random Q, K, V
+    Q = torch.randn(num_heads, D, device=device)
+    K_full = torch.randn(num_kv_heads, N, D, device=device)
+    V_full = torch.randn(num_kv_heads, N, D, device=device)
+    attn_scale = 1.0 / (D**0.5)
+
+    # Quantize K and V to int4
+    k_packed, k_scales, k_biases = quantize_int4(K_full, group_size)
+    v_packed, v_scales, v_biases = quantize_int4(V_full, group_size)
+
+    # Run all three implementations
+    out_ref = sdpa_int4_reference(
+        Q, k_packed, k_scales, k_biases,
+        v_packed, v_scales, v_biases,
+        attn_scale, gqa_factor,
+    )
+    out_fused = sdpa_int4_fused(
+        Q, k_packed, k_scales, k_biases,
+        v_packed, v_scales, v_biases,
+        attn_scale, gqa_factor,
+    )
+    out_vec = sdpa_int4_fused_vectorized(
+        Q, k_packed, k_scales, k_biases,
+        v_packed, v_scales, v_biases,
+        attn_scale, gqa_factor,
+    )
+
+    # Compare
+    diff_fused = (out_ref - out_fused).abs().max().item()
+    diff_vec = (out_ref - out_vec).abs().max().item()
+
+    print(f"Reference vs Fused (loop):       max diff = {diff_fused:.6e}")
+    print(f"Reference vs Fused (vectorized): max diff = {diff_vec:.6e}")
+    print(f"Shape: ({num_heads}, {D}), KV heads: {num_kv_heads}, N: {N}")
+    print(f"Quantization: int4, group_size={group_size}")
+
+    assert diff_fused < 1e-4, f"Fused loop too far off: {diff_fused}"
+    assert diff_vec < 1e-4, f"Vectorized too far off: {diff_vec}"
+    print("\nAll implementations match!")

--- a/metal-int4-sdpa/tests/test_sdpa_int4.py
+++ b/metal-int4-sdpa/tests/test_sdpa_int4.py
@@ -1,0 +1,458 @@
+"""
+Correctness tests for sdpa_int4.
+
+Tests the PyTorch reference implementations against each other and,
+when available, against the Metal kernel. Validates:
+  1. Quantization round-trip (int4 quantize → dequantize)
+  2. Fused vs materialized SDPA match
+  3. GQA (grouped-query attention) correctness
+  4. Sliding window masking
+  5. Numerical stability with large/small values
+  6. Edge cases: N=1, N=large, uniform inputs
+"""
+
+import math
+import pytest
+import torch
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from reference import (
+    quantize_int4,
+    dequantize_int4,
+    sdpa_int4_reference,
+    sdpa_int4_fused,
+    sdpa_int4_fused_vectorized,
+)
+
+
+# --- Helpers ---
+
+def make_test_data(
+    num_heads=8, num_kv_heads=4, D=256, N=64, group_size=64, seed=42
+):
+    torch.manual_seed(seed)
+    Q = torch.randn(num_heads, D)
+    K = torch.randn(num_kv_heads, N, D)
+    V = torch.randn(num_kv_heads, N, D)
+    scale = 1.0 / math.sqrt(D)
+    gqa_factor = num_heads // num_kv_heads
+
+    k_packed, k_scales, k_biases = quantize_int4(K, group_size)
+    v_packed, v_scales, v_biases = quantize_int4(V, group_size)
+
+    return {
+        "Q": Q, "K": K, "V": V, "scale": scale,
+        "gqa_factor": gqa_factor,
+        "k_packed": k_packed, "k_scales": k_scales, "k_biases": k_biases,
+        "v_packed": v_packed, "v_scales": v_scales, "v_biases": v_biases,
+    }
+
+
+# --- Quantization tests ---
+
+class TestQuantization:
+    def test_roundtrip_shape(self):
+        x = torch.randn(4, 128, 256)
+        packed, scales, biases = quantize_int4(x, group_size=64)
+        assert packed.shape == (4, 128, 32)   # 256/8 = 32
+        assert scales.shape == (4, 128, 4)    # 256/64 = 4
+        assert biases.shape == (4, 128, 4)
+
+    def test_roundtrip_accuracy(self):
+        x = torch.randn(2, 64, 128)
+        packed, scales, biases = quantize_int4(x, group_size=64)
+        x_recon = dequantize_int4(packed, scales, biases, group_size=64)
+        # int4 quantization error should be bounded
+        rel_error = (x - x_recon).abs().mean() / x.abs().mean()
+        assert rel_error < 0.15, f"Relative error too high: {rel_error:.4f}"
+
+    def test_nibble_range(self):
+        """All packed nibbles should be in [0, 15]."""
+        x = torch.randn(1, 1, 64)
+        packed, _, _ = quantize_int4(x, group_size=64)
+        for i in range(8):
+            nibbles = (packed >> (4 * i)) & 0xF
+            assert nibbles.max() <= 15
+            assert nibbles.min() >= 0
+
+    def test_constant_input(self):
+        """Constant input should quantize to same nibble value everywhere."""
+        x = torch.ones(1, 1, 64) * 3.14
+        packed, scales, biases = quantize_int4(x, group_size=64)
+        x_recon = dequantize_int4(packed, scales, biases, group_size=64)
+        # All values should be identical after dequant
+        assert (x_recon - x_recon[0, 0, 0]).abs().max() < 1e-6
+
+
+# --- SDPA correctness tests ---
+
+class TestSDPACorrectness:
+    def test_reference_vs_fused_vectorized(self):
+        d = make_test_data()
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_vec = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        diff = (out_ref - out_vec).abs().max().item()
+        assert diff < 1e-5, f"ref vs vectorized: {diff}"
+
+    @pytest.mark.slow
+    def test_reference_vs_fused_loop(self):
+        """Slow: tests the per-token loop implementation."""
+        d = make_test_data(num_heads=2, num_kv_heads=1, D=128, N=16)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_fused = sdpa_int4_fused(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        diff = (out_ref - out_fused).abs().max().item()
+        assert diff < 1e-4, f"ref vs fused loop: {diff}"
+
+
+class TestGQA:
+    @pytest.mark.parametrize("gqa_factor", [1, 2, 4, 8])
+    def test_gqa_factors(self, gqa_factor):
+        num_kv_heads = 2
+        num_heads = num_kv_heads * gqa_factor
+        d = make_test_data(num_heads=num_heads, num_kv_heads=num_kv_heads, D=128, N=32)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_vec = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        diff = (out_ref - out_vec).abs().max().item()
+        assert diff < 1e-5, f"GQA factor {gqa_factor}: {diff}"
+
+    def test_shared_kv_heads_produce_same_output(self):
+        """Query heads sharing a KV head should differ only due to different Q."""
+        d = make_test_data(num_heads=4, num_kv_heads=1, D=128, N=32)
+        # Use identical queries for heads 0 and 1 (same KV head)
+        d["Q"][1] = d["Q"][0].clone()
+        out = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        diff = (out[0] - out[1]).abs().max().item()
+        assert diff < 1e-6, f"Identical queries should give identical output: {diff}"
+
+
+class TestSlidingWindow:
+    def test_sliding_window_basic(self):
+        d = make_test_data(D=128, N=64)
+        out_full = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=0,
+        )
+        out_window = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=32,
+        )
+        # With a window, output should differ from full attention
+        diff = (out_full - out_window).abs().max().item()
+        assert diff > 1e-3, "Sliding window should change output"
+
+    def test_window_equals_N_matches_full(self):
+        """Window >= N should give same result as no window."""
+        d = make_test_data(D=128, N=32)
+        out_full = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=0,
+        )
+        out_window = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=32,
+        )
+        diff = (out_full - out_window).abs().max().item()
+        assert diff < 1e-6
+
+
+class TestEdgeCases:
+    def test_single_token(self):
+        """N=1: output should be V[0] regardless of Q."""
+        d = make_test_data(D=128, N=1)
+        out = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        V_deq = dequantize_int4(d["v_packed"], d["v_scales"], d["v_biases"])
+        # Each head should output the single V token (expanded via GQA)
+        for h in range(out.shape[0]):
+            kv_h = h // d["gqa_factor"]
+            diff = (out[h] - V_deq[kv_h, 0]).abs().max().item()
+            assert diff < 1e-5, f"N=1 head {h}: {diff}"
+
+    def test_large_values(self):
+        """Should handle large input magnitudes without NaN."""
+        d = make_test_data(D=128, N=32)
+        d["Q"] *= 100
+        out = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        assert not torch.isnan(out).any(), "NaN in output with large Q"
+        assert not torch.isinf(out).any(), "Inf in output with large Q"
+
+    @pytest.mark.parametrize("D", [128, 256, 512])
+    def test_head_dimensions(self, D):
+        d = make_test_data(D=D, N=32)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_vec = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        diff = (out_ref - out_vec).abs().max().item()
+        assert diff < 1e-5, f"D={D}: {diff}"
+
+
+class TestNumericalStability:
+    def test_uniform_scores(self):
+        """When all K are identical, attention should be uniform → output = mean(V)."""
+        torch.manual_seed(0)
+        num_heads, num_kv_heads, D, N = 2, 1, 128, 16
+        Q = torch.randn(num_heads, D)
+        # All K identical
+        k_row = torch.randn(1, 1, D).expand(num_kv_heads, N, D).contiguous()
+        V = torch.randn(num_kv_heads, N, D)
+        scale = 1.0 / math.sqrt(D)
+
+        k_packed, k_scales, k_biases = quantize_int4(k_row)
+        v_packed, v_scales, v_biases = quantize_int4(V)
+
+        out = sdpa_int4_fused_vectorized(
+            Q, k_packed, k_scales, k_biases,
+            v_packed, v_scales, v_biases,
+            scale, num_heads // num_kv_heads,
+        )
+
+        V_deq = dequantize_int4(v_packed, v_scales, v_biases)
+        expected = V_deq[0].mean(dim=0)  # uniform attention = mean
+
+        for h in range(num_heads):
+            diff = (out[h] - expected).abs().max().item()
+            assert diff < 0.05, f"Uniform K, head {h}: diff={diff}"
+
+    def test_output_normalized(self):
+        """Output should be a convex combination of V rows."""
+        d = make_test_data(D=128, N=32)
+        out = sdpa_int4_fused_vectorized(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        V_deq = dequantize_int4(d["v_packed"], d["v_scales"], d["v_biases"])
+        # Output should be bounded by min/max of V values per KV head
+        for h in range(out.shape[0]):
+            kv_h = h // d["gqa_factor"]
+            v_min = V_deq[kv_h].min(dim=0).values
+            v_max = V_deq[kv_h].max(dim=0).values
+            assert (out[h] >= v_min - 1e-4).all(), "Output below V range"
+            assert (out[h] <= v_max + 1e-4).all(), "Output above V range"
+
+
+# --- Metal kernel tests (requires MPS + compiled kernel) ---
+
+def _load_metal_ext():
+    """Try loading the compiled Metal kernel extension."""
+    try:
+        if not torch.backends.mps.is_available():
+            return None
+        from torch.utils.cpp_extension import load
+        from pathlib import Path
+        root = Path(__file__).parent.parent
+        build_dir = root / "build"
+        if not (build_dir / "sdpa_int4_bridge.mm").exists():
+            return None
+        return load(
+            name="sdpa_int4_ext",
+            sources=[str(build_dir / "sdpa_int4_bridge.mm"), str(build_dir / "binding.mm")],
+            extra_include_paths=[str(root / "torch-ext"), str(build_dir)],
+            extra_cflags=["-std=c++17"],
+            extra_ldflags=["-framework", "Metal", "-framework", "Foundation",
+                           "-framework", "MetalPerformanceShaders"],
+            is_python_module=True,
+        )
+    except Exception:
+        return None
+
+
+_metal_ext = _load_metal_ext()
+requires_metal = pytest.mark.skipif(_metal_ext is None, reason="Metal kernel not compiled")
+
+
+def _run_metal(ext, d, sliding_window=0):
+    """Run Metal kernel with test data dict."""
+    Q_m = d["Q"].to("mps")
+    kp = d["k_packed"].to("mps")
+    ks = d["k_scales"].to("mps")
+    kb = d["k_biases"].to("mps")
+    vp = d["v_packed"].to("mps")
+    vs = d["v_scales"].to("mps")
+    vb = d["v_biases"].to("mps")
+    N = d["k_packed"].shape[1]
+    return ext.sdpa_int4(Q_m, kp, ks, kb, vp, vs, vb,
+                         d["gqa_factor"], N, d["scale"], sliding_window).cpu()
+
+
+class TestMetalKernel:
+    @requires_metal
+    @pytest.mark.parametrize("D", [128, 256, 512])
+    def test_metal_vs_reference(self, D):
+        d = make_test_data(D=D, N=128)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_metal = _run_metal(_metal_ext, d)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Metal vs ref D={D}: {diff}"
+
+    @requires_metal
+    @pytest.mark.parametrize("N", [1, 32, 512, 2048, 8192])
+    def test_metal_sequence_lengths(self, N):
+        d = make_test_data(D=256, N=N)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_metal = _run_metal(_metal_ext, d)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Metal vs ref N={N}: {diff}"
+
+    @requires_metal
+    def test_metal_sliding_window(self):
+        d = make_test_data(D=256, N=256)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=64,
+        )
+        out_metal = _run_metal(_metal_ext, d, sliding_window=64)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Metal sliding window: {diff}"
+
+    @requires_metal
+    @pytest.mark.parametrize("gqa_factor", [1, 2, 4, 8])
+    def test_metal_gqa(self, gqa_factor):
+        num_kv_heads = 2
+        num_heads = num_kv_heads * gqa_factor
+        d = make_test_data(num_heads=num_heads, num_kv_heads=num_kv_heads, D=256, N=128)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_metal = _run_metal(_metal_ext, d)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Metal GQA factor {gqa_factor}: {diff}"
+
+    @requires_metal
+    def test_metal_no_nan_inf(self):
+        d = make_test_data(D=256, N=512)
+        d["Q"] *= 100  # Large values
+        out = _run_metal(_metal_ext, d)
+        assert not torch.isnan(out).any(), "NaN in Metal output"
+        assert not torch.isinf(out).any(), "Inf in Metal output"
+
+
+    @requires_metal
+    @pytest.mark.parametrize("batch", [2, 4, 8])
+    def test_metal_batched_decode(self, batch):
+        """Batched decode: flatten Q as (batch*num_heads, D) for speculative decoding."""
+        d = make_test_data(num_heads=8, num_kv_heads=4, D=256, N=256)
+        Q_batch = torch.randn(batch, 8, 256)
+        ref = torch.stack([
+            sdpa_int4_reference(
+                Q_batch[b], d["k_packed"], d["k_scales"], d["k_biases"],
+                d["v_packed"], d["v_scales"], d["v_biases"],
+                d["scale"], d["gqa_factor"],
+            )
+            for b in range(batch)
+        ])
+        Q_flat = Q_batch.reshape(batch * 8, 256).to("mps")
+        kp = d["k_packed"].to("mps"); ks = d["k_scales"].to("mps"); kb = d["k_biases"].to("mps")
+        vp = d["v_packed"].to("mps"); vs = d["v_scales"].to("mps"); vb = d["v_biases"].to("mps")
+        out = _metal_ext.sdpa_int4(Q_flat, kp, ks, kb, vp, vs, vb,
+                                    d["gqa_factor"], 256, d["scale"], 0)
+        out = out.cpu().reshape(batch, 8, 256)
+        diff = (ref - out).abs().max().item()
+        assert diff < 1e-3, f"Batched decode batch={batch}: {diff}"
+
+
+class TestMetalArchitectures:
+    """Validate kernel against real model architectures."""
+
+    @requires_metal
+    def test_llama31_8b(self):
+        """Llama 3.1 8B: 32 heads, 8 KV heads, D=128, GQA=4."""
+        d = make_test_data(num_heads=32, num_kv_heads=8, D=128, N=512)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_metal = _run_metal(_metal_ext, d)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Llama 3.1 8B: {diff}"
+
+    @requires_metal
+    def test_gemma4_sliding(self):
+        """Gemma 4 31B sliding layer: 32 heads, 16 KV heads, D=256, sw=1024."""
+        d = make_test_data(num_heads=32, num_kv_heads=16, D=256, N=2048)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"], sliding_window=1024,
+        )
+        out_metal = _run_metal(_metal_ext, d, sliding_window=1024)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Gemma 4 sliding: {diff}"
+
+    @requires_metal
+    def test_gemma4_full(self):
+        """Gemma 4 31B full attention layer: 32 heads, 16 KV heads, D=512."""
+        d = make_test_data(num_heads=32, num_kv_heads=16, D=512, N=1024)
+        out_ref = sdpa_int4_reference(
+            d["Q"], d["k_packed"], d["k_scales"], d["k_biases"],
+            d["v_packed"], d["v_scales"], d["v_biases"],
+            d["scale"], d["gqa_factor"],
+        )
+        out_metal = _run_metal(_metal_ext, d)
+        diff = (out_ref - out_metal).abs().max().item()
+        assert diff < 1e-3, f"Gemma 4 full: {diff}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short", "-x"])

--- a/metal-int4-sdpa/torch-ext/sdpa_int4/__init__.py
+++ b/metal-int4-sdpa/torch-ext/sdpa_int4/__init__.py
@@ -1,0 +1,43 @@
+import torch
+from ._ops import ops
+
+
+def sdpa_int4(
+    queries: torch.Tensor,
+    k_quant: torch.Tensor,
+    k_scales: torch.Tensor,
+    k_biases: torch.Tensor,
+    v_quant: torch.Tensor,
+    v_scales: torch.Tensor,
+    v_biases: torch.Tensor,
+    gqa_factor: int,
+    N: int,
+    scale: float,
+    sliding_window: int = 0,
+) -> torch.Tensor:
+    """Fused int4 SDPA for Apple Silicon.
+
+    Computes softmax(Q @ dequant(K_int4)^T * scale) @ dequant(V_int4)
+    in a single Metal kernel dispatch with online softmax.
+
+    Args:
+        queries: (num_heads, D) float32 — single-token decode query
+        k_quant: (num_kv_heads, N, D//8) uint32 — packed int4 keys
+        k_scales: (num_kv_heads, N, D//64) float32 — per-group scale
+        k_biases: (num_kv_heads, N, D//64) float32 — per-group bias
+        v_quant: (num_kv_heads, N, D//8) uint32 — packed int4 values
+        v_scales: (num_kv_heads, N, D//64) float32
+        v_biases: (num_kv_heads, N, D//64) float32
+        gqa_factor: num_heads // num_kv_heads
+        N: sequence length
+        scale: attention scale (typically 1/sqrt(D))
+        sliding_window: if > 0, attend only to last `sliding_window` tokens
+
+    Returns:
+        (num_heads, D) float32 — attention output
+    """
+    return ops.sdpa_int4(
+        queries, k_quant, k_scales, k_biases,
+        v_quant, v_scales, v_biases,
+        gqa_factor, N, scale, sliding_window,
+    )

--- a/metal-int4-sdpa/torch-ext/torch_binding.cpp
+++ b/metal-int4-sdpa/torch-ext/torch_binding.cpp
@@ -1,0 +1,24 @@
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+    ops.def(
+        "sdpa_int4("
+        "Tensor queries, "
+        "Tensor k_quant, "
+        "Tensor k_scales, "
+        "Tensor k_biases, "
+        "Tensor v_quant, "
+        "Tensor v_scales, "
+        "Tensor v_biases, "
+        "int gqa_factor, "
+        "int N, "
+        "float scale, "
+        "int sliding_window"
+        ") -> Tensor");
+#if defined(METAL_KERNEL)
+    ops.impl("sdpa_int4", torch::kMPS, &sdpa_int4);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/metal-int4-sdpa/torch-ext/torch_binding.h
+++ b/metal-int4-sdpa/torch-ext/torch_binding.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <torch/torch.h>
+
+torch::Tensor sdpa_int4(
+    torch::Tensor queries,
+    torch::Tensor k_quant,
+    torch::Tensor k_scales,
+    torch::Tensor k_biases,
+    torch::Tensor v_quant,
+    torch::Tensor v_scales,
+    torch::Tensor v_biases,
+    int64_t gqa_factor,
+    int64_t N,
+    double scale,
+    int64_t sliding_window);


### PR DESCRIPTION
## Summary

Fused int4 SDPA Metal kernel for Apple Silicon (M1/M2/M3/M4). Computes `softmax(Q @ dequant(K_int4)^T * scale) @ dequant(V_int4)` in a single kernel dispatch with online softmax — never materializing full K/V or score matrices.

## Performance (M1 Max)

| N | Metal int4 | MPS Deq+SDPA | Speedup | KV Compression |
|---|---|---|---|---|
| 512 | 0.31ms | 0.74ms | **2.4x** | 6.4x |
| 2048 | 0.44ms | 1.20ms | **2.7x** | 6.4x |
| 4096 | 0.47ms | 1.56ms | **3.4x** | 6.4x |
| 8192 | 0.68ms | 2.05ms | **3.0x** | 6.4x |

- **51x** faster than CPU reference at N=8192
- **6.4x** KV cache memory compression (int4 vs FP32)
- **170 tok/s** SDPA ceiling with GPU pipelining (60-layer Gemma 4 decode)

## Features

- **qdot pattern** — eliminates per-nibble shift operations in K dot product
- **Online softmax** — O(1) memory in sequence length
- **Adaptive split-K** — doubles GPU utilization for models with few attention heads
- **Sliding window fast-skip** — jumps directly to valid tokens for sliding attention
- **GQA support** — grouped-query attention with arbitrary factors
- **Batched decode** — speculative decoding via flattened Q
- **D = 128, 256, 512** — common head dimensions

## Validated Models

- **Gemma 4 31B** — 12/12 end-to-end eval tests pass (factual recall, instruction following, coherence, perplexity)
- **Llama 3.1 8B architecture** — 32 heads, 8 KV heads, D=128, GQA=4
- 40 unit tests covering all dimensions, sequence lengths, GQA factors, sliding window, batched decode

## Origin

Based on TurboQuant's `sdpa_int4_vector` kernel ([arxiv.org/abs/2504.19874](https://arxiv.org/abs/2504.19874), ICLR 2026).

## Test plan

- [x] 40 unit tests pass (reference + Metal kernel + architecture-specific)
- [x] 43 stress tests pass (extreme N, GQA up to 32, sliding window edge cases)
- [x] Gemma 4 31B end-to-end eval (12/12)
- [x] Nix build succeeds (3 Metal variants: torch 2.8/2.9/2.10)
- [x] Mixed MPS ops safety test (no crashes when interleaved with PyTorch operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)