### PR TITLE
[CI] Fix backend check for ROCm targets.

### DIFF
--- a/gpt-oss-triton-kernels/torch-ext/gpt_oss_triton_kernels/target_info.py
+++ b/gpt-oss-triton-kernels/torch-ext/gpt_oss_triton_kernels/target_info.py
@@ -92,7 +92,7 @@ def has_native_mxfp():
 
 
 def num_sms():
-    if is_cuda():
+    if is_cuda() or is_hip():
         return torch.cuda.get_device_properties(0).multi_processor_count
     if is_xpu():
         return torch.xpu.get_device_properties(0).max_compute_units


### PR DESCRIPTION
Nearly duplicate of https://huggingface.co/kernels-community/gpt-oss-triton-kernels/discussions/2

This fix is necessary to run gpt-oss model on AMD hardware. When running this model at AMD GPUs, `is_cuda()` will return `False`, and `is_hip()` is never called. This causes function to return None, which causes exceptions on caller's side. Pytorch uses cuda submodule when is built for HIP backend.