### PR TITLE
rotary: Add rotary for CPU backend

### DIFF
--- a/rotary/build.toml
+++ b/rotary/build.toml
@@ -5,6 +5,7 @@ version = 1
 backends = [
     "cuda",
     "xpu",
+    "cpu",
 ]
 
 
@@ -26,3 +27,35 @@ src = [
 backend = "cuda"
 depends = ["torch"]
 src = ["rotary/rotary_cuda.cu"]
+
+[kernel.rotary_cpu]
+backend = "cpu"
+depends = ["torch"]
+include = ["rotary-cpu"]
+src = [
+    "rotary-cpu/rotary_cpu_torch.cpp",
+    "rotary-cpu/rotary_cpu.cpp",
+    "rotary-cpu/rotary_cpu.hpp",
+    "rotary-cpu/cpu_features.hpp",
+]
+
+[kernel.rotary_cpu_avx512]
+backend = "cpu"
+depends = ["torch"]
+include = ["rotary-cpu"]
+cxx-flags = [
+    "-O3",
+    "-fopenmp",
+    "-mf16c",
+    "-mavx512f",
+    "-mavx512bf16",
+    "-mavx512vl",
+    "-mavx512dq",
+    "-mavx512bw",
+    "-DCPU_CAPABILITY_AVX512",
+    "-DCPU_CAPABILITY=AVX512",
+]
+src = [
+    "rotary-cpu/rotary_avx512.cpp",
+    "rotary-cpu/rotary_avx512.hpp",
+]

--- a/rotary/flake.nix
+++ b/rotary/flake.nix
@@ -8,5 +8,15 @@
     kernel-builder.lib.genKernelFlakeOutputs {
       inherit self;
       path = ./.;
+
+    torchVersions =
+      let
+        # For CPU builds, only x86_64-linux is currently supported.
+        cpuSupported = version: system: !(version ? "cpu") || system == "x86_64-linux";
+      in
+      allVersions:
+      builtins.map (
+        version: version // { systems = builtins.filter (cpuSupported version) version.systems; }
+      ) allVersions;
     };
 }

--- a/rotary/rotary-cpu/cpu_features.hpp
+++ b/rotary/rotary-cpu/cpu_features.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
+
+namespace rotary_cpu {
+
+// Runtime CPU feature detection. Used to pick the AVX512 path only on hardware
+// that actually supports it; otherwise the generic ATen fallback is used.
+class CPUFeatures {
+public:
+  static bool hasAVX512() {
+    static bool supported = checkAVX512();
+    return supported;
+  }
+
+private:
+  static bool checkAVX512() {
+#ifdef _MSC_VER
+    int cpu_info[4];
+    __cpuid(cpu_info, 0);
+    if (cpu_info[0] < 7)
+      return false;
+    __cpuidex(cpu_info, 7, 0);
+    bool avx512f = (cpu_info[1] & (1 << 16)) != 0; // EBX bit 16
+    if (!avx512f)
+      return false;
+    __cpuid(cpu_info, 1);
+    bool osxsave = (cpu_info[2] & (1 << 27)) != 0; // ECX bit 27
+    if (!osxsave)
+      return false;
+    unsigned long long xcr0 = _xgetbv(0);
+    return ((xcr0 & 0xE6ULL) == 0xE6ULL);
+#else
+    unsigned int eax, ebx, ecx, edx;
+    if (__get_cpuid_max(0, nullptr) < 7)
+      return false;
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    bool avx512f = (ebx & (1 << 16)) != 0; // EBX bit 16
+    if (!avx512f)
+      return false;
+    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) == 0)
+      return false;
+    bool osxsave = (ecx & (1 << 27)) != 0; // ECX bit 27
+    if (!osxsave)
+      return false;
+    unsigned int xcr0_lo = 0, xcr0_hi = 0;
+    __asm__ volatile("xgetbv" : "=a"(xcr0_lo), "=d"(xcr0_hi) : "c"(0));
+    unsigned long long xcr0 =
+        ((unsigned long long)xcr0_hi << 32) | xcr0_lo;
+    return ((xcr0 & 0xE6ULL) == 0xE6ULL);
+#endif
+  }
+};
+
+} // namespace rotary_cpu

--- a/rotary/rotary-cpu/rotary_avx512.cpp
+++ b/rotary/rotary-cpu/rotary_avx512.cpp
@@ -1,0 +1,174 @@
+// AVX512 implementation of the rotary embedding op for BF16.
+// Compile with -mavx512f -mavx512vl -mavx512dq -mavx512bw -mf16c
+// -DCPU_CAPABILITY_AVX512 so that at::vec::Vectorized actually lowers to AVX512
+// (otherwise it falls back to the scalar vec_base.h implementation).
+#include "rotary_avx512.hpp"
+
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/cpu/vec/functional.h>
+#include <ATen/Parallel.h>
+#include <algorithm>
+#include <tuple>
+
+using namespace at::vec;
+
+namespace rotary_cpu {
+namespace avx512 {
+
+// Per-row strides (in elements) for a 4-D tensor laid out as
+// (batch, head, seq, rot_dim). The last dim is required to be contiguous so it
+// can be loaded as a vector; the other three dims may have arbitrary strides
+// (e.g. a transposed-then-cloned q/k tensor), so row pointers are computed from
+// (b, h, s) explicitly rather than assuming uniform spacing.
+struct Strides4 {
+  int64_t b, h, s;
+};
+
+// Process rows [r0, r1). Each "row" is one (batch, head, seq) position holding
+// `rot` contiguous BF16 elements. cos/sin are shared across heads, so their
+// pointer is derived from (batch, seq) only.
+//
+// Parallelization is over (batch, seq) positions. cos/sin are shared across the
+// H heads of a position, so they are converted to fp32 once per position and
+// reused for all heads (cutting cos/sin loads + bf16->fp32 conversions by H).
+template <bool Conj>
+static inline void apply_rotary_core(
+    const at::BFloat16 *x1b, const at::BFloat16 *x2b, const at::BFloat16 *cosb,
+    const at::BFloat16 *sinb, at::BFloat16 *o1b, at::BFloat16 *o2b, int64_t p0,
+    int64_t p1, int64_t rot, int64_t H, int64_t S, Strides4 sx1, Strides4 sx2,
+    Strides4 so1, Strides4 so2, int64_t cb, int64_t cs, int64_t sb, int64_t ss) {
+  using Vb = Vectorized<at::BFloat16>;
+  using Vf = Vectorized<float>;
+  constexpr int kVb = Vb::size(); // 32 bf16 lanes = 2 x 16 fp32
+  constexpr int kMaxChunks = 8; // cache cos/sin for rot up to 256
+  const int64_t nfull = rot / kVb;
+  const bool cache = nfull <= kMaxChunks;
+
+  Vf cos0[kMaxChunks], cos1[kMaxChunks], sin0[kMaxChunks], sin1[kMaxChunks];
+
+  for (int64_t p = p0; p < p1; ++p) {
+    const int64_t b = p / S;
+    const int64_t s = p - b * S;
+
+    const at::BFloat16 *cosp = cosb + b * cb + s * cs;
+    const at::BFloat16 *sinp = sinb + b * sb + s * ss;
+
+    // Convert cos/sin once for this (batch, seq) position; reuse over heads.
+    if (cache) {
+      for (int64_t ci = 0; ci < nfull; ++ci) {
+        const int64_t jj = ci * kVb;
+        std::tie(cos0[ci], cos1[ci]) =
+            convert_bfloat16_float(Vb::loadu(cosp + jj));
+        std::tie(sin0[ci], sin1[ci]) =
+            convert_bfloat16_float(Vb::loadu(sinp + jj));
+      }
+    }
+
+    const at::BFloat16 *x1h = x1b + b * sx1.b + s * sx1.s;
+    const at::BFloat16 *x2h = x2b + b * sx2.b + s * sx2.s;
+    at::BFloat16 *o1h = o1b + b * so1.b + s * so1.s;
+    at::BFloat16 *o2h = o2b + b * so2.b + s * so2.s;
+
+    for (int64_t h = 0; h < H; ++h) {
+      const at::BFloat16 *x1p = x1h + h * sx1.h;
+      const at::BFloat16 *x2p = x2h + h * sx2.h;
+      at::BFloat16 *o1p = o1h + h * so1.h;
+      at::BFloat16 *o2p = o2h + h * so2.h;
+
+      int64_t j = 0;
+      for (int64_t ci = 0; ci < nfull; ++ci, j += kVb) {
+        Vb av = Vb::loadu(x1p + j);
+        Vb cv = Vb::loadu(x2p + j);
+
+        Vf a0, a1, c0, c1, co0, co1, si0, si1;
+        std::tie(a0, a1) = convert_bfloat16_float(av);
+        std::tie(c0, c1) = convert_bfloat16_float(cv);
+        if (cache) {
+          co0 = cos0[ci]; co1 = cos1[ci];
+          si0 = sin0[ci]; si1 = sin1[ci];
+        } else {
+          std::tie(co0, co1) = convert_bfloat16_float(Vb::loadu(cosp + j));
+          std::tie(si0, si1) = convert_bfloat16_float(Vb::loadu(sinp + j));
+        }
+
+        Vf o1_0, o1_1, o2_0, o2_1;
+        if constexpr (Conj) {
+          // o1 = a*cos + c*sin ; o2 = c*cos - a*sin
+          o1_0 = fmadd(a0, co0, c0 * si0);
+          o1_1 = fmadd(a1, co1, c1 * si1);
+          o2_0 = fmsub(c0, co0, a0 * si0);
+          o2_1 = fmsub(c1, co1, a1 * si1);
+        } else {
+          // o1 = a*cos - c*sin ; o2 = a*sin + c*cos
+          o1_0 = fmsub(a0, co0, c0 * si0);
+          o1_1 = fmsub(a1, co1, c1 * si1);
+          o2_0 = fmadd(a0, si0, c0 * co0);
+          o2_1 = fmadd(a1, si1, c1 * co1);
+        }
+
+        convert_float_bfloat16(o1_0, o1_1).store(o1p + j);
+        convert_float_bfloat16(o2_0, o2_1).store(o2p + j);
+      }
+
+      for (; j < rot; ++j) {
+        float a = x1p[j];
+        float c = x2p[j];
+        float co = cosp[j];
+        float si = sinp[j];
+        if constexpr (Conj) {
+          o1p[j] = at::BFloat16(a * co + c * si);
+          o2p[j] = at::BFloat16(c * co - a * si);
+        } else {
+          o1p[j] = at::BFloat16(a * co - c * si);
+          o2p[j] = at::BFloat16(a * si + c * co);
+        }
+      }
+    }
+  }
+}
+
+void apply_rotary(const torch::Tensor &x1, const torch::Tensor &x2,
+                  const torch::Tensor &cos, const torch::Tensor &sin,
+                  torch::Tensor &out1, torch::Tensor &out2, bool conj) {
+  const int64_t rot = x1.size(-1);
+  const int64_t S = x1.size(-2);
+  const int64_t H = x1.size(-3);
+  const int64_t B = x1.size(0);
+  const int64_t P = B * S; // number of (batch, seq) positions
+
+  const at::BFloat16 *x1b = x1.data_ptr<at::BFloat16>();
+  const at::BFloat16 *x2b = x2.data_ptr<at::BFloat16>();
+  const at::BFloat16 *cosb = cos.data_ptr<at::BFloat16>();
+  const at::BFloat16 *sinb = sin.data_ptr<at::BFloat16>();
+  at::BFloat16 *o1b = out1.data_ptr<at::BFloat16>();
+  at::BFloat16 *o2b = out2.data_ptr<at::BFloat16>();
+
+  // Full (batch, head, seq) strides so any layout works (e.g. transposed q/k).
+  const Strides4 sx1{x1.stride(0), x1.stride(1), x1.stride(2)};
+  const Strides4 sx2{x2.stride(0), x2.stride(1), x2.stride(2)};
+  const Strides4 so1{out1.stride(0), out1.stride(1), out1.stride(2)};
+  const Strides4 so2{out2.stride(0), out2.stride(1), out2.stride(2)};
+  // cos/sin are (batch, 1, seq, rot) broadcast over heads.
+  const int64_t cb = cos.stride(0), cs = cos.stride(2);
+  const int64_t sb = sin.stride(0), ss = sin.stride(2);
+
+  const int64_t num_threads = at::get_num_threads();
+  // Each position does H heads * rot elements of work.
+  const int64_t pos_per_grain =
+      std::max<int64_t>(1, 8192 / std::max<int64_t>(H * rot, 1));
+  const int64_t grain_size =
+      std::max<int64_t>(pos_per_grain, P / std::max<int64_t>(num_threads, 1));
+
+  at::parallel_for(0, P, grain_size, [&](int64_t begin, int64_t end) {
+    if (conj) {
+      apply_rotary_core<true>(x1b, x2b, cosb, sinb, o1b, o2b, begin, end, rot, H,
+                              S, sx1, sx2, so1, so2, cb, cs, sb, ss);
+    } else {
+      apply_rotary_core<false>(x1b, x2b, cosb, sinb, o1b, o2b, begin, end, rot,
+                               H, S, sx1, sx2, so1, so2, cb, cs, sb, ss);
+    }
+  });
+}
+
+} // namespace avx512
+} // namespace rotary_cpu

--- a/rotary/rotary-cpu/rotary_avx512.hpp
+++ b/rotary/rotary-cpu/rotary_avx512.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <torch/all.h>
+
+namespace rotary_cpu {
+namespace avx512 {
+
+// Optimized rotary embedding for BF16 on AVX512 CPUs.
+//
+// Requires:
+//   * x1, x2, cos, sin, out1, out2 are BF16
+//   * all tensors are 4-D (batch, heads, seq, rot_dim) with a contiguous last
+//     dim and uniform row spacing (slices of a contiguous parent are fine)
+//   * cos/sin broadcast over the head dimension (size(1) == 1)
+//
+// out1/out2 may alias x1/x2.
+void apply_rotary(const torch::Tensor &x1, const torch::Tensor &x2,
+                  const torch::Tensor &cos, const torch::Tensor &sin,
+                  torch::Tensor &out1, torch::Tensor &out2, bool conj);
+
+} // namespace avx512
+} // namespace rotary_cpu

--- a/rotary/rotary-cpu/rotary_cpu.cpp
+++ b/rotary/rotary-cpu/rotary_cpu.cpp
@@ -1,0 +1,52 @@
+#include "rotary_cpu.hpp"
+#include "cpu_features.hpp"
+#include "rotary_avx512.hpp"
+
+#include <ATen/ATen.h>
+
+namespace rotary_cpu {
+
+void apply_rotary(const torch::Tensor &x1, const torch::Tensor &x2,
+                  const torch::Tensor &cos, const torch::Tensor &sin,
+                  torch::Tensor &out1, torch::Tensor &out2, bool conj) {
+  const int64_t rot = x1.size(-1);
+
+  // Fast path: contiguous-last-dim BF16, 4-D (batch, heads, seq, rot) tensors
+  // with cos/sin broadcast over the head dimension, on an AVX512 CPU.
+  const bool last_dim_contig =
+      x1.stride(-1) == 1 && x2.stride(-1) == 1 && cos.stride(-1) == 1 &&
+      sin.stride(-1) == 1 && out1.stride(-1) == 1 && out2.stride(-1) == 1;
+
+  const bool all_bf16 =
+      x1.scalar_type() == at::kBFloat16 && x2.scalar_type() == at::kBFloat16 &&
+      cos.scalar_type() == at::kBFloat16 && sin.scalar_type() == at::kBFloat16 &&
+      out1.scalar_type() == at::kBFloat16 && out2.scalar_type() == at::kBFloat16;
+
+  const bool shape_ok =
+      x1.dim() == 4 && cos.dim() == 4 && cos.size(-3) == 1 && sin.size(-3) == 1;
+
+  if (all_bf16 && last_dim_contig && shape_ok && CPUFeatures::hasAVX512()) {
+    avx512::apply_rotary(x1, x2, cos, sin, out1, out2, conj);
+    return;
+  }
+
+  // Generic ATen fallback: any dtype/layout on any CPU. Arithmetic in fp32,
+  // results computed into fresh tensors so in-place aliasing (out1==x1) is safe.
+  auto x1f = x1.to(at::kFloat);
+  auto x2f = x2.to(at::kFloat);
+  auto cosf = cos.to(at::kFloat);
+  auto sinf = sin.to(at::kFloat);
+
+  torch::Tensor o1, o2;
+  if (conj) {
+    o1 = x1f * cosf + x2f * sinf;
+    o2 = x2f * cosf - x1f * sinf;
+  } else {
+    o1 = x1f * cosf - x2f * sinf;
+    o2 = x1f * sinf + x2f * cosf;
+  }
+  out1.copy_(o1);
+  out2.copy_(o2);
+}
+
+} // namespace rotary_cpu

--- a/rotary/rotary-cpu/rotary_cpu.hpp
+++ b/rotary/rotary-cpu/rotary_cpu.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <torch/all.h>
+
+namespace rotary_cpu {
+
+// Dispatcher for the rotary embedding op on CPU.
+//
+// Computes, for non-conjugated (conj == false):
+//     out1 = x1 * cos - x2 * sin
+//     out2 = x1 * sin + x2 * cos
+// and for conj == true:
+//     out1 =  x1 * cos + x2 * sin
+//     out2 = -x1 * sin + x2 * cos
+// All arithmetic is done in fp32 and rounded back to the tensor dtype, matching
+// the CUDA/XPU kernels. `cos`/`sin` broadcast over the head dimension. `out1`
+// and `out2` may alias `x1`/`x2` (in-place rotation).
+//
+// Selects an AVX512 BF16 path when inputs are contiguous BF16 with cos/sin
+// broadcast over heads on an AVX512 CPU; otherwise uses a generic ATen fallback.
+void apply_rotary(const torch::Tensor &x1, const torch::Tensor &x2,
+                  const torch::Tensor &cos, const torch::Tensor &sin,
+                  torch::Tensor &out1, torch::Tensor &out2, bool conj);
+
+} // namespace rotary_cpu

--- a/rotary/rotary-cpu/rotary_cpu_torch.cpp
+++ b/rotary/rotary-cpu/rotary_cpu_torch.cpp
@@ -1,0 +1,12 @@
+#include <torch/all.h>
+
+#include "rotary_cpu.hpp"
+
+// Global entry point referenced by torch-ext/torch_binding.cpp for the CPU
+// backend. The `apply_rotary` wrapper there validates devices/dtypes/shapes and
+// forwards to this function.
+void _apply_rotary(torch::Tensor const &x1, torch::Tensor const &x2,
+                   torch::Tensor const &cos, torch::Tensor const &sin,
+                   torch::Tensor &out1, torch::Tensor &out2, bool const conj) {
+  rotary_cpu::apply_rotary(x1, x2, cos, sin, out1, out2, conj);
+}

--- a/rotary/torch-ext/torch_binding.cpp
+++ b/rotary/torch-ext/torch_binding.cpp
@@ -8,7 +8,7 @@
 
 #include "registration.h"
 
-#define CHECK_DEVICE(x) TORCH_CHECK(x.device().type() == torch::kCUDA || x.device().type() == torch::kXPU, #x " must be on CUDA or XPU")
+#define CHECK_DEVICE(x) TORCH_CHECK(x.device().type() == torch::kCUDA || x.device().type() == torch::kXPU || x.device().type() == torch::kCPU, #x " must be on CUDA, XPU or CPU")
 #define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
 
 void _apply_rotary(torch::Tensor const &x1, torch::Tensor const &x2,
@@ -48,6 +48,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
     ops.impl("apply_rotary", torch::kCUDA, &apply_rotary);
 #elif defined(XPU_KERNEL)
     ops.impl("apply_rotary", torch::kXPU, &apply_rotary);
+#elif defined(CPU_KERNEL)
+    ops.impl("apply_rotary", torch::kCPU, &apply_rotary);
 #endif
 }
 


### PR DESCRIPTION
## Summary

This PR adds a CPU backend for the `rotary` kernel so that
`apply_rotary` / `apply_rotary_transformers` run natively on CPU (previously only
`cuda` and `xpu` backends existed, and CPU tensors fell back to the eager
`apply_rotary_pos_emb` in transformers).

The implementation follows the same fp32-accumulation semantics as the existing
CUDA/XPU kernels:

```
conj == false:  out1 = x1*cos - x2*sin    out2 = x1*sin + x2*cos
conj == true :  out1 = x1*cos + x2*sin    out2 = x2*cos - x1*sin
```

All arithmetic is done in fp32 and rounded back to the input dtype, so the kernel
is actually *more* accurate than the eager bf16 path (which accumulates in bf16).

## What's added

New `rotary-cpu/` sources plus `build.toml` / `torch_binding.cpp` wiring:

- `cpu_features.hpp` — runtime AVX512 detection (CPUID + XCR0), in its own
  `rotary_cpu` namespace.
- `rotary_cpu.cpp` — dispatcher. Picks the AVX512 path for contiguous-last-dim
  BF16 4-D tensors with `cos`/`sin` broadcast over heads; otherwise a generic
  ATen fp32 fallback that works for any dtype/layout on any CPU.
- `rotary_avx512.cpp` — vectorized BF16 implementation using `at::vec`.
- `rotary_cpu_torch.cpp` — global `_apply_rotary` entry point used by the binding.
- `build.toml` — adds `"cpu"` to `backends` and two CPU `[kernel.*]` sections
  (base + AVX512 with its own `cxx-flags`).
- `torch_binding.cpp` — allows `kCPU` in `CHECK_DEVICE` and registers the
  `torch::kCPU` impl.

The Python wrapper is unchanged: PyTorch dispatches CPU tensors to the new impl
automatically.

## Correctness

Validated against the eager transformers rotary (`rotate_half`) over bf16 / fp16
/ fp32, multiple `head_dim`s (64/96/128), the `conj=true` path, and both
contiguous and transposed (real-attention-layout) `q`/`k`. Using an fp32 ground
truth, the kernel's error is consistently *below* the eager-bf16 error, confirming
the fp32 accumulation is a small accuracy win on top of the speedup.

## Performance

Element-wise / memory-bound op. Measured against the eager baseline on a single
NUMA node (Intel Xeon 6, bf16, 32 threads, `torch.utils.benchmark` median),
Qwen2.5-0.5B rotary shapes (14 q-heads / 2 kv-heads / head_dim 64):

| case               | speedup |
|--------------------|---------|
| decode bs1         | ~1.8x   |
| decode bs16        | ~2.3x   |
| decode bs64        | ~1.9x   |
| prefill bs1 s512   | ~2.3x   |
| prefill bs1 s2048  | ~5.7x   |
| prefill bs8 s512   | ~3.9x   |

End-to-end (Qwen2.5-0.5B) the change is small but consistently positive
(~4–6% decode, ~10% large-batch prefill), as expected: rotary is a tiny fraction
of per-token cost, which is dominated by matmuls.

## How the `cpu-kernels` skill was used

I followed the skill's two-phase workflow:

- **Phase 1 (correctness):** generic ATen fp32 fallback first, then the AVX512
  tier in its own translation unit with its own `cxx-flags`, using the required
  `cpu_features.hpp` runtime-dispatch pattern and `at::vec::Vectorized` with
  `-DCPU_CAPABILITY_AVX512` so the BF16 conversions actually lower to AVX512
  (rather than silently falling back to the scalar `vec_base.h` path).
- **Phase 2 (performance):** starting from a correct AVX512 kernel, I profiled
  via the roofline lens the skill recommends (this op is memory-bound) and then,
  following the decision tree's "prefer a structural change over knob-sweeping"
  guidance, restructured the parallel loop from per-`(batch, head, seq)` rows to
  per-`(batch, seq)` positions with `cos`/`sin` converted once and reused across
  all heads. Because `cos`/`sin` broadcast over heads, this removes redundant
  loads + bf16→fp32 conversions and was the main win on the bandwidth-bound
  prefill cases (e.g. `bs1 s2048` 3.8x → 5.7x). A follow-up FMA trial was neutral
  (the compiler already contracted to FMA) and kept only for robustness.

> Test harnesses live outside this repo; only kernel sources, `build.toml`, and
> `torch_binding.cpp` are changed here.
