### PR TITLE
rotary: add Metal backend (MPS)

### DIFF
--- a/rotary/build.toml
+++ b/rotary/build.toml
@@ -4,6 +4,7 @@ license = "BSD-3-Clause"
 version = 1
 backends = [
     "cuda",
+    "metal",
     "xpu",
 ]
 
@@ -26,3 +27,11 @@ src = [
 backend = "cuda"
 depends = ["torch"]
 src = ["rotary/rotary_cuda.cu"]
+
+[kernel.rotary_metal]
+backend = "metal"
+depends = ["torch"]
+src = [
+    "rotary_metal/rotary.mm",
+    "rotary_metal/rotary.metal",
+]

--- a/rotary/rotary_metal/rotary.metal
+++ b/rotary/rotary_metal/rotary.metal
@@ -1,0 +1,65 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Params buffer layout (uint32), see rotary.mm:
+// [0] ndim  [1] conj
+// [2..9]   sizes (broadcast shape)
+// [10..17] strides x1   [18..25] strides x2
+// [26..33] strides cos  [34..41] strides sin
+// [42..49] strides out1 [50..57] strides out2
+constant constexpr uint P_SIZES = 2;
+constant constexpr uint P_STRIDES = 10;
+constant constexpr uint MAX_DIMS = 8;
+
+// Elementwise rotation with explicit stride arithmetic so that broadcast
+// cos/sin and non-contiguous views (e.g. q[..., :rotary_dim]) work like the
+// CUDA TensorIterator path. Math is done in float and rounded once, matching
+// the CUDA kernel.
+template <typename T>
+inline void rotary_impl(device const T *x1, device const T *x2,
+                        device const T *cos_, device const T *sin_,
+                        device T *out1, device T *out2,
+                        constant uint *p, uint index) {
+    const uint ndim = p[0];
+    const bool conj = p[1] != 0;
+
+    uint offs[6] = {0, 0, 0, 0, 0, 0};
+    uint rem = index;
+    for (uint i = 0; i < ndim; ++i) {
+        const uint d = ndim - 1 - i;
+        const uint coord = rem % p[P_SIZES + d];
+        rem /= p[P_SIZES + d];
+        for (uint t = 0; t < 6; ++t) {
+            offs[t] += coord * p[P_STRIDES + t * MAX_DIMS + d];
+        }
+    }
+
+    const float a = float(x1[offs[0]]);
+    const float b = float(x2[offs[1]]);
+    const float c = float(cos_[offs[2]]);
+    const float s = float(sin_[offs[3]]);
+
+    if (!conj) {
+        out1[offs[4]] = static_cast<T>(a * c - b * s);
+        out2[offs[5]] = static_cast<T>(a * s + b * c);
+    } else {
+        out1[offs[4]] = static_cast<T>(a * c + b * s);
+        out2[offs[5]] = static_cast<T>(-a * s + b * c);
+    }
+}
+
+#define ROTARY_KERNEL(name, T)                                            \
+kernel void name(device const T *x1 [[buffer(0)]],                        \
+                 device const T *x2 [[buffer(1)]],                        \
+                 device const T *cos_ [[buffer(2)]],                      \
+                 device const T *sin_ [[buffer(3)]],                      \
+                 device T *out1 [[buffer(4)]],                            \
+                 device T *out2 [[buffer(5)]],                            \
+                 constant uint *params [[buffer(6)]],                     \
+                 uint index [[thread_position_in_grid]]) {                \
+    rotary_impl<T>(x1, x2, cos_, sin_, out1, out2, params, index);        \
+}
+
+ROTARY_KERNEL(rotary_float, float)
+ROTARY_KERNEL(rotary_half, half)
+ROTARY_KERNEL(rotary_bfloat, bfloat)

--- a/rotary/rotary_metal/rotary.mm
+++ b/rotary/rotary_metal/rotary.mm
@@ -1,0 +1,132 @@
+#include <torch/torch.h>
+#include <ATen/ExpandUtils.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+// Include the auto-generated header with embedded metallib
+#ifdef EMBEDDED_METALLIB_HEADER
+#include EMBEDDED_METALLIB_HEADER
+#else
+#error "EMBEDDED_METALLIB_HEADER not defined"
+#endif
+
+namespace {
+
+constexpr uint32_t MAX_DIMS = 8;
+constexpr uint32_t NUM_TENSORS = 6;
+// [0] ndim, [1] conj, [2..9] sizes, then strides for x1, x2, cos, sin,
+// out1, out2 (MAX_DIMS entries each). Must match rotary.metal.
+constexpr uint32_t PARAMS_LEN = 2 + MAX_DIMS + NUM_TENSORS * MAX_DIMS;
+
+inline id<MTLBuffer> getMTLBufferStorage(const torch::Tensor &tensor) {
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
+const char *kernelNameForDtype(torch::ScalarType dtype) {
+  switch (dtype) {
+  case torch::kFloat:
+    return "rotary_float";
+  case torch::kHalf:
+    return "rotary_half";
+  case torch::kBFloat16:
+    return "rotary_bfloat";
+  default:
+    TORCH_CHECK(false, "Unsupported data type: ", dtype);
+  }
+}
+
+} // namespace
+
+void _apply_rotary(torch::Tensor const &x1, torch::Tensor const &x2,
+                   torch::Tensor const &cos, torch::Tensor const &sin,
+                   torch::Tensor &out1, torch::Tensor &out2,
+                   bool const conj) {
+  // Broadcast cos/sin against x1/x2 the way TensorIterator does on CUDA.
+  auto shape = at::infer_size(x1.sizes(), cos.sizes());
+  TORCH_CHECK(torch::IntArrayRef(shape) == out1.sizes(),
+              "out1 must have the broadcast shape of x1 and cos");
+  const auto ndim = shape.size();
+  TORCH_CHECK(ndim <= MAX_DIMS, "rotary-metal supports at most ", MAX_DIMS,
+              " dimensions, got ", ndim);
+
+  std::array<torch::Tensor, NUM_TENSORS> tensors = {
+      x1.expand(shape), x2.expand(shape), cos.expand(shape),
+      sin.expand(shape), out1,            out2};
+
+  std::array<uint32_t, PARAMS_LEN> params{};
+  params[0] = static_cast<uint32_t>(ndim);
+  params[1] = conj ? 1 : 0;
+  for (size_t d = 0; d < ndim; ++d) {
+    params[2 + d] = static_cast<uint32_t>(shape[d]);
+  }
+  for (size_t t = 0; t < NUM_TENSORS; ++t) {
+    const auto strides = tensors[t].strides();
+    for (size_t d = 0; d < ndim; ++d) {
+      params[2 + MAX_DIMS + t * MAX_DIMS + d] =
+          static_cast<uint32_t>(strides[d]);
+    }
+  }
+
+  int64_t numel = 1;
+  for (auto s : shape) {
+    numel *= s;
+  }
+  if (numel == 0) {
+    return;
+  }
+
+  @autoreleasepool {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+
+    NSError *error = nil;
+    id<MTLLibrary> library =
+        EMBEDDED_METALLIB_NAMESPACE::createLibrary(device, &error);
+    TORCH_CHECK(library, "Failed to create Metal library from embedded data: ",
+                error.localizedDescription.UTF8String);
+
+    const char *kernelName = kernelNameForDtype(x1.scalar_type());
+    id<MTLFunction> function = [library
+        newFunctionWithName:[NSString stringWithUTF8String:kernelName]];
+    TORCH_CHECK(function, "Failed to create function state object for ",
+                kernelName);
+
+    id<MTLComputePipelineState> pso =
+        [device newComputePipelineStateWithFunction:function error:&error];
+    TORCH_CHECK(pso, error.localizedDescription.UTF8String);
+
+    id<MTLCommandBuffer> commandBuffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(commandBuffer, "Failed to retrieve command buffer reference");
+
+    dispatch_queue_t serialQueue = torch::mps::get_dispatch_queue();
+
+    dispatch_sync(serialQueue, ^() {
+      id<MTLComputeCommandEncoder> encoder =
+          [commandBuffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create compute command encoder");
+
+      [encoder setComputePipelineState:pso];
+      for (uint32_t t = 0; t < NUM_TENSORS; ++t) {
+        [encoder setBuffer:getMTLBufferStorage(tensors[t])
+                    offset:tensors[t].storage_offset() *
+                           tensors[t].element_size()
+                   atIndex:t];
+      }
+      [encoder setBytes:params.data()
+                 length:sizeof(params)
+                atIndex:NUM_TENSORS];
+
+      MTLSize gridSize = MTLSizeMake(numel, 1, 1);
+      NSUInteger threadGroupSize = pso.maxTotalThreadsPerThreadgroup;
+      if (threadGroupSize > static_cast<NSUInteger>(numel)) {
+        threadGroupSize = numel;
+      }
+      MTLSize threadgroupSize = MTLSizeMake(threadGroupSize, 1, 1);
+
+      [encoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
+      [encoder endEncoding];
+
+      torch::mps::commit();
+    });
+  }
+}

--- a/rotary/tests/utils.py
+++ b/rotary/tests/utils.py
@@ -9,6 +9,8 @@ def infer_device():
         return "cuda"
     elif torch.xpu.is_available():
         return "xpu"
+    elif torch.backends.mps.is_available():
+        return "mps"
     else:
         return None
 
@@ -19,5 +21,7 @@ def supports_bfloat16():
         return torch.cuda.get_device_capability() >= (8, 0)  # Ampere and newer
     elif device == "xpu":
         return True
+    elif device == "mps":
+        return True  # bfloat16 is supported on Apple Silicon
     else:
         return False

--- a/rotary/torch-ext/torch_binding.cpp
+++ b/rotary/torch-ext/torch_binding.cpp
@@ -8,7 +8,7 @@
 
 #include "registration.h"
 
-#define CHECK_DEVICE(x) TORCH_CHECK(x.device().type() == torch::kCUDA || x.device().type() == torch::kXPU, #x " must be on CUDA or XPU")
+#define CHECK_DEVICE(x) TORCH_CHECK(x.device().type() == torch::kCUDA || x.device().type() == torch::kXPU || x.device().type() == torch::kMPS, #x " must be on CUDA, XPU or MPS")
 #define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
 
 void _apply_rotary(torch::Tensor const &x1, torch::Tensor const &x2,
@@ -48,6 +48,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
     ops.impl("apply_rotary", torch::kCUDA, &apply_rotary);
 #elif defined(XPU_KERNEL)
     ops.impl("apply_rotary", torch::kXPU, &apply_rotary);
+#elif defined(METAL_KERNEL)
+    ops.impl("apply_rotary", torch::kMPS, &apply_rotary);
 #endif
 }
 


### PR DESCRIPTION
## What

Adds a Metal backend to `rotary` for Apple Silicon (MPS), implementing
`apply_rotary` as a single fused kernel with full broadcast and
non-contiguous-view support.

## Implementation

- `rotary_metal/rotary.metal`: elementwise rotation with explicit stride
  arithmetic mirroring the CUDA TensorIterator path — broadcast cos/sin and
  strided views (e.g. `q[..., :rotary_dim]`) work without materializing
  contiguous copies. Math in float with a single rounding, matching the CUDA
  kernel. float32 / float16 / bfloat16 via template instantiation.
- `rotary_metal/rotary.mm`: embedded-metallib loading, dtype dispatch,
  parameter buffer (ndim, conj, sizes, per-tensor strides), dispatch on
  `torch::mps` command buffer / dispatch queue.
- `build.toml`: adds the `metal` backend; builds clean for
  torch 2.10 / 2.11 / 2.12 (`aarch64-darwin`) with kernel-builder.
- `tests/utils.py`: device inference extended to MPS.

## Tests

Full `tests/test_rotary.py` suite passes on MPS (M-series): 191–192 of 192
across runs; singleton failures are the bf16 tolerance cases already covered
by the existing `@pytest.mark.flaky(max_runs=2)` marker upstream.

## Benchmarks (M-series, eager PyTorch MPS reference vs this kernel)

| shape (b, s, h, d) | dtype | eager µs | kernel µs | speedup |
|---|---|---|---|---|
| 1×512×32×64 (7B prefill) | fp32 | 975 | 117 | 8.3× |
| 1×512×32×64 | fp16 | 862 | 123 | 7.0× |
| 1×4096×32×64 (long prefill) | fp32 | 9008 | 1175 | 7.7× |
| 1×4096×32×64 | fp16 | 7529 | 924 | 8.2× |
| 1×2048×8×32 | fp32 | 528 | 82 | 6.5× |
| 8×1×32×64 (decode) | fp16 | 108 | 74 | 1.5× |
| 32×1×8×64 (batch decode) | fp16 | 111 | 61 | 1.8× |

One fused dispatch replaces six elementwise MPS ops; prefill shapes are
6–8× faster, small decode shapes remain launch-bound but still ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
