### PR TITLE
ci: correctly handle the case when there is nothing to sign

### DIFF
--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -175,9 +175,9 @@ jobs:
         env:
           KERNEL: ${{ steps.validate.outputs.kernel }}
         run: |
-          for metadata_file in "$KERNEL"/build/*/metadata.json; do
+          while IFS= read -r metadata_file; do
             cosign sign-blob "$metadata_file" --bundle "${metadata_file}.sigstore" --yes
-          done
+          done < <(find "$KERNEL/build" -mindepth 2 -maxdepth 2 -name "metadata.json")
 
       # Upload built artifacts to both model and kernel Hub repos.
       - name: Upload kernel to Hub

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,9 +226,9 @@ jobs:
         if: inputs.mode != 'pr'
         run: |
           KERNEL="${{ needs.setup.outputs.kernel }}"
-          for metadata_file in "$KERNEL"/build/*/metadata.json; do
+          while IFS= read -r metadata_file; do
             cosign sign-blob "$metadata_file" --bundle "${metadata_file}.sigstore" --yes
-          done
+          done < <(find "$KERNEL/build" -mindepth 2 -maxdepth 2 -name "metadata.json")
 
       # Upload built artifacts to both model and kernel Hub repos.
       - name: Upload kernel to Hub


### PR DESCRIPTION
E.g. when a workflow does not result in any builds.

Fixes #971.