### PR TITLE
Fix #935: Checkout PR branch instead of default branch in comment workflow

### DIFF
--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 1
       - name: Handle /kernel-bot command
         env:


### PR DESCRIPTION
Fixes #935. 

Switches the `issue_comment` workflow checkout step from using the repository's default branch to fetching the actual incoming pull request branch head (`refs/pull/${{ github.event.issue.number }}/head`). 

This ensures that `dispatch.py` can correctly read the updated or newly added `build.toml` backend configurations from the contributor's code rather than failing on `main`.