### PR TITLE
ci: improve signature verification

### DIFF
--- a/.github/scripts/verify-signatures.sh
+++ b/.github/scripts/verify-signatures.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KERNELS=$(find . -maxdepth 2 -name "build.toml" -exec dirname {} \; | sed 's|^\./||' | sort)
+
+FAILED_LIST=/tmp/verify-failed
+: > "$FAILED_LIST"
+
+{
+  for kernel in $KERNELS; do
+    echo "::group::$kernel"
+
+    VERSION=$(awk -F'[[:space:]]*=[[:space:]]*' '/^version/ {print $2; exit}' "$kernel/build.toml")
+
+    # Continue on failure to verify all kernels before reporting.
+    if ! nix run -L github:huggingface/kernels#kernels -- \
+      verify-signature --all-variants "kernels-community/$kernel" "$VERSION"; then
+      echo "::warning::$kernel verification FAILED"
+      echo "$kernel" >> "$FAILED_LIST"
+    fi
+
+    # Remove the HF cache to reclaim disk space before the next kernel.
+    rm -rf ~/.cache/huggingface/hub
+
+    echo "::endgroup::"
+  done
+
+  FAILURES=$(wc -l < "$FAILED_LIST" | tr -d '[:space:]')
+  echo ""
+  if [ "$FAILURES" -ne 0 ]; then
+    echo "❌ Verification failed for $FAILURES kernel(s):"
+    sed 's/^/  - /' "$FAILED_LIST"
+    echo ""
+    echo "See the corresponding groups above for details."
+  else
+    echo "✅ All kernels verified successfully."
+  fi
+} 2>&1 | tee /tmp/verify-output.log
+
+[ -s "$FAILED_LIST" ] && exit 1 || exit 0

--- a/.github/workflows/verify-signatures.yaml
+++ b/.github/workflows/verify-signatures.yaml
@@ -34,44 +34,7 @@ jobs:
       - name: Verify all kernels
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          KERNELS=$(find . -maxdepth 2 -name "build.toml" -exec dirname {} \; | sed 's|^\./||' | sort)
-
-          FAILED_LIST=/tmp/verify-failed
-          : > "$FAILED_LIST"
-
-          {
-            for kernel in $KERNELS; do
-              echo "::group::$kernel"
-
-              VERSION=$(awk -F'[[:space:]]*=[[:space:]]*' '/^version/ {print $2; exit}' "$kernel/build.toml")
-
-              # Continue on failure to verify all kernels before reporting.
-              if ! nix run -L github:huggingface/kernels#kernels -- \
-                verify-signature --all-variants "kernels-community/$kernel" "$VERSION"; then
-                echo "::warning::$kernel verification FAILED"
-                echo "$kernel" >> "$FAILED_LIST"
-              fi
-
-              # Remove the HF cache to reclaim disk space before the next kernel.
-              rm -rf ~/.cache/huggingface/hub
-
-              echo "::endgroup::"
-            done
-
-            FAILURES=$(wc -l < "$FAILED_LIST" | tr -d '[:space:]')
-            echo ""
-            if [ "$FAILURES" -ne 0 ]; then
-              echo "❌ Verification failed for $FAILURES kernel(s):"
-              sed 's/^/  - /' "$FAILED_LIST"
-              echo ""
-              echo "See the corresponding groups above for details."
-            else
-              echo "✅ All kernels verified successfully."
-            fi
-          } 2>&1 | tee /tmp/verify-output.log
-
-          [ -s "$FAILED_LIST" ] && exit 1 || exit 0
+        run: .github/scripts/verify-signatures.sh
 
       - name: Post results to Slack
         if: always()

--- a/.github/workflows/verify-signatures.yaml
+++ b/.github/workflows/verify-signatures.yaml
@@ -37,21 +37,41 @@ jobs:
         run: |
           KERNELS=$(find . -maxdepth 2 -name "build.toml" -exec dirname {} \; | sed 's|^\./||' | sort)
 
+          FAILED_LIST=/tmp/verify-failed
+          : > "$FAILED_LIST"
+
           {
             for kernel in $KERNELS; do
               echo "::group::$kernel"
 
               VERSION=$(awk -F'[[:space:]]*=[[:space:]]*' '/^version/ {print $2; exit}' "$kernel/build.toml")
 
-              nix run -L github:huggingface/kernels#kernels -- \
-                verify-signature --all-variants "kernels-community/$kernel" "$VERSION"
+              # Continue on failure to verify all kernels before reporting.
+              if ! nix run -L github:huggingface/kernels#kernels -- \
+                verify-signature --all-variants "kernels-community/$kernel" "$VERSION"; then
+                echo "::warning::$kernel verification FAILED"
+                echo "$kernel" >> "$FAILED_LIST"
+              fi
 
               # Remove the HF cache to reclaim disk space before the next kernel.
               rm -rf ~/.cache/huggingface/hub
 
               echo "::endgroup::"
             done
+
+            FAILURES=$(wc -l < "$FAILED_LIST" | tr -d '[:space:]')
+            echo ""
+            if [ "$FAILURES" -ne 0 ]; then
+              echo "❌ Verification failed for $FAILURES kernel(s):"
+              sed 's/^/  - /' "$FAILED_LIST"
+              echo ""
+              echo "See the corresponding groups above for details."
+            else
+              echo "✅ All kernels verified successfully."
+            fi
           } 2>&1 | tee /tmp/verify-output.log
+
+          [ -s "$FAILED_LIST" ] && exit 1 || exit 0
 
       - name: Post results to Slack
         if: always()

--- a/.github/workflows/verify-signatures.yaml
+++ b/.github/workflows/verify-signatures.yaml
@@ -41,8 +41,10 @@ jobs:
             for kernel in $KERNELS; do
               echo "::group::$kernel"
 
+              VERSION=$(awk -F'[[:space:]]*=[[:space:]]*' '/^version/ {print $2; exit}' "$kernel/build.toml")
+
               nix run -L github:huggingface/kernels#kernels -- \
-                verify-signature --all-variants "kernels-community/$kernel"
+                verify-signature --all-variants "kernels-community/$kernel" "$VERSION"
 
               # Remove the HF cache to reclaim disk space before the next kernel.
               rm -rf ~/.cache/huggingface/hub


### PR DESCRIPTION
- Pass kernel version (does not work otherwise).
- Do not fail on verification failure, we want all outputs.
- Move script to a separate file.