### PR TITLE
relu: disable fail-fast on Mac and Windows CI

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -65,6 +65,8 @@ jobs:
   # Build the Metal kernel; PR mode builds .#ci, release builds the full bundle and uploads.
   build-kernel:
     runs-on: macos-26
+    strategy:
+      fail-fast: false
     steps:
       # Post a running commit status so the PR shows the build is in progress.
       - name: Set running status

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -80,6 +80,7 @@ jobs:
   # Build the kernel for each CUDA/XPU variant; release mode uploads to the Hub.
   build-kernel:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2022]
         python: [3.12]


### PR DESCRIPTION
This mirrors Linux builds and avoids masquerading build results for other backends when one backend fails.