### PR TITLE
feat: add vouch with known contributors

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,18 @@
+# Vouched contributors for kernels-community
+# One GitHub handle per line, sorted alphabetically.
+# Denounce with a leading hyphen: -username reason
+Abdennacer-Badaoui
+adarshxs
+danieldk
+drbh
+IlyasMoutawwakil
+jiqing-feng
+kaixuanliu
+MekkCyber
+mfuntowicz
+paulinebm
+salmanmkc
+sayakpaul
+shawntan
+sywangyi
+YangKai0616

--- a/.github/workflows/vouch-check-pr.yaml
+++ b/.github/workflows/vouch-check-pr.yaml
@@ -1,0 +1,20 @@
+name: "Check PR author is vouched"
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check PR author
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds [vouch](https://github.com/mitchellh/vouch) to limit unsolicited PRs. being that this repo is intended to be maintained by the HF team and a small set of external collaborators - vouch will auto close PR's unless a user is in the trustdown file.

External contributors are encouraged to open issues for any changes they'd like upstreamed.

**note the initial VOUCHED.td file contains users who've previously contributed to the project