### PR TITLE
relu: do not build Windows kernels using two Python versions

### DIFF
--- a/.github/workflows/build-pr-windows.yaml
+++ b/.github/workflows/build-pr-windows.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        python: [3.11, 3.12]
+        python: [3.12]
         platform: [
             # CUDA platforms
             # { backend: 'cuda', torch_version: '2.9.1', cuda: '12.6.3', wheel: '126' },

--- a/.github/workflows/build-release-windows.yaml
+++ b/.github/workflows/build-release-windows.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        python: [3.11, 3.12]
+        python: [3.12]
         platform: [
             # CUDA platforms
             # { backend: 'cuda', torch_version: '2.9.1', cuda: '12.6.3', wheel: '126' },


### PR DESCRIPTION
Kernels use ABI3, so there is no point in compiling using two different Python versions and it doubles build time.