### PR TITLE
Adding Mamba SSM Arm SVE Kernel

### DIFF
--- a/mamba-ssm-armsve-kernel/build.toml
+++ b/mamba-ssm-armsve-kernel/build.toml
@@ -1,0 +1,29 @@
+[general]
+name = "mamba_selective_scan"
+backends = ["cpu"]
+
+[torch]
+src = [
+    "torch-ext/torch_binding.cpp",
+    "torch-ext/torch_binding.h",
+]
+
+[kernel.mamba_selective_scan]
+backend = "cpu"
+depends = ["torch"]
+include = ["mamba_selective_scan_cpu"]
+src = [
+    "mamba_selective_scan_cpu/mamba_selective_scan.cpp",
+    "mamba_selective_scan_cpu/mamba_selective_scan.hpp",
+    "mamba_selective_scan_cpu/cpu_feature.hpp",
+]
+
+[kernel.mamba_selective_scan_sve]
+backend = "cpu"
+cxx-flags = ["-march=armv8-a+sve", "-O3", "-ffast-math"]
+depends = ["torch"]
+include = ["mamba_selective_scan_cpu"]
+src = [
+    "mamba_selective_scan_cpu/mamba_selective_scan_sve.cpp",
+    "mamba_selective_scan_cpu/mamba_selective_scan_sve.hpp",
+]

--- a/mamba-ssm-armsve-kernel/flake.lock
+++ b/mamba-ssm-armsve-kernel/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "kernel-builder": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1769448133,
+        "narHash": "sha256-XOp8+8u7fmXn1f63mJ40dPj/OHPMKtL9o4q7y0CUZFU=",
+        "owner": "huggingface",
+        "repo": "kernel-builder",
+        "rev": "078351df6e0fddb4a1a41ba3ffb8b804f58c4c6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "huggingface",
+        "repo": "kernel-builder",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766341660,
+        "narHash": "sha256-4yG6vx7Dddk9/zh45Y2KM82OaRD4jO3HA9r98ORzysA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "26861f5606e3e4d1400771b513cc63e5f70151a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "kernel-builder": "kernel-builder"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/mamba-ssm-armsve-kernel/flake.nix
+++ b/mamba-ssm-armsve-kernel/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for ReLU kernel";
+
+  inputs = {
+    kernel-builder.url = "github:huggingface/kernel-builder";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/cpu_feature.hpp
+++ b/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/cpu_feature.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+#if defined(__linux__) || defined(__ANDROID__)
+  #include <sys/auxv.h>
+  #include <asm/hwcap.h>
+#endif
+
+namespace cpuinfo {
+
+class CPUFeaturesARM {
+public:
+    static bool hasSVE() {
+        static bool supported = checkSVE();
+        return supported;
+    }
+
+private:
+    static bool checkSVE() {
+#if (defined(__aarch64__) || defined(_M_ARM64))
+  #if defined(__linux__) || defined(__ANDROID__)
+        // Best: auxv HWCAP bit (kernel-validated for user-space)
+        const unsigned long hwcap = getauxval(AT_HWCAP);
+        #ifdef HWCAP_SVE
+        if (hwcap & HWCAP_SVE) return true;
+        #endif
+        return cpuinfoHasFlag("sve");
+  #else
+        return false;
+  #endif
+#else
+        return false;
+#endif
+    }
+
+    static bool cpuinfoHasFlag(const char* flag) {
+#if defined(__linux__) || defined(__ANDROID__)
+        std::ifstream f("/proc/cpuinfo");
+        if (!f) return false;
+
+        std::string line;
+        while (std::getline(f, line)) {
+            // Typical key is "Features" on ARM. We also accept "flags".
+            if ((line.find("Features") != std::string::npos ||
+                 line.find("flags")    != std::string::npos ||
+                 line.find("Flags")    != std::string::npos) &&
+                line.find(flag) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+#else
+        (void)flag;
+        return false;
+#endif
+    }
+};
+
+} // namespace rmsnorm_cpu

--- a/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan.cpp
+++ b/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan.cpp
@@ -1,0 +1,115 @@
+#include "mamba_selective_scan.hpp"
+#include "mamba_selective_scan_sve.hpp"
+
+#include "cpu_feature.hpp"
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+namespace mamba {
+
+static inline void mamba_selective_scan_kernel_cpu(
+    float* A,
+    float* B,
+    float* C,
+    float* hidden_states,
+    float* discrete_time_step,
+    float* ssm_state,
+    float* scan_output,
+    int64_t B_size,
+    int64_t D_size,
+    int64_t L_size,
+    int64_t N_size
+) {
+    for (int64_t i = 0; i < B_size; i++) {
+        for (int64_t j = 0; j < D_size; j++) {
+            for (int64_t l = 0; l < L_size; l++) {
+                const int64_t dts_offset = i * D_size * L_size + j * L_size + l;
+
+                const float dts = discrete_time_step[dts_offset];
+                const float hs  = hidden_states[dts_offset];
+
+                float r1 = 0.0f;
+
+                const int64_t B_base        = i * L_size * N_size + l * N_size;
+                const int64_t ssmstate_base = i * D_size * N_size + j * N_size;
+                const int64_t A_base        = j * N_size;
+
+                for (int64_t k = 0; k < N_size; k++) {
+                    const float a = A[A_base + k];
+                    const float b = B[B_base + k];
+                    const float c = C[B_base + k];
+
+                    // discrete_A = exp(dts * a)
+                    const float discA = std::exp(dts * a);
+
+                    // deltaB_u = hs * (dts * b)
+                    const float deltaBu = hs * (dts * b);
+
+                    // ssm = ssm * discA + deltaBu
+                    float& s = ssm_state[ssmstate_base + k];
+                    s = s * discA + deltaBu;
+
+                    // r1 += s * c
+                    r1 += s * c;
+                }
+
+                scan_output[dts_offset] += r1;
+            }
+        }
+    }
+}
+
+void mamba_selective_scan(
+    torch::Tensor& A,
+    torch::Tensor& B,
+    torch::Tensor& C,
+    torch::Tensor& hidden_states,
+    torch::Tensor& discrete_time_step,
+    torch::Tensor& ssm_state,
+    torch::Tensor& scan_output,
+    int64_t B_size,
+    int64_t D_size,
+    int64_t L_size,
+    int64_t N_size
+) {
+
+#if (defined(__aarch64__) || defined(_M_ARM64))
+    if (cpuinfo::CPUFeaturesARM::hasSVE()) {
+    
+        mamba_selective_scan_sve(
+            A, B, C, hidden_states, discrete_time_step, ssm_state, scan_output,
+            B_size, D_size, L_size, N_size
+        );
+        return;
+    }
+#endif
+    mamba_selective_scan_kernel_cpu(
+        A.data_ptr<float>(),
+        B.data_ptr<float>(),
+        C.data_ptr<float>(),
+        hidden_states.data_ptr<float>(),
+        discrete_time_step.data_ptr<float>(),
+        ssm_state.data_ptr<float>(),
+        scan_output.data_ptr<float>(),
+        B_size, D_size, L_size, N_size
+    );
+}
+
+} // namespace mamba
+
+void mamba_selective_scan(torch::Tensor &A,
+                          torch::Tensor &B,
+                          torch::Tensor &C,
+                          torch::Tensor &hidden_states,
+                          torch::Tensor &discrete_time_step,
+                          torch::Tensor &ssm_state,
+                          torch::Tensor &scan_output,
+                          int64_t B_size,
+                          int64_t D_size,
+                          int64_t L_size,
+                          int64_t N_size) {
+    mamba::mamba_selective_scan(
+        A, B, C, hidden_states, discrete_time_step, ssm_state, scan_output,
+        B_size, D_size, L_size, N_size
+    );
+}

--- a/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan.hpp
+++ b/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <torch/torch.h>
+
+namespace mamba {
+
+    void mamba_selective_scan(
+        torch::Tensor& A,
+        torch::Tensor& B,
+        torch::Tensor& C,
+        torch::Tensor& hidden_states,
+        torch::Tensor& discrete_time_step,
+        torch::Tensor& ssm_state,
+        torch::Tensor& scan_output,
+        int64_t B_size,
+        int64_t D_size,
+        int64_t L_size,
+        int64_t N_size
+    );
+
+}

--- a/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan_sve.cpp
+++ b/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan_sve.cpp
@@ -1,0 +1,143 @@
+/*******************************************************************************
+* Copyright 2025 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "mamba_selective_scan_sve.hpp"
+
+#if !(defined(__aarch64__) || defined(_M_ARM64))
+#error "mamba_selective_scan_sve.cpp should only be built for AArch64/ARM64"
+#endif
+
+#include <arm_sve.h>
+#include <omp.h>
+#include <thread>
+#include <torch/torch.h>
+
+namespace mamba {
+    size_t get_sve_vector_length() {
+    return svcntw();
+}
+
+/* 
+Below function was borrowed from the GitHub repository: 
+https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/common.hpp 
+*/
+svfloat32_t exp_ps_sve(svbool_t& pg, svfloat32_t& src) {
+    // Constants
+    const auto log2_e = svdup_n_f32(1.4426950409f);
+    const auto ln2 = svdup_n_f32(0.6931473921f);
+    const auto half_ln2_sq = svdup_n_f32(0.2413862043f);
+    const auto not_mask17 = svdup_n_u32(~((1u << 17) - 1));
+    const auto one = svdup_n_f32(1.0f);
+    const svfloat32_t inactive1 = svdup_n_f32(0.0f);
+    const svint32_t inactive2 = svdup_n_s32(0);
+
+    // Algorithm starts here
+    svfloat32_t t0 = svmul_f32_m(pg, src, log2_e);                      // y = x * log2(e)
+    svfloat32_t t1 = svrintm_f32_m(inactive1, pg, t0);                  // rount to int (float)
+    svint32_t t2 = svcvt_s32_f32_m(inactive2, pg, t1);                  // n
+
+    t1 = svsub_f32_m(pg, t0, t1);                                       // a = y - floor(y)
+    t1 = svadd_f32_m(pg, t1, one);                                      // b = a + 1
+
+    svuint32_t t3 = svlsr_n_u32_m(pg, svreinterpret_u32_f32(t1), 17);   // v = b >> 17 (u32)
+    svfloat32_t t4 = svexpa_f32(t3);                                    // c = fexpa(v)
+    t4 = svscale_f32_m(pg, t4, t2);                                     // fexpa(v) * 2^(n)
+
+    // and_(t2.d, t1.d, not_mask17.d)
+    svfloat32_t t5 = svreinterpret_f32_u32(svand_u32_m(pg, svreinterpret_u32_f32(t1), not_mask17));
+    t5 = svsub_f32_m(pg, t1, t5);                                       // z
+    t0 = svmla_f32_m(pg, ln2, t5, half_ln2_sq);                         // ln2 + half_ln2_sq * z
+    t0 = svmla_f32_m(pg, one, t5, t0);                                  // 1 + (ln2 * z) + (half_ln2_sq * z * z)
+    t0 = svmul_f32_m(pg, t0, t4);                                       // Final result
+
+    return t0;
+}
+
+void mamba_selective_scan_sve_kernel(float* A, 
+                          float* B, 
+                          float* C, 
+                          float* hidden_states,
+                          float* discrete_time_step, 
+                          float* ssm_state, 
+                          float* scan_output, 
+                          int64_t B_size, 
+                          int64_t D_size, 
+                          int64_t L_size, 
+                          int64_t N_size) 
+{   
+    // std::cout << "hit mamba_selective_scan_kernel" << std::endl;
+    unsigned int total_cores = std::thread::hardware_concurrency();
+    #pragma omp parallel for schedule(dynamic, int(B_size * D_size / total_cores)) collapse(2)
+    for (int64_t i = 0; i < B_size; i++) {
+        for (int64_t j = 0; j < D_size; j++) {
+            for (int64_t l = 0; l < L_size; l++) {
+                int64_t dts_offset = i * D_size * L_size + j * L_size + l;
+                svfloat32_t vdts1 = svdup_n_f32(discrete_time_step[dts_offset]);            // load and broadcast value, d_t_s dims: [B_size, D_size, L_size]
+                svfloat32_t vhs1 = svdup_n_f32(hidden_states[dts_offset]);                  // load and broadcast value, h_s dims: [B_size, D_size, L_size]
+                svfloat32_t r1_vector = svdup_n_f32(0.0f);
+                float r1 = 0.0;
+
+                for (int64_t k = 0; k < N_size; k += svcntw()) {
+                    svbool_t pg = svwhilelt_b32(k, N_size);
+
+                    int64_t B_offset = i * L_size * N_size + l * N_size + k;
+                    int64_t ssmstate_offset = i * D_size * N_size + j * N_size + k;
+
+                    svfloat32_t vA1 = svld1_f32(pg, &A[j * N_size + k]);                    // load A values, A dims: [D_size, N_size]
+                    svfloat32_t vB1 = svld1_f32(pg, &B[B_offset]);                          // load B values, B dims: [B_size, L_size, N_size]
+                    svfloat32_t vC1 = svld1_f32(pg, &C[B_offset]);                          // load C values, C dims: [B_size, L_size, N_size]
+                    svfloat32_t vssm1 = svld1_f32(pg, &ssm_state[ssmstate_offset]);
+                    svfloat32_t t1 = svmul_f32_m(pg, vdts1, vA1);                           // perform vds1*vA1 & vds1*vA2 which forms discrete_A
+                    t1 = exp_ps_sve(pg, t1);
+                    svfloat32_t t3 = svmul_f32_m(pg, vdts1, vB1);                           // t3 & t4 contains first 8 chunks and last 8 chunks of discrete_B
+                    svfloat32_t t5 = svmul_f32_m(pg, vhs1, t3);                             // perform vhs1*t3 and vhs1*t4 which forms deltaB_u
+
+                    // Sequential scan algorithm starts here
+                    vssm1 = svmad_f32_m(pg, vssm1, t1, t5);                                 // perform discrete_A*ssm_state + deltaB_u in two chunks 
+                    r1_vector = svmla_f32_m(pg, r1_vector, vssm1, vC1);                     // r1_vector += vssm1*vC1
+                    svst1_f32(pg, &ssm_state[ssmstate_offset], vssm1);
+                }
+                scan_output[dts_offset] += svaddv(svptrue_b32(), r1_vector);                // scan_output dims: [B_size, D_size, L_size]
+            }
+        }
+    }
+}
+
+void mamba_selective_scan_sve(
+    torch::Tensor& A,
+    torch::Tensor& B,
+    torch::Tensor& C,
+    torch::Tensor& hidden_states,
+    torch::Tensor& discrete_time_step,
+    torch::Tensor& ssm_state,
+    torch::Tensor& scan_output,
+    int64_t B_size,
+    int64_t D_size,
+    int64_t L_size,
+    int64_t N_size) 
+{
+    mamba_selective_scan_sve_kernel(
+        A.data_ptr<float>(),
+        B.data_ptr<float>(),
+        C.data_ptr<float>(),
+        hidden_states.data_ptr<float>(),
+        discrete_time_step.data_ptr<float>(),
+        ssm_state.data_ptr<float>(),
+        scan_output.data_ptr<float>(),
+        B_size, D_size, L_size, N_size
+    );
+}
+}

--- a/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan_sve.hpp
+++ b/mamba-ssm-armsve-kernel/mamba_selective_scan_cpu/mamba_selective_scan_sve.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <torch/torch.h>
+
+namespace mamba {
+
+    void mamba_selective_scan_sve(
+        torch::Tensor& A,
+        torch::Tensor& B,
+        torch::Tensor& C,
+        torch::Tensor& hidden_states,
+        torch::Tensor& discrete_time_step,
+        torch::Tensor& ssm_state,
+        torch::Tensor& scan_output,
+        int64_t B_size,
+        int64_t D_size,
+        int64_t L_size,
+        int64_t N_size
+    );
+
+} // namespace mamba

--- a/mamba-ssm-armsve-kernel/tests/test_sel_scan_sve.py
+++ b/mamba-ssm-armsve-kernel/tests/test_sel_scan_sve.py
@@ -1,0 +1,86 @@
+from typing import Optional
+import torch
+import mamba_selective_scan
+import time
+
+print(dir(mamba_selective_scan))
+def mamba_selective_scan_ref(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    hidden_states: torch.Tensor,
+    discrete_time_step: torch.Tensor,
+    ssm_state: torch.Tensor,
+):
+    """
+    Reference implementation of mamba_selective_scan with broadcasting.
+    Shapes:
+    A: [D, N]
+    B: [B, L, N]
+    C: [B, L, N]
+    hidden_states: [B, L, D]
+    discrete_time_step: [B, D, L]
+    ssm_state: [B, D, N]
+    """
+    dtype = hidden_states.dtype
+    B_size, L_size, N_size = B.shape
+    D_size = A.shape[0]
+    print(dtype, A.dtype, B.dtype, C.dtype, hidden_states.dtype, discrete_time_step.dtype, ssm_state.dtype)
+    # Clamp to avoid numerical overflow
+    # A = A.clamp(min=-5.0, max=0.0)
+    # discrete_time_step = discrete_time_step.clamp(min=-0.1, max=0.1)
+
+    discrete_A = torch.exp(A[None, :, None, :] * discrete_time_step[:, :, :, None])  # [B, D, L, N]
+    discrete_B = discrete_time_step[:, :, :, None] * B[:, None, :, :].float()        # [B, D, L, N]
+    deltaB_u = discrete_B * hidden_states[:, :, :, None] 
+
+    scan_output_list = []
+    for i in range(L_size):
+        ssm_state = discrete_A[:, :, i, :] * ssm_state + deltaB_u[:, :, i, :]
+        out_i = torch.matmul(ssm_state.to(dtype), C[:, i, :].unsqueeze(-1))  # [B, D, 1]
+        scan_output_list.append(out_i[:, :, 0])
+
+    scan_output = torch.stack(scan_output_list, dim=-1)  # [B, D, L]
+    return scan_output
+
+def test_kernel():
+    # Smaller and safe tensor sizes
+    B_size = 1
+    D_size = 8
+    L_size = 5
+    N_size = 4
+
+    A = -torch.linspace(0.1, 1.0, N_size).expand(D_size, N_size)  # [8, 4]
+    B = torch.randn(B_size, L_size, N_size) * 0.1
+    C = torch.randn(B_size, L_size, N_size) * 0.1
+    
+    hidden_states = torch.randn(B_size, D_size, L_size, dtype=torch.float32).contiguous()*0.1
+    discrete_time_step = torch.randn(B_size, D_size, L_size, dtype=torch.float32) * 0.05
+    ssm_state = torch.randn(B_size, D_size, N_size, dtype=torch.float32).contiguous()*0.1
+    
+    kernel_out = torch.zeros(B_size, D_size, L_size, dtype=torch.float32).contiguous()
+
+    # Reference output
+    start_time = time.perf_counter()
+    ref_out = mamba_selective_scan_ref(A, B, C, hidden_states, discrete_time_step, ssm_state)
+    end_time1 = time.perf_counter()
+    # Call your C++ kernel
+    mamba_selective_scan.mamba_selective_scan(
+        A, B, C, hidden_states, discrete_time_step, ssm_state, kernel_out,
+        B_size, D_size, L_size, N_size
+    )
+    end_time2 = time.perf_counter()
+    print(f"Reference implementation time: {end_time1 - start_time:.6f} seconds")
+    print(f"C++ kernel time: {end_time2 - end_time1:.6f} seconds")
+
+    # Compare outputs
+    err_norm = torch.linalg.norm(ref_out - kernel_out)
+    print("Error norm:", err_norm)
+    if err_norm >= 1e-6:
+        assert err_norm < 1e-6, f"Error too high! norm = {err_norm}"
+    else:
+        print("Test passed!")
+    print ("Speedup over reference: {:.2f}x".format((end_time1 - start_time) / (end_time2 - end_time1)))
+
+if __name__ == "__main__":
+    test_kernel()

--- a/mamba-ssm-armsve-kernel/torch-ext/mamba_selective_scan/__init__.py
+++ b/mamba-ssm-armsve-kernel/torch-ext/mamba_selective_scan/__init__.py
@@ -1,0 +1,6 @@
+from ._ops import ops
+
+def mamba_selective_scan(A, B, C, hidden_states, discrete_time_step, ssm_state, scan_output, B_size, D_size, L_size, N_size):
+    return ops.mamba_selective_scan(A, B, C, hidden_states, discrete_time_step, ssm_state, scan_output, B_size, D_size, L_size, N_size)
+
+__all__ = ["mamba_selective_scan"]

--- a/mamba-ssm-armsve-kernel/torch-ext/torch_binding.cpp
+++ b/mamba-ssm-armsve-kernel/torch-ext/torch_binding.cpp
@@ -1,0 +1,11 @@
+#include <torch/library.h>
+#include "registration.h"
+#include "torch_binding.h"
+
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+    ops.def("mamba_selective_scan(Tensor A, Tensor B, Tensor C, Tensor hidden_states, Tensor discrete_time_step, Tensor ssm_state, Tensor scan_output, int B_size, int D_size, int L_size, int N_size) -> ()");
+    ops.impl("mamba_selective_scan", torch::kCPU, mamba_selective_scan);
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/mamba-ssm-armsve-kernel/torch-ext/torch_binding.h
+++ b/mamba-ssm-armsve-kernel/torch-ext/torch_binding.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <torch/torch.h>
+
+void mamba_selective_scan(torch::Tensor &A,
+                          torch::Tensor &B,
+                          torch::Tensor &C,
+                          torch::Tensor &hidden_states,
+                          torch::Tensor &discrete_time_step,
+                          torch::Tensor &ssm_state,
+                          torch::Tensor &scan_output,
+                          int64_t B_size,
+                          int64_t D_size,
+                          int64_t L_size,
+                          int64_t N_size);


### PR DESCRIPTION
## Summary
With reference to the following PR https://github.com/huggingface/transformers/pull/38185, and as per our knowledge since the kernels raised to this repo are automatically built and uploaded to the hub, we would like to raise this kernel to kernels-community
This kernel was successfully built and tested on G3E, this correction does not have any effect on the accuracy
## Implementation
The new kernel vectorizes the selective scan computation using ARM SVE intrinsics. The implementation is intended to:

- improve throughput on SVE-capable ARM CPUs
- keep numerical behavior aligned with the existing implementation

## Performance Check
We also integrated this kernel to transformers repo(https://github.com/huggingface/transformers) locally, this kernel is **3-4x faster** than the current implementation
**Task 32 input tokens, 1 Generated token**
|Batch Size | SVE | OSS |
|------------|-----|------|
|32| 16.18|53.42|
|64|32.24|96.36|
|128|62.04|219.32|
|256|119.86|407.42|
|512|235.53|843.59|
|1024|466.49|1711.95|

The above table represents the overall generation time **(in seconds)**, this benchmarking was also done on **G3E(64 cores)**
Co-authored by @hrushitfujitsu and @abhijain1204fujitsu