### PR TITLE
aiter-rope/aiter-kernels: sync apply_rotary_transformers signature with rotary

### DIFF
--- a/aiter-kernels/build.toml
+++ b/aiter-kernels/build.toml
@@ -1,6 +1,6 @@
 [general]
 name = "aiter-kernels"
-version = 1
+version = 2
 license = "MIT"
 backends = ["rocm"]
 

--- a/aiter-kernels/torch-ext/aiter_kernels/rope/__init__.py
+++ b/aiter-kernels/torch-ext/aiter_kernels/rope/__init__.py
@@ -30,7 +30,7 @@ def _to_bhsd(t: torch.Tensor) -> torch.Tensor:
     return t.permute(1, 2, 0, 3)
 
 
-def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+def apply_rotary_transformers(q, k, cos, sin, unsqueeze_dim=1):
     """Apply NEOX-style RoPE to ``q`` and ``k``.
 
     Drop-in replacement for ``kernels-community/rotary``'s
@@ -40,8 +40,8 @@ def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1
     Args:
         q, k: ``(batch, heads, seq, head_dim)``.
         cos, sin: ``(batch, seq, head_dim // 2)`` — pre-``unsqueeze`` form.
-        position_ids, unsqueeze_dim: accepted for API parity; the kernel reads
-            positions from the already-computed ``cos`` / ``sin``.
+        unsqueeze_dim: accepted for API parity; the kernel reads positions from
+            the already-computed ``cos`` / ``sin``.
 
     Returns:
         ``(q_embed, k_embed)`` in the same shape as ``q``, ``k``.
@@ -61,6 +61,10 @@ def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1
     k_out_sbhd = rope_cached_fwd(k_sbhd, cos_freqs, sin_freqs, **common)
 
     return _to_bhsd(q_out_sbhd), _to_bhsd(k_out_sbhd)
+
+
+# Add torch compile support for functions
+apply_rotary_transformers.can_torch_compile = True
 
 
 __all__ = [

--- a/aiter-rope/README.md
+++ b/aiter-rope/README.md
@@ -18,7 +18,7 @@ Original code: https://github.com/ROCm/aiter (MIT, © Advanced Micro Devices, In
 
 ## Functions
 
-### `apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1)`
+### `apply_rotary_transformers(q, k, cos, sin, unsqueeze_dim=1)`
 
 Apply NEOX-style RoPE to query and key tensors.
 

--- a/aiter-rope/build.toml
+++ b/aiter-rope/build.toml
@@ -1,6 +1,6 @@
 [general]
 name = "aiter-rope"
-version = 1
+version = 2
 license = "MIT"
 backends = ["rocm"]
 

--- a/aiter-rope/torch-ext/aiter_rope/__init__.py
+++ b/aiter-rope/torch-ext/aiter_rope/__init__.py
@@ -32,7 +32,7 @@ def _to_bhsd(t: torch.Tensor) -> torch.Tensor:
     return t.permute(1, 2, 0, 3)
 
 
-def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+def apply_rotary_transformers(q, k, cos, sin, unsqueeze_dim=1):
     """Apply NEOX-style RoPE to ``q`` and ``k``.
 
     Signature mirrors ``kernels-community/rotary``'s ``apply_rotary_transformers``
@@ -42,8 +42,8 @@ def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1
     Args:
         q, k: ``(batch, heads, seq, head_dim)``.
         cos, sin: ``(batch, seq, head_dim // 2)`` — pre-``unsqueeze`` form.
-        position_ids, unsqueeze_dim: accepted for API parity; the kernel reads
-            positions from the already-computed ``cos`` / ``sin``.
+        unsqueeze_dim: accepted for API parity; the kernel reads positions from
+            the already-computed ``cos`` / ``sin``.
 
     Returns:
         ``(q_embed, k_embed)`` in the same shape as ``q``, ``k``.
@@ -66,6 +66,10 @@ def apply_rotary_transformers(q, k, cos, sin, position_ids=None, unsqueeze_dim=1
     k_out_sbhd = rope_cached_fwd(k_sbhd, cos_freqs, sin_freqs, **common)
 
     return _to_bhsd(q_out_sbhd), _to_bhsd(k_out_sbhd)
+
+
+# Add torch compile support for functions
+apply_rotary_transformers.can_torch_compile = True
 
 
 __all__ = [


### PR DESCRIPTION
The `rotary` kernel's `apply_rotary_transformers` dropped the `position_ids` parameter (#242) and gained `can_torch_compile = True` (#907). The `aiter-rope` and `aiter-kernels` shims are meant to be drop-in replacements under the `"rocm"` entry of transformers' `_KERNEL_MAPPING["rotary_pos_emb"]`, but both still carried the old signature.

Updates both shims to `(q, k, cos, sin, unsqueeze_dim=1)`, sets `can_torch_compile = True`.