### PR TITLE
ci: merge-and-upload branch default should be unset

### DIFF
--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -545,7 +545,7 @@ def main():
         dispatch_upload = True
         dispatch_repo_prefix = "kernels-community"
     else:  # merge-and-upload
-        target_branch = requested_branch or "main"
+        target_branch = requested_branch or ""
         dispatch_pr_number = ""
         dispatch_upload = True
         dispatch_repo_prefix = "kernels-community"


### PR DESCRIPTION
Otherwise we only upload to the default branch (`main`) and the version (branch) in `build.toml` is not respected.