### PR TITLE
fix: avoid title parsing trigger

### DIFF
--- a/.github/workflows/build-release-dispatch.yaml
+++ b/.github/workflows/build-release-dispatch.yaml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
+  validate:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
@@ -56,12 +56,18 @@ jobs:
         run: |
           echo "skip=${{ steps.validate.outputs.skip }}"
           echo "kernel=${{ steps.validate.outputs.kernel }}"
+
+  dispatch:
+    needs: validate
+    if: needs.validate.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Dispatch release workflows
-        if: steps.validate.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          KERNEL="${{ steps.validate.outputs.kernel }}"
+          KERNEL="${{ needs.validate.outputs.kernel }}"
           REF="${{ github.event.repository.default_branch || 'main' }}"
           python3 .github/scripts/dispatch.py "$KERNEL" --ref "$REF" --mode release

--- a/.github/workflows/build-release-dispatch.yaml
+++ b/.github/workflows/build-release-dispatch.yaml
@@ -2,8 +2,8 @@ name: Build Release (Dispatch)
 run-name: >-
   Build Release (Dispatch) / ${{ inputs.kernel_name || github.event.pull_request.title || '' }} / request=${{ inputs.dispatch_key || '' }}
 on:
-  pull_request:
-    types: [closed]
+  # pull_request:
+  #   types: [closed]
   workflow_dispatch:
     inputs:
       kernel_name:


### PR DESCRIPTION
avoid triggering the workflow that checks for a kernel in a pr title since we are moving to the kernel-bot for CI instead of parsing titles