### PR TITLE
bitsandbytes-mps: build Metal/CUDA for Torch 2.12

### DIFF
--- a/bitsandbytes-mps/flake.lock
+++ b/bitsandbytes-mps/flake.lock
@@ -41,26 +41,27 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777309065,
-        "narHash": "sha256-AOrbnyvPCRi9I6wYhT/F4+LMCCUWkJEqbzQQW500u5c=",
+        "lastModified": 1777630673,
+        "narHash": "sha256-6d8ne6nImfvf2kXmn5ibBVqev6S6Ig9EHSa/WMtTFwM=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "013b0e1326df42215dc5abe1e9095445b1075d09",
+        "rev": "6b6d9ce26c0ef0dcfbb1101a0e7b325aad6592d0",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
+        "ref": "torch-2.12",
         "repo": "kernels",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774935083,
-        "narHash": "sha256-Mh6bLcYAcENBAZk3RoMPMFCGGMZmfaGMERE4siZOgP4=",
+        "lastModified": 1776927958,
+        "narHash": "sha256-XOzEtft7E0P6TgQViLUOQeGHlEYiQ0+FY24BPEksj6s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f4fd5e1abf9bac8c1d22750c701a7a5e6b524c6",
+        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
         "type": "github"
       },
       "original": {
@@ -83,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774926780,
-        "narHash": "sha256-JMdDYn0F+swYBILlpCeHDbCSyzqkeSGNxZ/Q5J584jM=",
+        "lastModified": 1776914043,
+        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "962a0934d0e32f42d1b5e49186f9595f9b178d2d",
+        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
         "type": "github"
       },
       "original": {

--- a/bitsandbytes-mps/flake.nix
+++ b/bitsandbytes-mps/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for triton-kernels kernels";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernels";
+    kernel-builder.url = "github:huggingface/kernels/torch-2.12";
   };
 
   outputs =


### PR DESCRIPTION
Automated update to target to build Metal/CUDA Torch 2.12 variants.