### PR TITLE
Fix duplicate-address store race in batched FP8 matmul kernels (XPU c…

### DIFF
--- a/finegrained-fp8/flake.lock
+++ b/finegrained-fp8/flake.lock
@@ -41,16 +41,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777901020,
-        "narHash": "sha256-m54hEdh1kK+pDcRfJDwN0P861X5VWpC/yZ1TjTwshtA=",
+        "lastModified": 1778686770,
+        "narHash": "sha256-Er46ex4haOijaJjGHFgqVoVuNkhacoVcci/tD/txitw=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "614c6bb2ee922a832852cb5562d5571cd9600a9c",
+        "rev": "7098da1dc22a71770a985e9d54c95b9cb3fccd5f",
         "type": "github"
       },
       "original": {
         "owner": "huggingface",
-        "ref": "torch-2.12",
         "repo": "kernels",
         "type": "github"
       }

--- a/finegrained-fp8/flake.nix
+++ b/finegrained-fp8/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for fine-grained FP8 block-wise quantization kernels";
 
   inputs = {
-    kernel-builder.url = "github:huggingface/kernels/torch-2.12";
+    kernel-builder.url = "github:huggingface/kernels";
   };
 
   outputs =

--- a/finegrained-fp8/torch-ext/finegrained_fp8/batched.py
+++ b/finegrained-fp8/torch-ext/finegrained_fp8/batched.py
@@ -103,7 +103,13 @@ def w8a8_block_fp8_matmul_batched_kernel(
     offs_cm = tl.arange(0, BLOCK_SIZE_M)
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = C + offs_cm[:, None] * 0 + stride_cn * offs_cn[None, :]
-    tl.store(c_ptrs, c)
+    # Fake-batch trick aliases all BLOCK_SIZE_M lanes to the same C row, so emitting
+    # `tl.store(c_ptrs, c)` issues BLOCK_SIZE_M duplicate-address stores. On NVIDIA
+    # WGMMA this is usually benign (last-write-wins of identical bytes), but on Intel
+    # XPU the duplicate-address store has hardware-undefined behavior and corrupts the
+    # output. Mask so only lane 0 stores — the (M, N) accumulator rows are
+    # mathematically identical (same A row × same B), so lane 0 holds the right value.
+    tl.store(c_ptrs, c, mask=(offs_cm == 0)[:, None])
 
 
 @triton.autotune(
@@ -181,7 +187,9 @@ def w8a8_tensor_fp8_matmul_batched_kernel(
     offs_cm = tl.arange(0, BLOCK_SIZE_M)
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = C + offs_cm[:, None] * 0 + stride_cn * offs_cn[None, :]
-    tl.store(c_ptrs, c)
+    # See block-FP8 kernel above: BLOCK_SIZE_M lanes alias the same C row;
+    # mask so only lane 0 stores to avoid hardware-undefined duplicate writes on XPU.
+    tl.store(c_ptrs, c, mask=(offs_cm == 0)[:, None])
 
 
 @triton_op("finegrained_fp8::w8a8_block_fp8_matmul_batched", mutates_args=())


### PR DESCRIPTION
…orrectness)

Summary
w8a8_block_fp8_matmul_batched_kernel and w8a8_tensor_fp8_matmul_batched_kernel issue BLOCK_SIZE_M-way duplicate-address tl.stores to the output, which is undefined behavior. On NVIDIA GPUs the writes happen to be benign (last-write-wins of byte-identical values), but on Intel XPU it corrupts the output. This PR adds a single-lane store mask to make the write well-defined.

Fix:
Mask the store so only lane 0 writes: