### PR TITLE
feat: improve kernel bot release flow

### DIFF
--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -670,6 +670,7 @@ def main():
                     "ref": default_branch,
                     "inputs": {
                         "kernel_name": kernel_name,
+                        "dispatch_key": dispatch_key,
                     },
                 }
                 try:

--- a/.github/workflows/build-release-mac.yaml
+++ b/.github/workflows/build-release-mac.yaml
@@ -1,4 +1,6 @@
 name: Build Release (macOS)
+run-name: >-
+  Build Release (macOS) / ${{ inputs.kernel_name || '' }} / request=${{ inputs.dispatch_key || '' }}
 on:
   pull_request:
     types: [closed]
@@ -7,6 +9,10 @@ on:
       kernel_name:
         description: "Kernel directory name to build"
         required: true
+        type: string
+      dispatch_key:
+        description: "Unique key for matching this run back to a bot dispatch"
+        required: false
         type: string
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-release-windows.yaml
+++ b/.github/workflows/build-release-windows.yaml
@@ -1,4 +1,6 @@
 name: Build Release (Windows)
+run-name: >-
+  Build Release (Windows) / ${{ inputs.kernel_name || '' }} / request=${{ inputs.dispatch_key || '' }}
 on:
   pull_request:
     types: [closed]
@@ -9,6 +11,10 @@ on:
       kernel_name:
         description: "Kernel directory name to build"
         required: true
+        type: string
+      dispatch_key:
+        description: "Unique key for matching this run back to a bot dispatch"
+        required: false
         type: string
 
 concurrency:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,4 +1,6 @@
 name: Build Release
+run-name: >-
+  Build Release / ${{ inputs.kernel_name || '' }} / request=${{ inputs.dispatch_key || '' }}
 on:
   pull_request:
     types: [closed]
@@ -7,6 +9,10 @@ on:
       kernel_name:
         description: "Kernel directory name to build"
         required: true
+        type: string
+      dispatch_key:
+        description: "Unique key for matching this run back to a bot dispatch"
+        required: false
         type: string
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/activation/flake.lock
+++ b/activation/flake.lock
@@ -41,16 +41,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777306635,
+        "lastModified": 1777309065,
         "narHash": "sha256-AOrbnyvPCRi9I6wYhT/F4+LMCCUWkJEqbzQQW500u5c=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "d03bfa6413c792d93f64093fc675d8f4d34c8340",
+        "rev": "013b0e1326df42215dc5abe1e9095445b1075d09",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
-        "ref": "kernels-use-kernels-data",
         "repo": "kernels",
         "type": "github"
       }

--- a/activation/flake.nix
+++ b/activation/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for activation kernels";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernels/kernels-use-kernels-data";
+    kernel-builder.url = "github:huggingface/kernels";
   };
 
   outputs =

--- a/relu/flake.lock
+++ b/relu/flake.lock
@@ -41,16 +41,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777306635,
+        "lastModified": 1777309065,
         "narHash": "sha256-AOrbnyvPCRi9I6wYhT/F4+LMCCUWkJEqbzQQW500u5c=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "d03bfa6413c792d93f64093fc675d8f4d34c8340",
+        "rev": "013b0e1326df42215dc5abe1e9095445b1075d09",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
-        "ref": "kernels-use-kernels-data",
         "repo": "kernels",
         "type": "github"
       }

--- a/relu/flake.nix
+++ b/relu/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for ReLU kernel";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernels/kernels-use-kernels-data";
+    kernel-builder.url = "github:huggingface/kernels";
   };
 
   outputs =


### PR DESCRIPTION
This PR is a follow up on https://github.com/huggingface/kernels-community/pull/673 and does two things. 
- add a dispatch_key to fix the bug with the comment not showing workflow urls
- remove the `kernels-use-kernels-data` branch from relu and activation as the related PR was merged in kernels and bumps flake