### PR TITLE
flash-attn3: limit to CUDA <= 13.0 to avoid ptxas failure

### DIFF
--- a/flash-attn3/build.toml
+++ b/flash-attn3/build.toml
@@ -6,6 +6,8 @@ backends = ["cuda"]
 
 [general.cuda]
 minver = "12.8"
+# ptxas fails on 13.2, but the 13.0 build is backwards compatible.
+maxver = "13.0"
 
 
 [general.hub]


### PR DESCRIPTION
Having only the 13.0 build is fine, since `kernels` will fall back to that version when no 13.2 build is available.