### PR TITLE
activation: ensure inputs are contiguous in bare activation functions

### DIFF
--- a/activation/torch-ext/activation/__init__.py
+++ b/activation/torch-ext/activation/__init__.py
@@ -31,30 +31,43 @@ def fatrelu_and_mul(out: torch.Tensor, x: torch.Tensor, threshold: float = 0.0) 
 
 
 def gelu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.gelu(out, x)
     return out
 
+
 def silu(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.silu(out, x)
     return out
 
 
 def gelu_tanh(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.gelu_tanh(out, x)
     return out
 
 
 def gelu_fast(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.gelu_fast(out, x)
     return out
 
 
 def gelu_new(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.gelu_new(out, x)
     return out
 
 
 def gelu_quick(out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
     ops.gelu_quick(out, x)
     return out
 


### PR DESCRIPTION
Fixes #106.

## Motivation

ModernBERT crashes when `kernelize()`d. Its gated MLP does `x.chunk(2, dim=-1)` and passes the non-contiguous first chunk to the activation. The bare `gelu()` in `__init__.py` doesn't call `.contiguous()` before invoking the op, so it hits the `TORCH_CHECK(input.is_contiguous())` added in #87:

```
RuntimeError: Expected input.is_contiguous() to be true, but got false.
```

The `nn.Module` wrappers in `layers.py` already guard against this. The bare functions in `__init__.py` don't — and `kernelize()` patches the bare functions, so that's the path users actually hit.

## Changes

- Add `if not x.is_contiguous(): x = x.contiguous()` to the 6 bare element-wise activation functions in `activation/torch-ext/activation/__init__.py`: `gelu`, `silu`, `gelu_tanh`, `gelu_fast`, `gelu_new`, `gelu_quick`.
- Mirrors the existing pattern from the `nn.Module` wrappers in `layers.py`.
- `*_and_mul` family is out of scope — its wrappers already have the guard.
- Pure Python; no kernel rebuild, no ABI change.

## Testing

Repro on `main` (NVIDIA A100 80GB, PyTorch 2.11.0+cu128, fp16):

```python
import torch
from kernels import get_kernel

act = get_kernel("kernels-community/activation", version=1)
x = torch.randn(2, 128, 1536, device="cuda", dtype=torch.float16)
inp, _ = x.chunk(2, dim=-1)
assert not inp.is_contiguous()

out = torch.empty_like(inp)
act.gelu(out, inp)
# RuntimeError: Expected input.is_contiguous() to be true, but got false.
```

With the fix applied (patched bare functions overlaid onto the Hub kernel for verification), the same ModernBERT chunk pattern produces matching outputs across all six activations vs the `torch.nn.functional` reference, and the contiguous path is unchanged:

```
gelu         max diff 0.0
silu         max diff 0.0
gelu_tanh    max diff 0.0
gelu_fast    max diff 0.0
gelu_new     max diff 0.0
gelu_quick   max diff 0.0
gelu contig  max diff 0.0   (no regression)
```

