### PR TITLE
activation: fix incorrect return type annotations (None → torch.Tensor)

### DIFF
--- a/activation/torch-ext/activation/__init__.py
+++ b/activation/torch-ext/activation/__init__.py
@@ -5,56 +5,56 @@ from ._ops import ops
 from . import layers
 
 
-def silu_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def silu_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.silu_and_mul(out, x)
     return out
 
 
-def mul_and_silu(out: torch.Tensor, x: torch.Tensor) -> None:
+def mul_and_silu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.mul_and_silu(out, x)
     return out
 
 
-def gelu_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_and_mul(out, x)
     return out
 
 
-def gelu_tanh_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_tanh_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_tanh_and_mul(out, x)
     return out
 
 
-def fatrelu_and_mul(out: torch.Tensor, x: torch.Tensor, threshold: float = 0.0) -> None:
+def fatrelu_and_mul(out: torch.Tensor, x: torch.Tensor, threshold: float = 0.0) -> torch.Tensor:
     ops.fatrelu_and_mul(out, x, threshold)
     return out
 
 
-def gelu(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu(out, x)
     return out
 
-def silu(out: torch.Tensor, x: torch.Tensor) -> None:
+def silu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.silu(out, x)
     return out
 
 
-def gelu_tanh(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_tanh(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_tanh(out, x)
     return out
 
 
-def gelu_fast(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_fast(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_fast(out, x)
     return out
 
 
-def gelu_new(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_new(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_new(out, x)
     return out
 
 
-def gelu_quick(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_quick(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_quick(out, x)
     return out
 


### PR DESCRIPTION
## What

All 11 public functions in `activation/torch-ext/activation/__init__.py`
were annotated with `-> None` despite every one of them returning `out`
(a `torch.Tensor`). This fixes the annotations to match the actual
runtime behaviour.

## Why

The mismatch causes:
- **Type checker errors** (mypy / pyright) at any call site that stores
  the return value — including the project's own test:
  `out = fn(out, x)` in `test_activation.py:117`
- **Misleading API contract**: callers reading the signature would
  reasonably conclude the functions are purely in-place and discard the
  return value unnecessarily
- **Incorrect auto-generated docs / stubs** for downstream integrators

## Change

`-> None` → `-> torch.Tensor` on all 11 wrapper functions:
`silu_and_mul`, `mul_and_silu`, `gelu_and_mul`, `gelu_tanh_and_mul`,
`fatrelu_and_mul`, `gelu`, `silu`, `gelu_tanh`, `gelu_fast`, `gelu_new`,
`gelu_quick`

No logic or behaviour is changed. The `return out` statements already
existed in every function; this is a pure annotation correction.

## Testing

Existing tests in `activation/tests/kernels/test_activation.py` cover
all affected functions and continue to pass unchanged.