### PR TITLE
fix: correct return type annotations from None to torch.Tensor in activation module

### DIFF
--- a/activation/torch-ext/activation/__init__.py
+++ b/activation/torch-ext/activation/__init__.py
@@ -5,56 +5,56 @@ from ._ops import ops
 from . import layers
 
 
-def silu_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def silu_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.silu_and_mul(out, x)
     return out
 
 
-def mul_and_silu(out: torch.Tensor, x: torch.Tensor) -> None:
+def mul_and_silu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.mul_and_silu(out, x)
     return out
 
 
-def gelu_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_and_mul(out, x)
     return out
 
 
-def gelu_tanh_and_mul(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_tanh_and_mul(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_tanh_and_mul(out, x)
     return out
 
 
-def fatrelu_and_mul(out: torch.Tensor, x: torch.Tensor, threshold: float = 0.0) -> None:
+def fatrelu_and_mul(out: torch.Tensor, x: torch.Tensor, threshold: float = 0.0) -> torch.Tensor:
     ops.fatrelu_and_mul(out, x, threshold)
     return out
 
 
-def gelu(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu(out, x)
     return out
 
-def silu(out: torch.Tensor, x: torch.Tensor) -> None:
+def silu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.silu(out, x)
     return out
 
 
-def gelu_tanh(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_tanh(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_tanh(out, x)
     return out
 
 
-def gelu_fast(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_fast(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_fast(out, x)
     return out
 
 
-def gelu_new(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_new(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_new(out, x)
     return out
 
 
-def gelu_quick(out: torch.Tensor, x: torch.Tensor) -> None:
+def gelu_quick(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
     ops.gelu_quick(out, x)
     return out
 


### PR DESCRIPTION
Fixes #848

All 11 public functions in `activation/torch-ext/activation/__init__.py` were annotated with `-> None` despite explicitly returning `out` (a `torch.Tensor`). This corrects all 11 signatures to `-> torch.Tensor`.

No logic or behaviour changes, purely an annotation fix.
