### PR TITLE
deep-gemm: build Torch 2.12

### DIFF
--- a/deep-gemm/flake.nix
+++ b/deep-gemm/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     self.submodules = true;
-    kernel-builder.url = "github:huggingface/kernels";
+    kernel-builder.url = "github:huggingface/kernels/torch-2.12";
   };
 
   outputs =


### PR DESCRIPTION
Automated update to target to build Torch 2.12 variants (rc7).