### PR TITLE
flash-attn2: make the build concurrency configurable

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Generate build matrix
         if: steps.validate.outputs.skip == 'false'
         id: matrix
+        env:
+          KERNEL: ${{ steps.validate.outputs.kernel }}
         run: |
           KERNEL="${{ steps.validate.outputs.kernel }}"
           X86_BACKENDS=$(cd "$KERNEL" && nix eval .#backendCi --apply builtins.attrNames --json --system x86_64-linux)
@@ -70,8 +72,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            max-jobs = 2
-            cores = 12
+            max-jobs = ${{ matrix.max_jobs }}
+            cores = ${{ matrix.cores }}
             sandbox-fallback = false
       - name: Nix info
         run: nix-shell -p nix-info --run "nix-info -m"

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -63,6 +63,8 @@ jobs:
       - name: Generate build matrix
         if: steps.validate.outputs.skip == 'false'
         id: matrix
+        env:
+          KERNEL: ${{ steps.validate.outputs.kernel }}
         run: |
           KERNEL="${{ steps.validate.outputs.kernel }}"
           X86_BACKENDS=$(cd "$KERNEL" && nix eval .#backendBundle --apply builtins.attrNames --json --system x86_64-linux)
@@ -84,8 +86,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
-            max-jobs = 2
-            cores = 12
+            max-jobs = ${{ matrix.max_jobs }}
+            cores = ${{ matrix.cores }}
             sandbox-fallback = false
       - name: Nix info
         run: nix-shell -p nix-info --run "nix-info -m"

--- a/.github/workflows/generate-build-matrix.py
+++ b/.github/workflows/generate-build-matrix.py
@@ -1,22 +1,39 @@
 """Generate a GitHub Actions build matrix from per-architecture backend lists.
 
 Usage:
-    python3 generate-build-matrix.py <x86-backends-json> <arm-backends-json>
+    KERNEL=<kernel> python3 generate-build-matrix.py <x86-backends-json> <arm-backends-json>
 
-Each argument is the JSON array produced by:
+<kernel> is the kernel directory name (e.g. 'flash-attn2'), passed via the
+KERNEL environment variable. Each JSON argument is the array produced by:
     nix eval .#backendCi --apply builtins.attrNames --json --system <arch>
 
 Prints a single-line JSON object suitable for use as a GitHub Actions matrix,
-with one entry per (backend, arch) combination.
+with one entry per (backend, arch) combination. Each entry includes max_jobs
+and cores, falling back to DEFAULT_MAX_JOBS and DEFAULT_CORES respectively,
+with per-kernel/backend overrides read from build-concurrency.json at the
+repo root.
 """
 
 import json
+import os
 import sys
+from pathlib import Path
 
 ARCHES = [
     ("x86_64-linux", "aws-highmemory-32-plus-nix"),
     ("aarch64-linux", "aws-r8g-8xl-plus-nix"),
 ]
+
+DEFAULT_MAX_JOBS = 2
+DEFAULT_CORES = 12
+
+
+def load_concurrency_overrides() -> dict:
+    overrides_path = Path(__file__).parent.parent.parent / "build-concurrency.json"
+    if overrides_path.exists():
+        with open(overrides_path) as f:
+            return json.load(f)
+    return {}
 
 
 def main():
@@ -27,13 +44,28 @@ def main():
         )
         sys.exit(1)
 
+    kernel = os.environ.get("KERNEL")
+    if not kernel:
+        print("KERNEL environment variable is not set or empty", file=sys.stderr)
+        sys.exit(1)
+
     backends_by_arch = {
         "x86_64-linux": json.loads(sys.argv[1]),
         "aarch64-linux": json.loads(sys.argv[2]),
     }
 
+    kernel_overrides = load_concurrency_overrides().get(kernel, {})
+
     include = [
-        {"backend": backend, "arch": arch, "runner": runner}
+        {
+            "backend": backend,
+            "arch": arch,
+            "runner": runner,
+            "max_jobs": kernel_overrides.get(backend, {}).get(
+                "max-jobs", DEFAULT_MAX_JOBS
+            ),
+            "cores": kernel_overrides.get(backend, {}).get("cores", DEFAULT_CORES),
+        }
         for arch, runner in ARCHES
         for backend in backends_by_arch[arch]
     ]

--- a/build-concurrency.json
+++ b/build-concurrency.json
@@ -1,0 +1,8 @@
+{
+  "flash-attn2": {
+    "xpu": {
+      "max-jobs": 1,
+      "cores": 8
+    }
+  }
+}

--- a/flash-attn2/flake.lock
+++ b/flash-attn2/flake.lock
@@ -41,16 +41,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777901020,
-        "narHash": "sha256-m54hEdh1kK+pDcRfJDwN0P861X5VWpC/yZ1TjTwshtA=",
+        "lastModified": 1778133282,
+        "narHash": "sha256-Qf5zaO7pnqsAiArT6uytQxYhVDJl1Hq3YF6oWCsRcJY=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "614c6bb2ee922a832852cb5562d5571cd9600a9c",
+        "rev": "9cc776021f73e3f4236144b387a7cd8967ca5c97",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
-        "ref": "torch-2.12",
         "repo": "kernels",
         "type": "github"
       }

--- a/flash-attn2/flake.nix
+++ b/flash-attn2/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for flash-attn kernel";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernels/torch-2.12";
+    kernel-builder.url = "github:huggingface/kernels";
   };
 
   outputs =


### PR DESCRIPTION
PR #666 fails due to going OOM. Add a mechanism to support per-kernel/backend configurable concurrency for such cases.