### PR TITLE
causal-conv1d: sync kernels with upstream v1.6.2.post1 (deterministic backward)

### DIFF
--- a/causal-conv1d/causal-conv1d/causal_conv1d.cpp
+++ b/causal-conv1d/causal-conv1d/causal_conv1d.cpp
@@ -10,9 +10,22 @@
 #endif
 
 #include <c10/cuda/CUDAStream.h>
+#include <ATen/Context.h>
 #include <vector>
+#include <cstdlib>
 
 #include "causal_conv1d.h"
+
+namespace {
+bool use_deterministic_mode() {
+    const char* env = std::getenv("CAUSAL_CONV1D_DETERMINISTIC");
+    if (env) {
+        if (*env == '1') return true;
+        if (*env == '0') return false;
+    }
+    return at::globalContext().deterministicAlgorithms();
+}
+}
 
 #define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
 
@@ -163,7 +176,7 @@ causal_conv1d_fwd(const at::Tensor &x,
 
     if (is_channel_last) {
         TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
-        TORCH_CHECK(x.stride(2) % 8 == 0 and x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
+        TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
     }
     TORCH_CHECK(width >= 2 && width <= 4, "causal_conv1d only supports width between 2 and 4");
 
@@ -285,8 +298,8 @@ causal_conv1d_bwd(const at::Tensor &x,
 
     if (is_channel_last) {
         TORCH_CHECK(dim % 8 == 0, "causal_conv1d only supports channel dimension divisible by 8 for now");
-        TORCH_CHECK(x.stride(2) % 8 == 0 and x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
-        TORCH_CHECK(dout.stride(2) % 8 == 0 and dout.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (dout.stride(0) and dout.stride(2)) to be multiples of 8");
+        TORCH_CHECK(x.stride(2) % 8 == 0 && x.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8");
+        TORCH_CHECK(dout.stride(2) % 8 == 0 && dout.stride(0) % 8 == 0, "causal_conv1d with channel last layout requires strides (dout.stride(0) and dout.stride(2)) to be multiples of 8");
     }
 
     if (bias_.has_value()) {
@@ -371,6 +384,57 @@ causal_conv1d_bwd(const at::Tensor &x,
         params.dinitial_states_ptr = nullptr;
     }
 
+    const bool deterministic = use_deterministic_mode();
+    params.deterministic = deterministic;
+
+    at::Tensor dweight_workspace;
+    at::Tensor dbias_workspace;
+
+    if (deterministic) {
+        if (!is_channel_last) {
+            dweight_workspace = at::zeros({batch_size, dim, width},
+                at::TensorOptions().dtype(at::kFloat).device(x.device()));
+            params.dweight_workspace_ptr = dweight_workspace.data_ptr();
+            params.dweight_workspace_batch_stride = dweight_workspace.stride(0);
+            params.dweight_workspace_dim_stride = dweight_workspace.stride(1);
+
+            if (dbias_.has_value()) {
+                dbias_workspace = at::zeros({batch_size, dim},
+                    at::TensorOptions().dtype(at::kFloat).device(x.device()));
+                params.dbias_workspace_ptr = dbias_workspace.data_ptr();
+                params.dbias_workspace_batch_stride = dbias_workspace.stride(0);
+            } else {
+                params.dbias_workspace_ptr = nullptr;
+                params.dbias_workspace_batch_stride = 0;
+            }
+        } else {
+            const int kChunkSizeL = seqlen <= 128 ? 64 : 128;
+            const int n_chunks_L = (seqlen + kChunkSizeL - 1) / kChunkSizeL;
+
+            dweight_workspace = at::zeros({batch_size, n_chunks_L, dim, width},
+                at::TensorOptions().dtype(at::kFloat).device(x.device()));
+            params.dweight_workspace_ptr = dweight_workspace.data_ptr();
+            params.dweight_workspace_batch_stride = dweight_workspace.stride(0);
+            params.dweight_workspace_dim_stride = dweight_workspace.stride(2);
+
+            if (dbias_.has_value()) {
+                dbias_workspace = at::zeros({batch_size, n_chunks_L, dim},
+                    at::TensorOptions().dtype(at::kFloat).device(x.device()));
+                params.dbias_workspace_ptr = dbias_workspace.data_ptr();
+                params.dbias_workspace_batch_stride = dbias_workspace.stride(0);
+            } else {
+                params.dbias_workspace_ptr = nullptr;
+                params.dbias_workspace_batch_stride = 0;
+            }
+        }
+    } else {
+        params.dweight_workspace_ptr = nullptr;
+        params.dbias_workspace_ptr = nullptr;
+        params.dweight_workspace_batch_stride = 0;
+        params.dweight_workspace_dim_stride = 0;
+        params.dbias_workspace_batch_stride = 0;
+    }
+
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     DISPATCH_ITYPE_FLOAT_AND_HALF_AND_BF16(x.scalar_type(), "causal_conv1d_bwd", [&] {
         DISPATCH_WTYPE_FLOAT_AND_HALF_AND_BF16(weight.scalar_type(), "causal_conv1d_bwd", [&] {
@@ -381,6 +445,20 @@ causal_conv1d_bwd(const at::Tensor &x,
             }
         });
     });
+
+    if (deterministic) {
+        if (!is_channel_last) {
+            dweight.add_(dweight_workspace.sum(0));
+            if (dbias_.has_value()) {
+                dbias_.value().add_(dbias_workspace.sum(0));
+            }
+        } else {
+            dweight.add_(dweight_workspace.sum(at::IntArrayRef({0, 1})));
+            if (dbias_.has_value()) {
+                dbias_.value().add_(dbias_workspace.sum(at::IntArrayRef({0, 1})));
+            }
+        }
+    }
 }
 
 void
@@ -477,10 +555,9 @@ causal_conv1d_update(const at::Tensor &x,
     });
 }
 
-/*
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("causal_conv1d_fwd", &causal_conv1d_fwd, "Causal conv1d forward");
-    m.def("causal_conv1d_bwd", &causal_conv1d_bwd, "Causal conv1d backward");
-    m.def("causal_conv1d_update", &causal_conv1d_update, "Causal conv1d update");
-}
-*/
+// Bindings are provided by torch-ext/torch_binding.cpp (kernels build).
+//PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+//    m.def("causal_conv1d_fwd", &causal_conv1d_fwd, "Causal conv1d forward");
+//    m.def("causal_conv1d_bwd", &causal_conv1d_bwd, "Causal conv1d backward");
+//    m.def("causal_conv1d_update", &causal_conv1d_update, "Causal conv1d update");
+//}

--- a/causal-conv1d/causal-conv1d/causal_conv1d.h
+++ b/causal-conv1d/causal-conv1d/causal_conv1d.h
@@ -78,4 +78,11 @@ struct ConvParamsBwd: public ConvParamsBase {
     index_t dfinal_states_batch_stride;
     index_t dfinal_states_l_stride;
     index_t dfinal_states_c_stride;
+
+    bool deterministic;
+    void *__restrict__ dweight_workspace_ptr;
+    void *__restrict__ dbias_workspace_ptr;
+    index_t dweight_workspace_batch_stride;
+    index_t dweight_workspace_dim_stride;
+    index_t dbias_workspace_batch_stride;
 };

--- a/causal-conv1d/causal-conv1d/causal_conv1d_bwd.cu
+++ b/causal-conv1d/causal-conv1d/causal_conv1d_bwd.cu
@@ -10,9 +10,11 @@
     #include <cub/block/block_load.cuh>
     #include <cub/block/block_store.cuh>
     #include <cub/block/block_reduce.cuh>
+    #define ROCM_ONLY(x)
 #else
     #include <hipcub/hipcub.hpp>
     namespace cub = hipcub;
+    #define ROCM_ONLY(x) x
 #endif
 
 #include "causal_conv1d.h"
@@ -48,7 +50,7 @@ struct Causal_conv1d_bwd_kernel_traits {
             int(sizeof(typename BlockReduceFloatT::TempStorage))}) + (kIsVecLoad ? 0 : kSmemIOSize);
 };
 
-template<typename Ktraits>
+template<typename Ktraits, bool kDeterministic>
 __global__ __launch_bounds__(Ktraits::kNThreads)
 void causal_conv1d_bwd_kernel(ConvParamsBwd params) {
     constexpr int kWidth = Ktraits::kWidth;
@@ -232,14 +234,26 @@ void causal_conv1d_bwd_kernel(ConvParamsBwd params) {
         __syncthreads();
         dweight_vals[w] = typename Ktraits::BlockReduceFloatT(smem_reduce_float).Sum(dweight_vals[w]);
         if (tidx == 0) {
-            atomicAdd(&reinterpret_cast<float *>(dweight)[w * params.dweight_width_stride], dweight_vals[w]);
+            if constexpr (kDeterministic) {
+                float *dweight_ws = reinterpret_cast<float *>(params.dweight_workspace_ptr);
+                dweight_ws[batch_id * params.dweight_workspace_batch_stride
+                         + dim_id * params.dweight_workspace_dim_stride
+                         + w] = dweight_vals[w];
+            } else {
+                atomicAdd(&reinterpret_cast<float *>(dweight)[w * params.dweight_width_stride], dweight_vals[w]);
+            }
         }
     }
     if (params.bias_ptr != nullptr) {
         __syncthreads();
         dbias_val = typename Ktraits::BlockReduceFloatT(smem_reduce_float).Sum(dbias_val);
         if (tidx == 0) {
-            atomicAdd(&reinterpret_cast<float *>(params.dbias_ptr)[dim_id], dbias_val);
+            if constexpr (kDeterministic) {
+                float *dbias_ws = reinterpret_cast<float *>(params.dbias_workspace_ptr);
+                dbias_ws[batch_id * params.dbias_workspace_batch_stride + dim_id] = dbias_val;
+            } else {
+                atomicAdd(&reinterpret_cast<float *>(params.dbias_ptr)[dim_id], dbias_val);
+            }
         }
     }
 }
@@ -249,26 +263,20 @@ void causal_conv1d_bwd_launch(ConvParamsBwd &params, cudaStream_t stream) {
     static constexpr int kNElts = sizeof(input_t) == 4 ? 4 : 8;
     BOOL_SWITCH(params.seqlen % kNElts == 0, kIsVecLoad, [&] {
         BOOL_SWITCH(params.silu_activation, kSiluAct, [&] {
-            using Ktraits = Causal_conv1d_bwd_kernel_traits<kNThreads, kWidth, kSiluAct, kIsVecLoad, input_t, weight_t>;
-            constexpr int kSmemSize = Ktraits::kSmemSize;
-            dim3 grid(params.batch, params.dim);
-            auto kernel = &causal_conv1d_bwd_kernel<Ktraits>;
-
-            if (kSmemSize >= 48 * 1024) {
-                #ifndef USE_ROCM
-                C10_CUDA_CHECK(cudaFuncSetAttribute(
-                    kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-                #else
-                // There is a slight signature discrepancy in HIP and CUDA "FuncSetAttribute" function.
-                C10_CUDA_CHECK(cudaFuncSetAttribute(
-                    (void *) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-                std::cerr << "Warning (causal_conv1d bwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl;
-                #endif
-            }
-
-
-            kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
-            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            BOOL_SWITCH(params.deterministic, kDeterministic, [&] {
+                using Ktraits = Causal_conv1d_bwd_kernel_traits<kNThreads, kWidth, kSiluAct, kIsVecLoad, input_t, weight_t>;
+                constexpr int kSmemSize = Ktraits::kSmemSize;
+                dim3 grid(params.batch, params.dim);
+                auto kernel = &causal_conv1d_bwd_kernel<Ktraits, kDeterministic>;
+                if (kSmemSize >= 48 * 1024) {
+                    // There is a slight signature discrepancy in HIP and CUDA "FuncSetAttribute" function.
+                    C10_CUDA_CHECK(cudaFuncSetAttribute(
+                        ROCM_ONLY((void *)) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
+                    ROCM_ONLY(std::cerr << "Warning (causal_conv1d bwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl);
+                }
+                kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
+                C10_CUDA_KERNEL_LAUNCH_CHECK();
+            });
         });
     });
 }
@@ -318,7 +326,7 @@ struct Causal_conv1d_channellast_bwd_kernel_traits {
     // static constexpr int kSmemSize = kChunkSizeL * kNEltsPerRow * kNBytes;
 };
 
-template<typename Ktraits, bool kHasSeqIdx, bool kHasDfinalStates>
+template<typename Ktraits, bool kHasSeqIdx, bool kHasDfinalStates, bool kDeterministic>
 __global__ __launch_bounds__(Ktraits::kNThreads)
 void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
     constexpr int kWidth = Ktraits::kWidth;
@@ -483,7 +491,15 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
         }
         dweight_vals[w] = Allreduce<kNThreadsPerRow>::run(dweight_vals[w], sum_op);
         if (col_idx == 0 && chunk_c_id * kChunkSizeC + row_idx < params.dim) {
-            atomicAdd(&reinterpret_cast<float *>(dweight)[row_idx * params.dweight_c_stride + w * params.dweight_width_stride], dweight_vals[w]);
+            if constexpr (kDeterministic) {
+                float *dweight_ws = reinterpret_cast<float *>(params.dweight_workspace_ptr);
+                dweight_ws[batch_id * params.dweight_workspace_batch_stride
+                         + chunk_l_id * params.dweight_workspace_dim_stride * params.dim
+                         + (chunk_c_id * kChunkSizeC + row_idx) * params.dweight_workspace_dim_stride
+                         + w] = dweight_vals[w];
+            } else {
+                atomicAdd(&reinterpret_cast<float *>(dweight)[row_idx * params.dweight_c_stride + w * params.dweight_width_stride], dweight_vals[w]);
+            }
         }
     }
 
@@ -492,7 +508,14 @@ void causal_conv1d_channellast_bwd_kernel(ConvParamsBwd params) {
         for (int i = 0; i < kLPerThread; ++i) { dbias_val += dout_vals[i]; }
         dbias_val = Allreduce<kNThreadsPerRow>::run(dbias_val, sum_op);
         if (col_idx == 0 && chunk_c_id * kChunkSizeC + row_idx < params.dim) {
-            atomicAdd(&reinterpret_cast<float *>(params.dbias_ptr)[chunk_c_id * kChunkSizeC + row_idx], dbias_val);
+            if constexpr (kDeterministic) {
+                float *dbias_ws = reinterpret_cast<float *>(params.dbias_workspace_ptr);
+                dbias_ws[batch_id * params.dbias_workspace_batch_stride
+                       + chunk_l_id * params.dim
+                       + (chunk_c_id * kChunkSizeC + row_idx)] = dbias_val;
+            } else {
+                atomicAdd(&reinterpret_cast<float *>(params.dbias_ptr)[chunk_c_id * kChunkSizeC + row_idx], dbias_val);
+            }
         }
     }
 
@@ -570,25 +593,27 @@ void causal_conv1d_channellast_bwd_launch(ConvParamsBwd &params, cudaStream_t st
     BOOL_SWITCH(params.silu_activation, kSiluAct, [&] {
         BOOL_SWITCH(params.seq_idx_ptr != nullptr, kHasSeqIdx, [&] {
             BOOL_SWITCH(params.dfinal_states_ptr != nullptr, kHasDfinalStates, [&] {
-                BOOL_SWITCH(params.seqlen <= 128, kChunkSizeL64, [&] {
-                    // kChunkSizeL = 128 is slightly faster than 64 when seqlen is larger
-                    static constexpr int kChunk = kChunkSizeL64 ? 64 : 128;
-                    using Ktraits = Causal_conv1d_channellast_bwd_kernel_traits<kNThreads, kWidth, kChunk, kSiluAct, true, input_t, weight_t>;
-                    // constexpr int kSmemSize = Ktraits::kSmemSize;
-                    constexpr int kChunkSizeL = Ktraits::kChunkSizeL;
-                    constexpr int kChunkSizeC = Ktraits::kNEltsPerRow;
-                    const int n_chunks_L = (params.seqlen + kChunkSizeL - 1) / kChunkSizeL;
-                    const int n_chunks_C = (params.dim + kChunkSizeC - 1) / kChunkSizeC;
-                    dim3 grid(params.batch, n_chunks_L, n_chunks_C);
-                    dim3 block(Ktraits::kNThreads);
-                    auto kernel = &causal_conv1d_channellast_bwd_kernel<Ktraits, kHasSeqIdx, kHasDfinalStates>;
-                    // if (kSmemSize >= 48 * 1024) {
-                    //     C10_CUDA_CHECK(cudaFuncSetAttribute(
-                    //         kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-                    //     }
-                    // kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
-                    kernel<<<grid, Ktraits::kNThreads, 0, stream>>>(params);
-                    C10_CUDA_KERNEL_LAUNCH_CHECK();
+                BOOL_SWITCH(params.deterministic, kDeterministic, [&] {
+                    BOOL_SWITCH(params.seqlen <= 128, kChunkSizeL64, [&] {
+                        // kChunkSizeL = 128 is slightly faster than 64 when seqlen is larger
+                        static constexpr int kChunk = kChunkSizeL64 ? 64 : 128;
+                        using Ktraits = Causal_conv1d_channellast_bwd_kernel_traits<kNThreads, kWidth, kChunk, kSiluAct, true, input_t, weight_t>;
+                        // constexpr int kSmemSize = Ktraits::kSmemSize;
+                        constexpr int kChunkSizeL = Ktraits::kChunkSizeL;
+                        constexpr int kChunkSizeC = Ktraits::kNEltsPerRow;
+                        const int n_chunks_L = (params.seqlen + kChunkSizeL - 1) / kChunkSizeL;
+                        const int n_chunks_C = (params.dim + kChunkSizeC - 1) / kChunkSizeC;
+                        dim3 grid(params.batch, n_chunks_L, n_chunks_C);
+                        dim3 block(Ktraits::kNThreads);
+                        auto kernel = &causal_conv1d_channellast_bwd_kernel<Ktraits, kHasSeqIdx, kHasDfinalStates, kDeterministic>;
+                        // if (kSmemSize >= 48 * 1024) {
+                        //     C10_CUDA_CHECK(cudaFuncSetAttribute(
+                        //         kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
+                        //     }
+                        // kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
+                        kernel<<<grid, Ktraits::kNThreads, 0, stream>>>(params);
+                        C10_CUDA_KERNEL_LAUNCH_CHECK();
+                    });
                 });
             });
         });

--- a/causal-conv1d/causal-conv1d/causal_conv1d_fwd.cu
+++ b/causal-conv1d/causal-conv1d/causal_conv1d_fwd.cu
@@ -9,9 +9,11 @@
 #ifndef USE_ROCM
     #include <cub/block/block_load.cuh>
     #include <cub/block/block_store.cuh>
+    #define ROCM_ONLY(x) 
 #else
     #include <hipcub/hipcub.hpp>
     namespace cub = hipcub;
+    #define ROCM_ONLY(x) x
 #endif
 
 #include "causal_conv1d.h"
@@ -145,15 +147,10 @@ void causal_conv1d_fwd_launch(ConvParamsBase &params, cudaStream_t stream) {
         auto kernel = &causal_conv1d_fwd_kernel<Ktraits>;
 
         if (kSmemSize >= 48 * 1024) {
-            #ifndef USE_ROCM
-            C10_CUDA_CHECK(cudaFuncSetAttribute(
-                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-            #else
             // There is a slight signature discrepancy in HIP and CUDA "FuncSetAttribute" function.
             C10_CUDA_CHECK(cudaFuncSetAttribute(
-                (void *) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-            std::cerr << "Warning (causal_conv1d fwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl;
-            #endif
+                ROCM_ONLY((void *)) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
+            ROCM_ONLY(std::cerr << "Warning (causal_conv1d fwd launch): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl);
         }
         kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
 
@@ -317,6 +314,11 @@ void causal_conv1d_channellast_fwd_kernel(ConvParamsBase params) {
     for (int i = 0; i < kLPerThread; ++i) {
         out_vals[i] = bias_val;
         const int seq_idx_cur = !kHasSeqIdx ? 0 : seq_idx_thread[i + kWidth - 1];
+        // For padding tokens (seq_idx < 0), we skip the computation and set the output to 0.
+        if (seq_idx_cur < 0) {
+            out_vals[i] = 0.f;
+            continue;
+        }
         #pragma unroll
         for (int w = 0; w < kWidth; ++w) {
             if constexpr (!kHasSeqIdx) {

--- a/causal-conv1d/causal-conv1d/causal_conv1d_update.cu
+++ b/causal-conv1d/causal-conv1d/causal_conv1d_update.cu
@@ -35,18 +35,27 @@ void causal_conv1d_update_kernel(ConvParamsBase params) {
 
     input_t *x = reinterpret_cast<input_t *>(params.x_ptr) + batch_id * params.x_batch_stride
         + channel_id * params.x_c_stride;
+    input_t *out = reinterpret_cast<input_t *>(params.out_ptr) + batch_id * params.out_batch_stride
+        + channel_id * params.out_c_stride;
 
     // If params.conv_state_batch_indices is set, then the conv state is gathered from the conv state tensor
     // along the batch axis. Otherwise, the conv state coordinate is the same as the batch id.
     const int conv_state_batch_coord = params.conv_state_indices_ptr == nullptr
         ? batch_id
         : params.conv_state_indices_ptr[batch_id];
-    input_t *conv_state = reinterpret_cast<input_t *>(params.conv_state_ptr) 
+
+    // Skip padding tokens.
+    if (conv_state_batch_coord < 0) {
+        #pragma unroll 2
+        for (int i = 0; i < params.seqlen; ++i) {
+            out[i * params.out_l_stride] = input_t(0.f);
+        }
+        return;
+    }
+    input_t *conv_state = reinterpret_cast<input_t *>(params.conv_state_ptr)
         + conv_state_batch_coord * params.conv_state_batch_stride
         + channel_id * params.conv_state_c_stride;
     weight_t *weight = reinterpret_cast<weight_t *>(params.weight_ptr) + channel_id * params.weight_c_stride;
-    input_t *out = reinterpret_cast<input_t *>(params.out_ptr) + batch_id * params.out_batch_stride
-        + channel_id * params.out_c_stride;
     float bias_val = params.bias_ptr == nullptr ? 0.f : float(reinterpret_cast<weight_t *>(params.bias_ptr)[channel_id]);
 
     int state_len = params.conv_state_len;

--- a/causal-conv1d/tests/test_causal_conv1d.py
+++ b/causal-conv1d/tests/test_causal_conv1d.py
@@ -9,11 +9,42 @@ import pytest
 
 from einops import rearrange
 
+from causal_conv1d.causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_ref
+from causal_conv1d.causal_conv1d_interface import causal_conv1d_update, causal_conv1d_update_ref
+from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states, causal_conv1d_varlen_states_ref
 
-from causal_conv1d import causal_conv1d_fn, causal_conv1d_update, causal_conv1d_varlen_states
-from causal_conv1d.causal_conv1d_interface import causal_conv1d_ref
-from causal_conv1d.causal_conv1d_interface import causal_conv1d_update_ref
-from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states_ref
+
+def _max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
+    return (a.float() - b.float()).abs().max().item()
+
+
+def _conv1d_bwd_once(*, seed: int, channel_last: bool):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    device = "cuda"
+    itype = torch.bfloat16
+    dim = 1024
+    seqlen = 2048
+    width = 4
+
+    batch = 4
+    if not channel_last:
+        x = torch.randn(batch, dim, seqlen, device=device, dtype=itype).requires_grad_()
+    else:
+        x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(1, 2).requires_grad_()
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32, requires_grad=True)
+    bias = torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True)
+    g = torch.randn_like(x)
+    out = causal_conv1d_fn(x, weight, bias, activation="silu")
+    out.backward(g)
+    torch.cuda.synchronize()
+    return x.grad.detach().clone(), weight.grad.detach().clone(), bias.grad.detach().clone()
+
+
+def _set_torch_deterministic(enabled: bool) -> bool:
+    old = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(enabled)
+    return old
 
 
 @pytest.mark.parametrize("return_final_states", [False, True])
@@ -204,6 +235,94 @@ def test_causal_conv1d_update_with_batch_gather(dim, width, seqlen, has_cache_se
 
 @pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
 # @pytest.mark.parametrize('itype', [torch.float16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+# @pytest.mark.parametrize('silu_activation', [True])
+@pytest.mark.parametrize("has_bias", [False, True])
+# @pytest.mark.parametrize('has_bias', [True])
+@pytest.mark.parametrize("has_cache_seqlens", [False])#, True])
+# @pytest.mark.parametrize('has_cache_seqlens', [True])
+@pytest.mark.parametrize("seqlen", [1, 4, 5])
+# @pytest.mark.parametrize('seqlen', [4])
+@pytest.mark.parametrize("width", [2, 3, 4])
+# @pytest.mark.parametrize('width', [4])
+@pytest.mark.parametrize("dim", [2048, 2048 + 16, 4096])
+# @pytest.mark.parametrize("dim", [2048])
+def test_causal_conv1d_update_with_padding(dim, width, seqlen, has_cache_seqlens, has_bias, silu_activation, itype):
+    device = "cuda"
+    rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    # set seed
+    torch.random.manual_seed(0)
+    batch = 64
+    x = torch.randn(batch, seqlen, dim, device=device, dtype=itype).transpose(-1, -2)
+    state_len = torch.randint(width - 1, width + 10, (1,)).item()
+
+    total_entries = 10 * batch
+    conv_state = torch.randn(total_entries, state_len, dim, device=device, dtype=itype).transpose(-1, -2)
+
+    # Introduce padding by setting some indices to -1
+    num_valid_requests = batch // 2
+    num_padded_requests = batch - num_valid_requests
+
+    valid_indices = torch.randperm(total_entries)[:num_valid_requests].to(device=device)
+    padded_indices = torch.full((num_padded_requests,), -1, device=device)
+
+    # Shuffle the valid and padded indices together
+    combined_indices = torch.cat([valid_indices, padded_indices])
+    perm = torch.randperm(batch, device=device)
+    conv_state_indices = combined_indices[perm].to(dtype=torch.int32)
+
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32)
+    bias = torch.randn(dim, device=device, dtype=torch.float32) if has_bias else None
+
+    activation = "silu" if silu_activation else None
+
+    has_cache_seqlens = False
+    cache_seqlens = None
+    #cache_seqlens = (torch.randint(0, 1024, (batch,), dtype=torch.int32, device=device)
+    #                 if has_cache_seqlens else None)
+
+    # Clone original state for later comparison
+    conv_state_original = conv_state.clone()
+
+    # Run the main function with padded indices
+    out = causal_conv1d_update(x, conv_state, weight, bias, activation=activation,
+                               cache_seqlens=cache_seqlens, conv_state_indices=conv_state_indices)
+
+    # Manually compute the reference output and expected final state
+    out_ref = torch.zeros_like(out)
+    conv_state_expected = conv_state_original.clone()
+    valid_mask = conv_state_indices != -1
+
+    # Only compute the reference for the valid (non-padded) requests
+    if num_valid_requests > 0:
+        x_valid = x[valid_mask]
+        conv_state_indices_valid = conv_state_indices[valid_mask]
+        # This will be modified in-place by the ref function to get the expected updated state
+        conv_state_valid_updated = conv_state_original[conv_state_indices_valid, :].detach().clone()
+        cache_seqlens_valid = cache_seqlens[valid_mask] if has_cache_seqlens else None
+
+        out_ref_valid = causal_conv1d_update_ref(x_valid, conv_state_valid_updated, weight, bias,
+                                                 activation=activation, cache_seqlens=cache_seqlens_valid)
+        out_ref[valid_mask] = out_ref_valid
+        # Place the updated states into our expected full state tensor
+        conv_state_expected[conv_state_indices_valid] = conv_state_valid_updated
+
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+
+    # The output for padded tokens should be exactly zero
+    assert torch.all(out[~valid_mask] == 0)
+    assert torch.allclose(out[valid_mask], out_ref[valid_mask], rtol=rtol, atol=atol)
+
+    # Check that conv_state was updated correctly for valid tokens and untouched otherwise
+    assert torch.equal(conv_state, conv_state_expected)
+
+
+@pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
+# @pytest.mark.parametrize('itype', [torch.float16])
 @pytest.mark.parametrize("dim", [2048, 2048 + 16, 4096])
 # @pytest.mark.parametrize("dim", [2048])
 def test_causal_conv1d_get_states(dim, itype):
@@ -351,3 +470,149 @@ def test_causal_conv1d_varlen(dim, seqlen, width, has_bias, silu_activation, ity
     assert torch.allclose(weight.grad, weight_ref.grad, rtol=rtolw, atol=atolw)
     if has_bias:
         assert torch.allclose(bias.grad, bias_ref.grad, rtol=rtolw, atol=atolw)
+
+@pytest.mark.parametrize("itype", [torch.float32, torch.float16, torch.bfloat16])
+# @pytest.mark.parametrize('itype', [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [False, True])
+# @pytest.mark.parametrize('silu_activation', [True])
+@pytest.mark.parametrize("has_bias", [False, True])
+# @pytest.mark.parametrize('has_bias', [True])
+@pytest.mark.parametrize("width", [2, 3, 4])
+# @pytest.mark.parametrize('width', [4])
+@pytest.mark.parametrize(
+    "seqlen", [128, 256, 512, 1024]
+)
+# @pytest.mark.parametrize('seqlen', [128])
+@pytest.mark.parametrize('dim', [64, 4096 + 32])
+# @pytest.mark.parametrize('dim', [64])
+def test_causal_conv1d_varlen_padding(dim, seqlen, width, has_bias, silu_activation, itype):
+    device = "cuda"
+    rtol, atol = (3e-4, 1e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    rtolw, atolw = (1e-3, 1e-3)
+    # set seed
+    torch.random.manual_seed(seqlen + dim + width)
+    batch = 3
+    max_seqlen = seqlen
+
+    # Generate sequences of varying lengths for each batch item, some shorter than max_seqlen
+    true_seqlens = [torch.randint(max_seqlen // 2, max_seqlen + 1, (1,)).item() for _ in range(batch)]
+
+    seqlens = []
+    for b in range(batch):
+        # Within each true sequence, we can have multiple sub-sequences
+        nsplits = torch.randint(1, 4, (1,)).item()
+        eos_pos = torch.randperm(true_seqlens[b] - 1)[:nsplits].sort().values
+        sl = torch.diff(torch.cat([torch.tensor([-1]), eos_pos, torch.tensor([true_seqlens[b] - 1])])).tolist()
+        seqlens.append(sl)
+        assert sum(sl) == true_seqlens[b]
+        assert all(s > 0 for s in sl)
+
+    # Only support channel_last
+    x = rearrange(
+        torch.randn(batch, max_seqlen, 4096 + dim + 64, device=device, dtype=itype)[:, :, 4096:4096 + dim], "b s d -> b d s"
+    ).requires_grad_()
+
+    weight = torch.randn(dim, width, device=device, dtype=torch.float32, requires_grad=True)
+    bias = torch.randn(dim, device=device, dtype=torch.float32, requires_grad=True) if has_bias else None
+
+    # Construct seq_idx with -1 for padding
+    seq_idx_list = []
+    conv_batch_idx_counter = 0
+    for b in range(batch):
+        seq_idx_b = []
+        for s in seqlens[b]:
+            seq_idx_b.append(torch.full((s,), conv_batch_idx_counter, dtype=torch.int32, device=device))
+            conv_batch_idx_counter += 1
+        seq_idx_b = torch.cat(seq_idx_b, dim=0)
+        # Add padding indices
+        padding_len = max_seqlen - true_seqlens[b]
+        assert padding_len > 0
+        seq_idx_b = torch.cat([seq_idx_b, torch.full((padding_len,), -1, dtype=torch.int32, device=device)], dim=0)
+        seq_idx_list.append(seq_idx_b)
+    seq_idx = torch.stack(seq_idx_list, dim=0)
+
+    x_ref = x.detach().clone()
+    weight_ref = weight.detach().clone()
+    bias_ref = bias.detach().clone() if bias is not None else None
+    activation = "silu" if silu_activation else None
+
+    # Run forward pass with padding
+    out = causal_conv1d_fn(x, weight, bias, seq_idx=seq_idx, activation=activation)
+
+    # Manual reference calculation
+    out_ref = torch.zeros_like(x_ref)
+    for b in range(batch):
+        out_ref_b = []
+        # We only process the true sequence part
+        x_b_unpadded = x_ref[[b], :, :true_seqlens[b]]
+        # Split into sub-sequences
+        for x_s in torch.split(x_b_unpadded, seqlens[b], dim=2):
+            out_ref_b.append(causal_conv1d_ref(x_s, weight_ref, bias_ref, activation=activation))
+        out_ref[b, :, :true_seqlens[b]] = torch.cat(out_ref_b, dim=2)
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Output mean diff: {(out - out_ref).abs().mean().item()}")
+    assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channel_last", [False, True])
+def test_causal_conv1d_bwd_deterministic_reproducible(channel_last: bool, monkeypatch):
+    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
+    old = _set_torch_deterministic(True)
+    try:
+        runs = 5
+        outs = [_conv1d_bwd_once(seed=123, channel_last=channel_last) for _ in range(runs)]
+        dx0, dw0, db0 = outs[0]
+        for i in range(1, runs):
+            dx, dw, db = outs[i]
+            assert _max_abs_diff(dx0, dx) == 0.0
+            assert _max_abs_diff(dw0, dw) == 0.0
+            assert _max_abs_diff(db0, db) == 0.0
+    finally:
+        torch.use_deterministic_algorithms(old)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channel_last", [False, True])
+def test_causal_conv1d_bwd_deterministic_close_to_default(channel_last: bool, monkeypatch):
+    default_runs = 3
+    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
+    old = _set_torch_deterministic(True)
+    try:
+        dx_det, dw_det, db_det = _conv1d_bwd_once(seed=123, channel_last=channel_last)
+        torch.use_deterministic_algorithms(False)
+        for _ in range(default_runs):
+            dx_def, dw_def, db_def = _conv1d_bwd_once(seed=123, channel_last=channel_last)
+            assert torch.allclose(dx_det, dx_def, rtol=1e-2, atol=5e-2)
+            assert torch.allclose(dw_det, dw_def, rtol=1e-3, atol=1e-3)
+            assert torch.allclose(db_det, db_def, rtol=1e-3, atol=1e-3)
+    finally:
+        torch.use_deterministic_algorithms(old)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channel_last", [False, True])
+def test_causal_conv1d_bwd_default_mode_is_not_reproducible(channel_last: bool, monkeypatch):
+    monkeypatch.delenv("CAUSAL_CONV1D_DETERMINISTIC", raising=False)
+    old = _set_torch_deterministic(False)
+    try:
+        runs = 20
+        dw0 = None
+        db0 = None
+        dx0 = None
+        observed = False
+        for _ in range(runs):
+            dx, dw, db = _conv1d_bwd_once(seed=123, channel_last=channel_last)
+            if dw0 is None:
+                dx0, dw0, db0 = dx, dw, db
+                continue
+            if _max_abs_diff(dx0, dx) != 0.0 or _max_abs_diff(dw0, dw) != 0.0 or _max_abs_diff(db0, db) != 0.0:
+                observed = True
+                break
+        if not observed:
+            pytest.xfail("Did not observe nondeterminism in default mode (may be GPU/runtime dependent).")
+    finally:
+        torch.use_deterministic_algorithms(old)

--- a/causal-conv1d/torch-ext/causal_conv1d/__init__.py
+++ b/causal-conv1d/torch-ext/causal_conv1d/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "1.6.2.post1"
+
 from .causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_update
 from .causal_conv1d_varlen import causal_conv1d_varlen_states
 

--- a/mamba-ssm/torch-ext/mamba_ssm/modules/mamba2.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/modules/mamba2.py
@@ -8,15 +8,11 @@ import torch.nn.functional as F
 
 from einops import rearrange, repeat
 
-try:
-    from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
-except ImportError:
-    causal_conv1d_fn, causal_conv1d_update = None, None
-
-try:
-    from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states
-except ImportError:
-    causal_conv1d_varlen_states = None
+from ..utils.causal_conv1d import (
+    causal_conv1d_fn,
+    causal_conv1d_update,
+    causal_conv1d_varlen_states,
+)
 
 try:
     from ..ops.triton.selective_state_update import selective_state_update

--- a/mamba-ssm/torch-ext/mamba_ssm/modules/mamba2_simple.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/modules/mamba2_simple.py
@@ -7,10 +7,7 @@ import torch.nn.functional as F
 
 from einops import rearrange, repeat
 
-try:
-    from causal_conv1d import causal_conv1d_fn
-except ImportError:
-    causal_conv1d_fn = None
+from ..utils.causal_conv1d import causal_conv1d_fn
 
 try:
     from ..ops.triton.layernorm_gated import RMSNorm as RMSNormGated, LayerNorm

--- a/mamba-ssm/torch-ext/mamba_ssm/modules/mamba_simple.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/modules/mamba_simple.py
@@ -12,10 +12,7 @@ from einops import rearrange, repeat
 
 from ..ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
 
-try:
-    from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
-except ImportError:
-    causal_conv1d_fn, causal_conv1d_update = None, None
+from ..utils.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 try:
     from ..ops.triton.selective_state_update import selective_state_update

--- a/mamba-ssm/torch-ext/mamba_ssm/modules/mha.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/modules/mha.py
@@ -17,10 +17,7 @@ try:
 except ImportError:
     RotaryEmbedding = None
 
-try:
-    from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
-except ImportError:
-    causal_conv1d_fn, causal_conv1d_update = None, None
+from ..utils.causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 
 
 def _update_kv_cache(kv, inference_params, layer_idx):

--- a/mamba-ssm/torch-ext/mamba_ssm/utils/causal_conv1d.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/utils/causal_conv1d.py
@@ -1,0 +1,17 @@
+"""Optional causal-conv1d dependency.
+
+The faster fused short-convolution is provided by the separately-installed
+``causal_conv1d`` package (e.g. ``pip install causal-conv1d``). When it is
+installed we use it; otherwise every symbol degrades to ``None`` and callers
+fall back to the pure-PyTorch / Triton implementations.
+"""
+
+try:
+    from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
+except ImportError:
+    causal_conv1d_fn, causal_conv1d_update = None, None
+
+try:
+    from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states
+except ImportError:
+    causal_conv1d_varlen_states = None


### PR DESCRIPTION
Syncs the `causal-conv1d` CUDA kernels with upstream `v1.6.2.post1`. The main thing this brings is an opt-in **deterministic backward** — set `CAUSAL_CONV1D_DETERMINISTIC=1` (or `torch.use_deterministic_algorithms(True)`) and the bwd accumulates through workspaces instead of atomics, so gradients are reproducible. I kept the kernels-build binding tweaks on top of the upstream sources (`<torch/all.h>`, op registration stays in `torch_binding.cpp`).

Also tidies up `mamba-ssm`: the four modules that optionally use `causal_conv1d` now import it from one small `utils/causal_conv1d.py` helper instead of each repeating the same `try/except`. The helper stays pip-only (use the installed `causal_conv1d`, else `None`) to match how every other kernel here works — composing from the Hub stays the caller's job. A lazy `get_kernel` fallback can be added later, once the updated causal-conv1d is published with a version tag to pin to.

Built and ran against torch 2.12 / cu13 on an sm_86 card — compiles fine and `causal_conv1d_fn` matches a reference conv1d+SiLU exactly.

The bigger mamba-ssm update (full selective-scan port, Mamba-3 / quack / tilelang) is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
