### PR TITLE
fix: add optional backends for linux and mac build ci

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: "kernels-community"
+      backends:
+        description: "Comma-separated list of backends to build (e.g. metal)"
+        required: false
+        type: string
+        default: ""
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: "kernels-community"
+      backends:
+        description: "Comma-separated list of backends to build (e.g. cuda,cpu,rocm)"
+        required: false
+        type: string
+        default: ""
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
This is a small followup PR to https://github.com/huggingface/kernels-community/pull/850