### PR TITLE
scripts: fix kernel existence validation in bot and kernel name display in freshness report

### DIFF
--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -643,7 +643,26 @@ def main():
     dispatches = []
     failed = []
 
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
     for kernel_name in kernels:
+        kernel_path = os.path.join(repo_root, kernel_name)
+        if not os.path.isdir(kernel_path) or not os.path.isfile(os.path.join(kernel_path, "build.toml")):
+            try_send_issue_comment(
+                api_base,
+                token,
+                issue_number,
+                format_result_comment(
+                    command_summary,
+                    mode_text,
+                    target_branch,
+                    pr_head_sha,
+                    failure_message=f"Kernel `{kernel_name}` was not found in this repository. Check the spelling and try again.",
+                ),
+                comment_id=status_comment_id,
+            )
+            return 0
+
         dispatch_key = make_dispatch_key(issue_number, kernel_name)
         dispatch_body = {
             "ref": default_branch,

--- a/scripts/check_kernel_freshness.py
+++ b/scripts/check_kernel_freshness.py
@@ -254,7 +254,7 @@ def _format_freshness_report(results: list[dict], skipped_kernels: list[str]) ->
 
     items = []
     for result in sorted_results:
-        items.append(f"• {result['source_url']}: upstream is {result['days_behind']} days newer")
+        items.append(f"• `{result['kernel_dir']}` ({result['source_url']}): upstream is {result['days_behind']} days newer")
 
     report = f"{heading}\n\n" + "\n".join(items)
 


### PR DESCRIPTION
Two silent bugs in the operations tooling are fixed by this PR.

**1. `pr_comment_kernel_bot.py` — validate kernel exists before dispatching**

When a `/kernel-bot build <kernel>` command is issued with a typo or
a non-existent kernel name, the bot previously dispatched a workflow
that would fail deep inside the Nix build step with no clear signal
to the requester. The bot now checks that the named kernel directory
exists and contains a `build.toml` before dispatching, and posts an
actionable error comment immediately if not.

**2. `check_kernel_freshness.py` — show kernel directory name in Slack report**

The freshness report was formatting stale entries using `source_url`
instead of `kernel_dir`. Since multiple kernels share the same upstream
(e.g. `flash-attn2`, `flash-attn3`, `flash-attn4`, `layer-norm`,
`rotary`, and `vllm-flash-attn3` all point to the same flash-attention
repo), the Slack message would repeat the same URL multiple times with
no indication of which local directory needs updating. Each line now
shows the kernel directory name alongside the upstream URL.