### PR TITLE
feat: refactor kernel bot and add tests

### DIFF
--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python3
-"""
-Dispatch build workflows for a kernel.
-
-Four entrypoints call this script:
-  1. The PR-merge dispatch workflow (via CLI)
-  2. The PR-open dispatch workflow (via CLI)
-  3. The comment bot (via import)
-  4. Local CLI invocation
-"""
-
 import argparse
 import json
 import os
@@ -23,27 +12,329 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
-RELEASE_WORKFLOWS = [
-    "build.yaml",
-    "build-mac.yaml",
-    "build-windows.yaml",
-]
+# Configuration
 
-# Dispatched alongside a build when run_security is set (see dispatch_release).
-SECURITY_WORKFLOW = "security-audit.yml"
+WORKFLOWS = {
+    "build": [
+        "build.yaml",
+        "build-mac.yaml",
+        "build-windows.yaml",
+    ],
+    "security": [
+        "security-audit.yml",
+    ],
+}
 
 KERNEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# Workflow file -> its YAML `name:`; must match the context the build reports.
+WORKFLOW_DISPLAY_NAMES = {
+    "build.yaml": "Build",
+    "build-mac.yaml": "Build (macOS)",
+    "build-windows.yaml": "Build (Windows)",
+}
+
+BACKEND_TO_WORKFLOWS = {
+    "cuda": {"build.yaml", "build-windows.yaml"},
+    "cpu": {"build.yaml"},
+    "rocm": {"build.yaml"},
+    "metal": {"build-mac.yaml"},
+    "xpu": {"build.yaml", "build-windows.yaml"},
+}
+
+WORKFLOW_TO_BACKENDS = {
+    workflow: {b for b, wfs in BACKEND_TO_WORKFLOWS.items() if workflow in wfs}
+    for workflow in WORKFLOWS["build"]
+}
+
+WINDOWS_KERNELS = {
+    "relu",
+    "activation",
+    # "flash-attn2",
+}
+
+WINDOWS_SKIP_BACKENDS: dict[str, set[str]] = {
+    "flash-attn2": {"xpu"},  # CUTLASS XPU headers fail on Windows (ushort undefined)
+}
+
+
+# Data types
+
 
 @dataclass
-class ReleaseDispatchResult:
+class DispatchResult:
     kernel_name: str
-    dispatched: list[tuple[str, str]] = field(default_factory=list)  # (workflow, dispatch_key)
-    failed: list[tuple[str, int]] = field(default_factory=list)  # (workflow, http_code)
-    skipped: list[str] = field(default_factory=list)  # workflow filenames
-    # Set when run_security dispatches the security audit (see dispatch_release).
-    security_dispatch_key: str | None = None  # dispatch_key of the audit run
-    security_failed_code: int | None = None  # http_code if the audit dispatch failed
+    dispatched: list[tuple[str, str]] = field(default_factory=list)
+    failed: list[tuple[str, int]] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    security_dispatched: list[tuple[str, str]] = field(default_factory=list)
+    security_failed: list[tuple[str, int]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    dry_run_payloads: list[tuple[str, dict]] = field(default_factory=list)
+
+
+@dataclass
+class PlannedDispatch:
+    kind: str  # "build" or "security"
+    workflow: str
+    dispatch_key: str
+    body: dict
+    description: str
+    status_context: str | None = None  # build only
+
+
+@dataclass
+class DispatchPlan:
+    kernel_name: str
+    head_sha: str = ""
+    actions: list[PlannedDispatch] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+# Reading build.toml and selecting workflows
+
+
+def read_backends(kernel_name: str) -> list[str] | None:
+    build_toml = Path(kernel_name) / "build.toml"
+    if not build_toml.exists():
+        return None
+    with open(build_toml, "rb") as f:
+        config = tomllib.load(f)
+    backends = config.get("general", {}).get("backends")
+    if backends is None:
+        backends = config.get("backends")
+    if isinstance(backends, list):
+        return backends
+    return None
+
+
+def select_workflows(kernel_name: str, *, notes: list[str]) -> set[str]:
+    backends = read_backends(kernel_name)
+    if backends is None:
+        notes.append(
+            f"Could not read backends for {kernel_name}, dispatching all workflows"
+        )
+        return set(WORKFLOWS["build"])
+
+    workflows = set()
+    for b in backends:
+        workflows.update(BACKEND_TO_WORKFLOWS.get(b, set()))
+
+    if not workflows:
+        notes.append(
+            f"No known backends found for {kernel_name}: {backends}, dispatching all workflows"
+        )
+        return set(WORKFLOWS["build"])
+
+    if "build-windows.yaml" in workflows and kernel_name not in WINDOWS_KERNELS:
+        workflows.discard("build-windows.yaml")
+        notes.append(
+            f"Skipping Windows build for {kernel_name} (not in WINDOWS_KERNELS allowlist)"
+        )
+
+    return workflows
+
+
+# Planning
+
+
+def _build_inputs(
+    kernel_name: str,
+    dispatch_key: str,
+    mode: str,
+    backends_csv: str,
+    repo_prefix: str,
+    *,
+    skip_build: bool,
+    pr_number: str,
+    head_sha: str,
+    target_branch: str,
+    upload: bool,
+) -> dict:
+    inputs = {
+        "kernel_name": kernel_name,
+        "dispatch_key": dispatch_key,
+        "mode": mode,
+        "backends": backends_csv,
+        "repo_prefix": repo_prefix,
+    }
+    if skip_build:
+        inputs["skip_build"] = "true"
+    if pr_number:
+        inputs["pr_number"] = pr_number
+    if head_sha:
+        inputs["head_sha"] = head_sha
+    if target_branch:
+        inputs["target_branch"] = target_branch
+    if not upload:
+        inputs["upload"] = "false"
+    return inputs
+
+
+def _plan_security_actions(
+    plan: DispatchPlan,
+    *,
+    ref: str,
+    pr_number: str,
+    head_sha: str,
+    dispatch_key_prefix: str,
+) -> None:
+    for workflow in WORKFLOWS["security"]:
+        dispatch_key = (
+            f"{dispatch_key_prefix}security-{workflow}-{uuid.uuid4().hex[:12]}"
+        )
+        body = {
+            "ref": ref,
+            "inputs": {
+                "pr_number": pr_number,
+                "dispatch_key": dispatch_key,
+                "head_sha": head_sha,
+            },
+        }
+        plan.actions.append(
+            PlannedDispatch(
+                kind="security",
+                workflow=workflow,
+                dispatch_key=dispatch_key,
+                body=body,
+                description=f"for PR #{pr_number} on ref `{ref}`",
+            )
+        )
+
+
+def _windows_scoped_backends(
+    scoped: list[str], kernel_name: str, plan: DispatchPlan
+) -> list[str] | None:
+    skip = WINDOWS_SKIP_BACKENDS.get(kernel_name, set())
+    kept = [b for b in scoped if b not in skip]
+    if dropped := set(scoped) - set(kept):
+        plan.notes.append(f"Skipping backends {dropped} on Windows for {kernel_name}")
+    if not kept:
+        plan.skipped.append("build-windows.yaml")
+        plan.notes.append(
+            f"Skipping build-windows.yaml for {kernel_name} (no backends remaining after filtering)"
+        )
+        return None
+    return kept
+
+
+def _plan_build_actions(
+    plan: DispatchPlan,
+    kernel_name: str,
+    *,
+    ref: str,
+    mode: str,
+    repo_prefix: str,
+    dispatch_key_prefix: str,
+    skip_build: bool,
+    pr_number: str,
+    head_sha: str,
+    target_branch: str,
+    upload: bool,
+) -> None:
+    backends = read_backends(kernel_name) or []
+    workflows = select_workflows(kernel_name, notes=plan.notes)
+    plan.skipped = sorted(set(WORKFLOWS["build"]) - workflows)
+
+    for workflow in sorted(workflows):
+        scoped = sorted(
+            b for b in backends if b in WORKFLOW_TO_BACKENDS.get(workflow, set())
+        )
+        if workflow == "build-windows.yaml":
+            scoped = _windows_scoped_backends(scoped, kernel_name, plan)
+            if scoped is None:
+                continue
+
+        dispatch_key = (
+            f"{dispatch_key_prefix}{kernel_name}-{workflow}-{uuid.uuid4().hex[:12]}"
+        )
+        status_context = (
+            f"{WORKFLOW_DISPLAY_NAMES.get(workflow, workflow)} / {kernel_name}"
+            if head_sha
+            else None
+        )
+        plan.actions.append(
+            PlannedDispatch(
+                kind="build",
+                workflow=workflow,
+                dispatch_key=dispatch_key,
+                body={
+                    "ref": ref,
+                    "inputs": _build_inputs(
+                        kernel_name,
+                        dispatch_key,
+                        mode,
+                        ",".join(scoped),
+                        repo_prefix,
+                        skip_build=skip_build,
+                        pr_number=pr_number,
+                        head_sha=head_sha,
+                        target_branch=target_branch,
+                        upload=upload,
+                    ),
+                },
+                description=f"for kernel `{kernel_name}` on ref `{ref}`",
+                status_context=status_context,
+            )
+        )
+
+
+def plan_dispatch(
+    kernel_name: str = "",
+    *,
+    ref: str = "main",
+    mode: str = "release",
+    repo_prefix: str = "kernels-community",
+    dispatch_key_prefix: str = "",
+    skip_build: bool = False,
+    pr_number: str = "",
+    head_sha: str = "",
+    target_branch: str = "",
+    upload: bool = True,
+    run_security: bool = False,
+    security_only: bool = False,
+) -> DispatchPlan:
+    want_security = run_security or security_only
+    plan = DispatchPlan(kernel_name=kernel_name, head_sha=head_sha)
+
+    if not security_only:
+        _plan_build_actions(
+            plan,
+            kernel_name,
+            ref=ref,
+            mode=mode,
+            repo_prefix=repo_prefix,
+            dispatch_key_prefix=dispatch_key_prefix,
+            skip_build=skip_build,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            target_branch=target_branch,
+            upload=upload,
+        )
+
+    if want_security:
+        if pr_number:
+            _plan_security_actions(
+                plan,
+                ref=ref,
+                pr_number=pr_number,
+                head_sha=head_sha,
+                dispatch_key_prefix=dispatch_key_prefix,
+            )
+        elif security_only:
+            plan.notes.append(
+                "security_only set but no pr_number provided; nothing to do."
+            )
+        else:
+            plan.notes.append(
+                "run_security set but no pr_number provided; skipping security audit."
+            )
+
+    return plan
+
+
+# Execution (performs the GitHub API I/O)
 
 
 def github_api_request(
@@ -68,9 +359,138 @@ def github_api_request(
         return resp.status, resp.read().decode("utf-8")
 
 
+def _blank_result(plan: DispatchPlan) -> DispatchResult:
+    return DispatchResult(
+        kernel_name=plan.kernel_name,
+        skipped=list(plan.skipped),
+        notes=list(plan.notes),
+    )
+
+
+def _set_pending_status(
+    action: PlannedDispatch,
+    result: DispatchResult,
+    *,
+    token: str,
+    api_base: str,
+    head_sha: str,
+) -> None:
+    if not (action.status_context and head_sha):
+        return
+    status_url = f"{api_base}/statuses/{head_sha}"
+    try:
+        github_api_request(
+            status_url,
+            token,
+            method="POST",
+            data={
+                "state": "pending",
+                "description": "Build queued",
+                "context": action.status_context,
+            },
+        )
+    except urllib.error.HTTPError as e:
+        # Non-fatal: the build was dispatched, status is best-effort.
+        result.notes.append(
+            f"Warning: failed to set pending status for {action.status_context}: {e}"
+        )
+
+
+def execute_plan(plan: DispatchPlan, *, token: str, repo: str) -> DispatchResult:
+    result = _blank_result(plan)
+    api_base = f"https://api.github.com/repos/{repo}"
+    for action in plan.actions:
+        url = f"{api_base}/actions/workflows/{action.workflow}/dispatches"
+        try:
+            result.notes.append(f"Dispatching {action.workflow} {action.description}")
+            github_api_request(url, token, method="POST", data=action.body)
+            if action.kind == "security":
+                result.security_dispatched.append(
+                    (action.workflow, action.dispatch_key)
+                )
+            else:
+                result.dispatched.append((action.workflow, action.dispatch_key))
+                _set_pending_status(
+                    action,
+                    result,
+                    token=token,
+                    api_base=api_base,
+                    head_sha=plan.head_sha,
+                )
+        except urllib.error.HTTPError as e:
+            err_text = e.read().decode("utf-8", errors="replace")
+            result.notes.append(
+                f"Failed to dispatch {action.workflow} (HTTP {e.code}): {err_text}"
+            )
+            if action.kind == "security":
+                result.security_failed.append((action.workflow, e.code))
+            else:
+                result.failed.append((action.workflow, e.code))
+    return result
+
+
+def _result_from_plan(plan: DispatchPlan) -> DispatchResult:
+    result = _blank_result(plan)
+    for action in plan.actions:
+        if action.kind == "security":
+            result.security_dispatched.append((action.workflow, action.dispatch_key))
+        else:
+            result.dispatched.append((action.workflow, action.dispatch_key))
+        result.dry_run_payloads.append((action.workflow, action.body))
+    return result
+
+
+# Orchestration
+
+
+def dispatch(
+    kernel_name: str = "",
+    *,
+    token: str,
+    repo: str,
+    ref: str = "main",
+    mode: str = "release",
+    repo_prefix: str = "kernels-community",
+    dispatch_key_prefix: str = "",
+    dry_run: bool = False,
+    skip_build: bool = False,
+    pr_number: str = "",
+    head_sha: str = "",
+    target_branch: str = "",
+    upload: bool = True,
+    run_security: bool = False,
+    security_only: bool = False,
+) -> DispatchResult:
+    if not security_only and (not kernel_name or not KERNEL_NAME_RE.match(kernel_name)):
+        result = DispatchResult(kernel_name=kernel_name)
+        result.notes.append(f"Invalid kernel name: {kernel_name!r}")
+        for wf in WORKFLOWS["build"]:
+            result.failed.append((wf, 0))
+        return result
+
+    plan = plan_dispatch(
+        kernel_name,
+        ref=ref,
+        mode=mode,
+        repo_prefix=repo_prefix,
+        dispatch_key_prefix=dispatch_key_prefix,
+        skip_build=skip_build,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        target_branch=target_branch,
+        upload=upload,
+        run_security=run_security,
+        security_only=security_only,
+    )
+    if dry_run:
+        return _result_from_plan(plan)
+    return execute_plan(plan, token=token, repo=repo)
+
+
+# Command-line interface
+
 
 def get_token() -> str | None:
-    """Resolve GitHub token: env var first, then ``gh auth token`` fallback."""
     token = os.environ.get("GITHUB_TOKEN")
     if token:
         return token
@@ -87,7 +507,6 @@ def get_token() -> str | None:
 
 
 def get_repo() -> str | None:
-    """Resolve repository: GITHUB_REPOSITORY env var, or parse from git remote."""
     repo = os.environ.get("GITHUB_REPOSITORY")
     if repo:
         return repo
@@ -107,362 +526,101 @@ def get_repo() -> str | None:
     return None
 
 
-# Maps workflow filename to the `name:` field in the YAML, used for commit
-# status context strings that must match between pending and final statuses.
-WORKFLOW_DISPLAY_NAMES = {
-    "build.yaml": "Build",
-    "build-mac.yaml": "Build (macOS)",
-    "build-windows.yaml": "Build (Windows)",
-}
-
-BACKEND_TO_WORKFLOWS = {
-    "cuda": {"build.yaml", "build-windows.yaml"},
-    "cpu": {"build.yaml"},
-    "rocm": {"build.yaml"},
-    "metal": {"build-mac.yaml"},
-    "xpu": {"build.yaml", "build-windows.yaml"},
-}
-
-# Only these kernels are known to build successfully on Windows.
-# Add new entries here as Windows support is validated for a kernel.
-WINDOWS_KERNELS = {
-    "relu",
-    "activation",
-    # "flash-attn2",
-}
-
-# Backends to skip on Windows for specific kernels (e.g. due to toolchain issues).
-WINDOWS_SKIP_BACKENDS: dict[str, set[str]] = {
-    "flash-attn2": {"xpu"},  # CUTLASS XPU headers fail on Windows (ushort undefined)
-}
-
-
-def read_backends(kernel_name: str) -> list[str] | None:
-    """Read the backends list from a kernel's build.toml. Returns None if not found."""
-    build_toml = Path(kernel_name) / "build.toml"
-    if not build_toml.exists():
-        return None
-    with open(build_toml, "rb") as f:
-        config = tomllib.load(f)
-    backends = config.get("general", {}).get("backends")
-    if backends is None:
-        backends = config.get("backends")
-    if isinstance(backends, list):
-        return backends
-    return None
-
-
-def select_workflows(kernel_name: str) -> set[str]:
-    """
-    Determine which build workflows to dispatch based on the kernel's
-    backends declared in build.toml.
-
-    Mapping:
-      cuda, cpu, rocm -> build.yaml (Linux)
-      metal           -> build-mac.yaml (macOS)
-      cuda, xpu       -> build-windows.yaml (Windows, allowlisted kernels only)
-
-    Falls back to all workflows if build.toml can't be read.
-    """
-    backends = read_backends(kernel_name)
-    if backends is None:
-        print(f"Could not read backends for {kernel_name}, dispatching all workflows")
-        return set(RELEASE_WORKFLOWS)
-
-    workflows = set()
-    for b in backends:
-        workflows.update(BACKEND_TO_WORKFLOWS.get(b, set()))
-
-    if not workflows:
-        print(f"No known backends found for {kernel_name}: {backends}, dispatching all workflows")
-        return set(RELEASE_WORKFLOWS)
-
-    # Only dispatch Windows builds for kernels known to build there.
-    if "build-windows.yaml" in workflows and kernel_name not in WINDOWS_KERNELS:
-        workflows.discard("build-windows.yaml")
-        print(f"Skipping Windows build for {kernel_name} (not in WINDOWS_KERNELS allowlist)")
-
-    return workflows
-
-
-def dispatch_security_audit(
-    *,
-    token: str,
-    repo: str,
-    ref: str,
-    pr_number: str,
-    head_sha: str = "",
-    dispatch_key_prefix: str = "",
-    dry_run: bool = False,
-) -> str:
-    """
-    Dispatch the security-audit workflow for a PR and return its dispatch_key.
-
-    The workflow definition is always read from ``ref`` (the default branch),
-    while the audit itself checks out the PR head for analysis. Raises
-    ``urllib.error.HTTPError`` if the dispatch request fails.
-    """
-    dispatch_key = f"{dispatch_key_prefix}security-{uuid.uuid4().hex[:12]}"
-    dispatch_body = {
-        "ref": ref,
-        "inputs": {
-            "pr_number": pr_number,
-            "dispatch_key": dispatch_key,
-            "head_sha": head_sha,
-        },
-    }
-    if dry_run:
-        print(f"\n[dry-run] {SECURITY_WORKFLOW}:")
-        print(json.dumps(dispatch_body, indent=2))
-        return dispatch_key
-
-    dispatch_url = (
-        f"https://api.github.com/repos/{repo}"
-        f"/actions/workflows/{SECURITY_WORKFLOW}/dispatches"
-    )
-    print(f"Dispatching {SECURITY_WORKFLOW} for PR #{pr_number} on ref `{ref}`")
-    github_api_request(dispatch_url, token, method="POST", data=dispatch_body)
-    return dispatch_key
-
-
-def dispatch_release(
-    kernel_name: str,
-    *,
-    token: str,
-    repo: str,
-    ref: str = "main",
-    mode: str = "release",
-    repo_prefix: str = "kernels-community",
-    dispatch_key_prefix: str = "",
-    dry_run: bool = False,
-    skip_build: bool = False,
-    pr_number: str = "",
-    head_sha: str = "",
-    target_branch: str = "",
-    upload: bool = True,
-    run_security: bool = False,
-) -> ReleaseDispatchResult:
-    """
-    Dispatch the appropriate build workflows for a kernel.
-
-    Args:
-        kernel_name: Name of the kernel directory.
-        token: GitHub API token.
-        repo: GitHub repository in "owner/repo" format.
-        ref: Git ref to dispatch against (default "main").
-        mode: Build mode - "pr" for CI builds, "release" for full builds.
-        repo_prefix: Hub org prefix for uploads (default "kernels-community").
-        dispatch_key_prefix: Optional prefix for dispatch keys (e.g. "pr42-").
-        dry_run: Print what would be dispatched without actually dispatching.
-        skip_build: Skip build and upload steps.
-        pr_number: Optional PR number to checkout before building.
-        head_sha: Optional PR head SHA for commit status reporting.
-        target_branch: Target branch for upload.
-        upload: Whether to upload after build.
-        run_security: Also dispatch the security-audit workflow for this PR
-            (requires pr_number). The audit runs concurrently with the build;
-            its key/failure are reported via the result's security_* fields.
-
-    Returns:
-        ReleaseDispatchResult with dispatched/failed/skipped lists.
-    """
-    if not KERNEL_NAME_RE.match(kernel_name):
-        print(f"Invalid kernel name: {kernel_name!r}", file=sys.stderr)
-        result = ReleaseDispatchResult(kernel_name=kernel_name)
-        for wf in RELEASE_WORKFLOWS:
-            result.failed.append((wf, 0))
-        return result
-
-    result = ReleaseDispatchResult(kernel_name=kernel_name)
-
-    backends = read_backends(kernel_name) or []
-    workflows = select_workflows(kernel_name)
-
-    # Invert BACKEND_TO_WORKFLOWS so we can scope backends per workflow.
-    workflow_to_backends: dict[str, set[str]] = {}
-    for backend, wfs in BACKEND_TO_WORKFLOWS.items():
-        for wf in wfs:
-            workflow_to_backends.setdefault(wf, set()).add(backend)
-
-    skipped_workflows = set(RELEASE_WORKFLOWS) - workflows
-    result.skipped = sorted(skipped_workflows)
-
-    api_base = f"https://api.github.com/repos/{repo}"
-    for workflow in workflows:
-        # Only pass backends that this workflow can actually build.
-        scoped = sorted(b for b in backends if b in workflow_to_backends.get(workflow, set()))
-
-        # Drop backends known to fail on Windows for this kernel.
-        if workflow == "build-windows.yaml":
-            skip = WINDOWS_SKIP_BACKENDS.get(kernel_name, set())
-            if skip:
-                before = set(scoped)
-                scoped = [b for b in scoped if b not in skip]
-                skipped_backends = before - set(scoped)
-                if skipped_backends:
-                    print(f"Skipping backends {skipped_backends} on Windows for {kernel_name}")
-            if not scoped:
-                result.skipped.append(workflow)
-                print(f"Skipping {workflow} for {kernel_name} (no backends remaining after filtering)")
-                continue
-
-        backends_csv = ",".join(scoped)
-
-        dispatch_key = (
-            f"{dispatch_key_prefix}{kernel_name}-{workflow}-{uuid.uuid4().hex[:12]}"
-        )
-        if dry_run:
-            inputs = {
-                "kernel_name": kernel_name,
-                "dispatch_key": dispatch_key,
-                "mode": mode,
-                "backends": backends_csv,
-                "repo_prefix": repo_prefix,
-            }
-            if skip_build:
-                inputs["skip_build"] = "true"
-            if pr_number:
-                inputs["pr_number"] = pr_number
-            if head_sha:
-                inputs["head_sha"] = head_sha
-            if target_branch:
-                inputs["target_branch"] = target_branch
-            if not upload:
-                inputs["upload"] = "false"
-            dispatch_body = {"ref": ref, "inputs": inputs}
-            print(f"\n[dry-run] {workflow}:")
-            print(json.dumps(dispatch_body, indent=2))
-            result.dispatched.append((workflow, dispatch_key))
-            continue
-        dispatch_url = f"{api_base}/actions/workflows/{workflow}/dispatches"
-        inputs = {
-            "kernel_name": kernel_name,
-            "dispatch_key": dispatch_key,
-            "mode": mode,
-            "backends": backends_csv,
-            "repo_prefix": repo_prefix,
-        }
-        if skip_build:
-            inputs["skip_build"] = "true"
-        if pr_number:
-            inputs["pr_number"] = pr_number
-        if head_sha:
-            inputs["head_sha"] = head_sha
-        if target_branch:
-            inputs["target_branch"] = target_branch
-        if not upload:
-            inputs["upload"] = "false"
-        dispatch_body = {
-            "ref": ref,
-            "inputs": inputs,
-        }
-        try:
-            print(f"Dispatching {workflow} for kernel `{kernel_name}` on ref `{ref}`")
-            github_api_request(dispatch_url, token, method="POST", data=dispatch_body)
-            result.dispatched.append((workflow, dispatch_key))
-
-            # Post a pending commit status so the PR shows the build is in progress.
-            if head_sha:
-                display_name = WORKFLOW_DISPLAY_NAMES.get(workflow, workflow)
-                context = f"{display_name} / {kernel_name}"
-                status_url = f"{api_base}/statuses/{head_sha}"
-                try:
-                    github_api_request(
-                        status_url,
-                        token,
-                        method="POST",
-                        data={
-                            "state": "pending",
-                            "description": "Build queued",
-                            "context": context,
-                        },
-                    )
-                except urllib.error.HTTPError as e:
-                    # Non-fatal: the build was dispatched, status is best-effort.
-                    print(f"Warning: failed to set pending status for {context}: {e}", file=sys.stderr)
-
-        except urllib.error.HTTPError as e:
-            err_text = e.read().decode("utf-8", errors="replace")
-            print(f"Failed to dispatch {workflow} (HTTP {e.code}): {err_text}", file=sys.stderr)
-            result.failed.append((workflow, e.code))
-
-    # Optionally fire the security audit for this PR, concurrently with the build.
-    if run_security:
-        if not pr_number:
-            print(
-                "run_security set but no pr_number provided; skipping security audit.",
-                file=sys.stderr,
-            )
-        else:
-            try:
-                result.security_dispatch_key = dispatch_security_audit(
-                    token=token,
-                    repo=repo,
-                    ref=ref,
-                    pr_number=pr_number,
-                    head_sha=head_sha,
-                    dispatch_key_prefix=dispatch_key_prefix,
-                    dry_run=dry_run,
-                )
-            except urllib.error.HTTPError as e:
-                err_text = e.read().decode("utf-8", errors="replace")
-                print(
-                    f"Failed to dispatch {SECURITY_WORKFLOW} (HTTP {e.code}): {err_text}",
-                    file=sys.stderr,
-                )
-                result.security_failed_code = e.code
-
-    return result
+def format_dry_run_payloads(result: DispatchResult) -> str:
+    lines = []
+    for workflow, body in result.dry_run_payloads:
+        lines.append(f"\n[dry-run] {workflow}:")
+        lines.append(json.dumps(body, indent=2))
+    return "\n".join(lines)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Dispatch release workflows for a kernel"
     )
-    parser.add_argument("kernel_name", help="Kernel directory name")
+    parser.add_argument(
+        "kernel_name",
+        nargs="?",
+        default="",
+        help="Kernel directory name (not required with --security-only)",
+    )
     parser.add_argument(
         "--ref", default="main", help="Git ref to dispatch on (default: main)"
     )
     parser.add_argument(
-        "--mode", default="release", choices=["pr", "release"],
+        "--mode",
+        default="release",
+        choices=["pr", "release"],
         help="Build mode: pr (CI only) or release (build + upload) (default: release)",
     )
     parser.add_argument(
-        "--repo", default=None, help="GitHub repo in owner/repo format (default: auto-detect)"
+        "--repo",
+        default=None,
+        help="GitHub repo in owner/repo format (default: auto-detect)",
     )
     parser.add_argument(
-        "--skip-build", action="store_true",
+        "--skip-build",
+        action="store_true",
         help="Skip build and upload steps (for testing workflow plumbing)",
     )
     parser.add_argument(
-        "--pr-number", default="",
+        "--pr-number",
+        default="",
         help="PR number to checkout before building",
     )
     parser.add_argument(
-        "--head-sha", default="",
+        "--head-sha",
+        default="",
         help="PR head SHA for commit status reporting",
     )
     parser.add_argument(
-        "--target-branch", default="",
+        "--target-branch",
+        default="",
         help="Target branch for upload",
     )
     parser.add_argument(
-        "--no-upload", action="store_true",
+        "--no-upload",
+        action="store_true",
         help="Build only, do not upload",
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Print the dispatch payloads without actually dispatching",
     )
     parser.add_argument(
-        "--repo-prefix", default="kernels-community",
+        "--repo-prefix",
+        default="kernels-community",
         help="Hub org prefix for uploads (default: kernels-community)",
     )
     parser.add_argument(
-        "--security", action="store_true",
+        "--security",
+        action="store_true",
         help="Also dispatch the security-audit workflow for the PR (requires --pr-number)",
     )
+    parser.add_argument(
+        "--security-only",
+        action="store_true",
+        help="Only dispatch the security-audit workflow, skip all builds (requires --pr-number)",
+    )
+    parser.add_argument(
+        "--dispatch-key-prefix",
+        default="",
+        help="Prefix for dispatch keys (the bot uses 'pr<N>-')",
+    )
     args = parser.parse_args()
+
+    if args.security_only:
+        if not args.pr_number:
+            print("Error: --security-only requires --pr-number.", file=sys.stderr)
+            return 1
+
+    if not args.security_only and not args.kernel_name:
+        print(
+            "Error: kernel_name is required (unless using --security-only).",
+            file=sys.stderr,
+        )
+        return 1
 
     common = dict(
         mode=args.mode,
@@ -474,10 +632,12 @@ def main() -> int:
         target_branch=args.target_branch,
         upload=not args.no_upload,
         run_security=args.security,
+        security_only=args.security_only,
+        dispatch_key_prefix=args.dispatch_key_prefix,
     )
 
     if args.dry_run:
-        result = dispatch_release(
+        result = dispatch(
             args.kernel_name,
             token="",
             repo=args.repo or "",
@@ -501,7 +661,7 @@ def main() -> int:
             )
             return 1
 
-        result = dispatch_release(
+        result = dispatch(
             args.kernel_name,
             token=token,
             repo=repo,
@@ -509,25 +669,25 @@ def main() -> int:
             **common,
         )
 
-    if result.dispatched:
-        print(f"\nDispatched ({len(result.dispatched)}):")
-        for wf, dk in result.dispatched:
-            print(f"  - {wf} (key: {dk})")
-    if result.security_dispatch_key:
-        print(f"\nSecurity audit: {SECURITY_WORKFLOW} (key: {result.security_dispatch_key})")
-    if result.security_failed_code is not None:
-        print(f"\nSecurity audit failed: {SECURITY_WORKFLOW} (HTTP {result.security_failed_code})")
-    if result.skipped:
-        print(f"\nSkipped ({len(result.skipped)}):")
-        for wf in result.skipped:
-            print(f"  - {wf}")
-    if result.failed:
-        print(f"\nFailed ({len(result.failed)}):")
-        for wf, code in result.failed:
-            print(f"  - {wf} (HTTP {code})")
-        return 1
+    # Diagnostics to stderr; results (payloads + summary) to stdout.
+    for note in result.notes:
+        print(note, file=sys.stderr)
+    if args.dry_run and result.dry_run_payloads:
+        print(format_dry_run_payloads(result))
 
-    return 0
+    def section(title: str, lines: list[str]) -> None:
+        if lines:
+            print(f"\n{title} ({len(lines)}):")
+            for line in lines:
+                print(f"  - {line}")
+
+    section("Dispatched", [f"{wf} (key: {dk})" for wf, dk in result.dispatched])
+    section("Security", [f"{wf} (key: {dk})" for wf, dk in result.security_dispatched])
+    section("Security failed", [f"{wf} (HTTP {c})" for wf, c in result.security_failed])
+    section("Skipped", result.skipped)
+    section("Failed", [f"{wf} (HTTP {c})" for wf, c in result.failed])
+
+    return 1 if result.failed else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from dataclasses import dataclass, field
 import json
 import os
@@ -8,31 +7,35 @@ import time
 import urllib.parse
 import urllib.error
 import urllib.request
+import uuid
 
 from dispatch import (
-    RELEASE_WORKFLOWS,
-    SECURITY_WORKFLOW,
-    dispatch_release as do_dispatch_release,
+    WORKFLOWS,
+    dispatch,
+    format_dry_run_payloads,
 )
-
 
 KERNEL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
 COMMENT_CHARS_RE = re.compile(r"^/kernel-bot[ A-Za-z0-9_./-]*$")
 COMMAND_PERMISSIONS = {
     "build": {"admin", "write"},
+    "security": {"admin", "write"},
     "security-and-build": {"admin", "write"},
     "build-and-stage": {"admin", "write"},
     "merge-and-upload": {"admin", "write"},
     "release": {"admin"},
 }
+# Commands that operate per-PR and do not require kernel names.
+KERNELLESS_COMMANDS = {"security"}
 MAX_COMMENT_LENGTH = 1024
 RUN_LOOKUP_ATTEMPTS = 10
 RUN_LOOKUP_SLEEP_SECONDS = 2
 RUN_LOOKUP_PAGE_SIZE = 100
 COMMAND_USAGE = (
-    "Invalid command. Use `/kernel-bot <build|security-and-build|build-and-stage|merge-and-upload|release> "
-    "<kernel1> [kernel2 ...] [--branch <target_branch>]`."
+    "Invalid command. Use `/kernel-bot <build|security|security-and-build|build-and-stage|merge-and-upload|release> "
+    "<kernel1> [kernel2 ...] [--branch <target_branch>]`.\n"
+    "The `security` command does not require kernel names."
 )
 
 
@@ -104,7 +107,9 @@ def try_post_issue_comment(api_base: str, token: str, issue_number: int, message
         return False
 
 
-def try_create_issue_comment(api_base: str, token: str, issue_number: int, message: str):
+def try_create_issue_comment(
+    api_base: str, token: str, issue_number: int, message: str
+):
     try:
         return create_issue_comment(api_base, token, issue_number, message)
     except urllib.error.HTTPError as e:
@@ -120,7 +125,10 @@ def try_update_issue_comment(api_base: str, token: str, comment_id: int, message
         return True
     except urllib.error.HTTPError as e:
         err_text = e.read().decode("utf-8", errors="replace")
-        print(f"Failed to update PR comment {comment_id} (HTTP {e.code}).", file=sys.stderr)
+        print(
+            f"Failed to update PR comment {comment_id} (HTTP {e.code}).",
+            file=sys.stderr,
+        )
         print(err_text, file=sys.stderr)
         return False
 
@@ -187,6 +195,19 @@ def list_workflow_runs(
     return parsed.get("workflow_runs", [])
 
 
+def emit_dispatch_diagnostics(result, *, dry_run: bool):
+    for note in result.notes:
+        print(note, file=sys.stderr)
+    if dry_run:
+        payloads = format_dry_run_payloads(result)
+        if payloads:
+            print(payloads)
+
+
+def make_dispatch_key(issue_number: int, kernel_name: str):
+    return f"pr{issue_number}-{kernel_name}-{uuid.uuid4().hex[:12]}"
+
+
 def workflow_run_matches_dispatch(run: dict, dispatch_key: str):
     for field in ("display_title", "name"):
         value = run.get(field)
@@ -220,7 +241,7 @@ def resolve_dispatch_run_urls(
         return
 
     if workflows is None:
-        workflows = RELEASE_WORKFLOWS
+        workflows = WORKFLOWS["build"]
 
     for attempt in range(RUN_LOOKUP_ATTEMPTS):
         for workflow in workflows:
@@ -273,7 +294,9 @@ def format_dispatched_lines(dispatches: list[DispatchResult]):
         if dispatch.action_url:
             lines.append(f"- `{dispatch.kernel_name}`: {dispatch.action_url}")
         else:
-            lines.append(f"- `{dispatch.kernel_name}`: dispatched, but run URL is not available yet")
+            lines.append(
+                f"- `{dispatch.kernel_name}`: dispatched, but run URL is not available yet"
+            )
     return lines
 
 
@@ -293,7 +316,7 @@ def comment_base_lines(
     ]
     if pr_head_sha:
         lines.append(f"PR head SHA: `{pr_head_sha}`")
-    lines.append(f"Workflows: `{', '.join(RELEASE_WORKFLOWS)}`")
+    lines.append(f"Workflows: `{', '.join(WORKFLOWS['build'])}`")
     return lines
 
 
@@ -313,7 +336,8 @@ def format_pending_comment(
         pr_head_sha,
     )
     if include_security:
-        lines.append(f"Security audit: `{SECURITY_WORKFLOW}` (running concurrently)")
+        wf_names = ", ".join(WORKFLOWS["security"])
+        lines.append(f"Security audit: `{wf_names}` (running concurrently)")
     lines.extend(["", "Status: `processing`"])
     return "\n".join(lines)
 
@@ -328,11 +352,13 @@ def format_result_comment(
     dispatches: list[DispatchResult] | None = None,
     failed: list[tuple[str, int]] | None = None,
     failure_message: str | None = None,
-    security_dispatch: DispatchResult | None = None,
-    security_failure: str | None = None,
+    security_dispatches: list[DispatchResult] | None = None,
+    security_failed: list[tuple[str, int]] | None = None,
 ):
     dispatches = dispatches or []
     failed = failed or []
+    security_dispatches = security_dispatches or []
+    security_failed = security_failed or []
     if failure_message is not None or (failed and not dispatches):
         title = "Build request failed."
     else:
@@ -351,18 +377,11 @@ def format_result_comment(
         lines.extend(["", f"Merge result: {merge_result_message}"])
     if dispatches:
         lines.extend(format_dispatched_lines(dispatches))
-    if security_failure:
-        lines.extend(["", f"Security audit: {security_failure}"])
-    elif security_dispatch is not None:
-        if security_dispatch.action_url:
-            lines.extend(["", f"Security audit: {security_dispatch.action_url}"])
-        else:
-            lines.extend(
-                [
-                    "",
-                    f"Security audit: dispatched, but run URL is not available yet (`{SECURITY_WORKFLOW}`).",
-                ]
-            )
+    if security_dispatches:
+        lines.extend(format_dispatched_lines(security_dispatches))
+    if security_failed:
+        failed_text = ", ".join(f"{wf} (HTTP {code})" for wf, code in security_failed)
+        lines.extend(["", f"Security audit failed: `{failed_text}`"])
     if failed:
         failed_text = ", ".join(f"{kernel} (HTTP {code})" for kernel, code in failed)
         lines.extend(["", f"Failed ({len(failed)}): `{failed_text}`"])
@@ -371,16 +390,15 @@ def format_result_comment(
 
 def parse_command(comment: str) -> ParsedCommand:
     tokens = comment.strip().split()
-    if len(tokens) < 3:
+    if len(tokens) < 2:
         return ParsedCommand(error=COMMAND_USAGE)
 
     command = tokens[1]
     if tokens[0] != "/kernel-bot" or command not in COMMAND_PERMISSIONS:
         return ParsedCommand(error=COMMAND_USAGE)
 
-    args = tokens[2:]
-
     branch = None
+    args = tokens[2:]
 
     if "--branch" in args:
         branch_idx = args.index("--branch")
@@ -391,7 +409,7 @@ def parse_command(comment: str) -> ParsedCommand:
         branch = args[branch_idx + 1]
         args = args[:branch_idx]
 
-    if not args:
+    if not args and command not in KERNELLESS_COMMANDS:
         return ParsedCommand(
             error="No kernels provided. Use `/kernel-bot <build|security-and-build|build-and-stage|merge-and-upload> <kernel1> [kernel2 ...]`.",
         )
@@ -450,13 +468,12 @@ def comment_has_only_supported_characters(comment: str):
     return bool(COMMENT_CHARS_RE.fullmatch(comment))
 
 
-def main():
-    token = os.environ.get("GITHUB_TOKEN")
-    repository = os.environ.get("GITHUB_REPOSITORY")
-
+def _resolve_context_from_env():
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
     if not token or not repository:
         print("Missing required environment variables.", file=sys.stderr)
-        return 1
+        return None
 
     comment = os.environ.get("COMMENT_BODY")
     comment_id = parse_numeric_id(os.environ.get("COMMENT_ID"))
@@ -472,35 +489,142 @@ def main():
         or sender_type is None
         or not default_branch
     ):
-        print("Missing required comment context environment variables.", file=sys.stderr)
-        return 1
+        print(
+            "Missing required comment context environment variables.", file=sys.stderr
+        )
+        return None
 
     if sender_type == "Bot":
         print("Ignoring bot comment.")
-        return 0
-
+        return None
     if len(comment) > MAX_COMMENT_LENGTH:
         print("Ignoring oversized comment payload.", file=sys.stderr)
-        return 0
+        return None
     if not comment.strip().startswith("/kernel-bot"):
         print("Ignoring non /kernel-bot comment.")
-        return 0
+        return None
     if not comment_has_only_supported_characters(comment.strip()):
         print("Ignoring /kernel-bot comment with unsupported characters.")
-        return 0
+        return None
+
+    return dict(
+        token=token,
+        repository=repository,
+        comment=comment,
+        comment_id=comment_id,
+        issue_number=issue_number,
+        default_branch=default_branch,
+        commenter=commenter,
+    )
+
+
+def _resolve_context_from_cli():
+    import argparse
+    import subprocess as _sp
+
+    parser = argparse.ArgumentParser(
+        description="Simulate what the comment bot would dispatch for a PR comment"
+    )
+    parser.add_argument(
+        "comment",
+        help='The comment to simulate, e.g. "/kernel-bot security-and-build activation"',
+    )
+    parser.add_argument("--pr-number", required=True, help="PR number")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub repo in owner/repo format (default: auto-detect from git remote)",
+    )
+    parser.add_argument(
+        "--ref",
+        default="main",
+        help="Default branch (default: main)",
+    )
+    parser.add_argument(
+        "--head-sha",
+        default=None,
+        help="PR head SHA (default: fetched via `gh pr view`)",
+    )
+    args = parser.parse_args()
+
+    repository = args.repo
+    if not repository:
+        try:
+            result = _sp.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=5,
+            )
+            match = re.search(r"github\.com[:/](.+?)(?:\.git)?$", result.stdout.strip())
+            if match:
+                repository = match.group(1)
+        except (FileNotFoundError, _sp.CalledProcessError, _sp.TimeoutExpired):
+            pass
+    if not repository:
+        print("Error: Cannot determine repository. Use --repo.", file=sys.stderr)
+        return None
+
+    pr_head_sha = args.head_sha or ""
+    if not pr_head_sha:
+        try:
+            result = _sp.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    args.pr_number,
+                    "--json",
+                    "headRefOid",
+                    "-q",
+                    ".headRefOid",
+                ],
+                stdin=_sp.DEVNULL,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=15,
+            )
+            pr_head_sha = result.stdout.strip()
+        except (FileNotFoundError, _sp.CalledProcessError, _sp.TimeoutExpired) as e:
+            print(f"Warning: could not fetch PR head SHA: {e}", file=sys.stderr)
+
+    return dict(
+        token="",
+        repository=repository,
+        comment=args.comment,
+        comment_id=None,
+        issue_number=int(args.pr_number),
+        default_branch=args.ref,
+        commenter=None,
+        pr_head_sha=pr_head_sha,
+    )
+
+
+def main(*, dry_run: bool = False):
+    # Resolve inputs from env (CI) or CLI args (dry-run).
+    ctx = _resolve_context_from_cli() if dry_run else _resolve_context_from_env()
+    if ctx is None:
+        return 1 if not dry_run else 0
+
+    token = ctx["token"]
+    repository = ctx["repository"]
+    comment = ctx["comment"]
+    comment_id = ctx["comment_id"]
+    issue_number = ctx["issue_number"]
+    default_branch = ctx["default_branch"]
 
     api_base = f"https://api.github.com/repos/{repository}"
-    if comment_id is not None:
+    if not dry_run and comment_id is not None:
         try_post_issue_comment_reaction(api_base, token, comment_id, "+1")
 
     parsed_command = parse_command(comment)
     if parsed_command.error:
-        try_post_issue_comment(
-            api_base,
-            token,
-            issue_number,
-            parsed_command.error,
-        )
+        if not dry_run:
+            try_post_issue_comment(api_base, token, issue_number, parsed_command.error)
+        else:
+            print(f"Parse error: {parsed_command.error}", file=sys.stderr)
         return 0
 
     command = parsed_command.command
@@ -510,45 +634,110 @@ def main():
         print("Internal error: command parsing returned no command.", file=sys.stderr)
         return 1
 
-    permission = get_user_permission(api_base, token, commenter)
-    allowed_permissions = COMMAND_PERMISSIONS[command]
-    if permission not in allowed_permissions:
-        if "write" in allowed_permissions:
-            permission_error = (
-                f"I can only run `/kernel-bot {command}` for users with `write` or `admin` "
-                "repository permission."
-            )
-        else:
-            permission_error = (
-                f"I can only run `/kernel-bot {command}` for users with `admin` "
-                "repository permission."
-            )
-        try_post_issue_comment(
-            api_base,
-            token,
-            issue_number,
-            permission_error,
-        )
-        return 0
+    # Permission check — skip in dry-run.
+    if not dry_run:
+        commenter = ctx["commenter"]
+        permission = get_user_permission(api_base, token, commenter)
+        allowed_permissions = COMMAND_PERMISSIONS[command]
+        if permission not in allowed_permissions:
+            if "write" in allowed_permissions:
+                permission_error = (
+                    f"I can only run `/kernel-bot {command}` for users with `write` or `admin` "
+                    "repository permission."
+                )
+            else:
+                permission_error = (
+                    f"I can only run `/kernel-bot {command}` for users with `admin` "
+                    "repository permission."
+                )
+            try_post_issue_comment(api_base, token, issue_number, permission_error)
+            return 0
 
-    try:
-        pull_request = get_pull_request(api_base, token, issue_number)
-    except urllib.error.HTTPError as e:
-        err_text = e.read().decode("utf-8", errors="replace")
-        print(
-            f"Failed to fetch PR metadata for #{issue_number} (HTTP {e.code}).",
-            file=sys.stderr,
-        )
-        print(err_text, file=sys.stderr)
-        try_post_issue_comment(
-            api_base,
-            token,
-            issue_number,
-            f"Could not verify PR metadata, so `/kernel-bot {command}` was not run.",
-        )
-        return 1
+    # Fetch PR metadata — API in CI, already resolved in dry-run.
+    if dry_run:
+        pr_head_sha = ctx.get("pr_head_sha", "")
+    else:
+        try:
+            pull_request = get_pull_request(api_base, token, issue_number)
+        except urllib.error.HTTPError as e:
+            err_text = e.read().decode("utf-8", errors="replace")
+            print(
+                f"Failed to fetch PR metadata for #{issue_number} (HTTP {e.code}).",
+                file=sys.stderr,
+            )
+            print(err_text, file=sys.stderr)
+            try_post_issue_comment(
+                api_base,
+                token,
+                issue_number,
+                f"Could not verify PR metadata, so `/kernel-bot {command}` was not run.",
+            )
+            return 1
+        pr_head_sha = pull_request.get("head", {}).get("sha")
 
-    pr_head_sha = pull_request.get("head", {}).get("sha")
+    if command == "security":
+        # Security-only: dispatch the audit and return early.
+        command_summary = f"/kernel-bot {command}"
+        mode_text = "security audit only"
+        target_branch = f"pr-{issue_number}"
+        status_comment_id = None
+        if not dry_run:
+            status_comment_id = comment_id_from_response(
+                try_create_issue_comment(
+                    api_base,
+                    token,
+                    issue_number,
+                    format_pending_comment(
+                        command_summary,
+                        mode_text,
+                        target_branch,
+                        pr_head_sha,
+                        include_security=True,
+                    ),
+                )
+            )
+        release_result = dispatch(
+            token=token,
+            repo=repository,
+            ref=default_branch,
+            pr_number=str(issue_number),
+            head_sha=pr_head_sha or "",
+            dispatch_key_prefix=f"pr{issue_number}-",
+            security_only=True,
+            dry_run=dry_run,
+        )
+        emit_dispatch_diagnostics(release_result, dry_run=dry_run)
+        security_dispatches = [
+            DispatchResult(kernel_name=f"security ({wf})", dispatch_key=dk)
+            for wf, dk in release_result.security_dispatched
+        ]
+
+        if not dry_run and security_dispatches:
+            resolve_dispatch_run_urls(
+                api_base,
+                token,
+                repository,
+                default_branch,
+                security_dispatches,
+                workflows=WORKFLOWS["security"],
+            )
+
+        if not dry_run:
+            try_send_issue_comment(
+                api_base,
+                token,
+                issue_number,
+                format_result_comment(
+                    command_summary,
+                    mode_text,
+                    target_branch,
+                    pr_head_sha,
+                    security_dispatches=security_dispatches,
+                    security_failed=release_result.security_failed,
+                ),
+                comment_id=status_comment_id,
+            )
+        return 1 if release_result.security_failed else 0
 
     if command in ("build", "security-and-build"):
         target_branch = requested_branch or f"pr-{issue_number}"
@@ -583,24 +772,28 @@ def main():
         command_summary += f" --branch {requested_branch}"
     # `/kernel-bot security-and-build` runs the security audit concurrently with the build.
     run_security = command == "security-and-build"
-    status_comment_id = comment_id_from_response(
-        try_create_issue_comment(
-            api_base,
-            token,
-            issue_number,
-            format_pending_comment(
-                command_summary,
-                mode_text,
-                target_branch,
-                pr_head_sha,
-                include_security=run_security,
-            ),
+    status_comment_id = None
+    if not dry_run:
+        status_comment_id = comment_id_from_response(
+            try_create_issue_comment(
+                api_base,
+                token,
+                issue_number,
+                format_pending_comment(
+                    command_summary,
+                    mode_text,
+                    target_branch,
+                    pr_head_sha,
+                    include_security=run_security,
+                ),
+            )
         )
-    )
 
     merge_result_message = None
     if command == "merge-and-upload":
-        if pull_request.get("merged"):
+        if dry_run:
+            print("[dry-run] Would merge PR before dispatching.\n")
+        elif pull_request.get("merged"):
             merge_result_message = "PR is already merged. Continuing with build/upload."
         elif pull_request.get("state") != "open":
             try_send_issue_comment(
@@ -666,11 +859,11 @@ def main():
             )
     dispatches = []
     failed = []
-    security_dispatch = None
-    security_failure = None
+    security_dispatches = []
+    security_failed = []
 
     for index, kernel_name in enumerate(kernels):
-        release_result = do_dispatch_release(
+        release_result = dispatch(
             kernel_name,
             token=token,
             repo=repository,
@@ -684,59 +877,62 @@ def main():
             upload=dispatch_upload,
             # The audit is per-PR, so request it only once (on the first kernel).
             run_security=run_security and index == 0,
+            dry_run=dry_run,
         )
+        emit_dispatch_diagnostics(release_result, dry_run=dry_run)
         for wf, dk in release_result.dispatched:
             dispatches.append(
                 DispatchResult(kernel_name=f"{kernel_name} ({wf})", dispatch_key=dk)
             )
         for wf, code in release_result.failed:
             failed.append((f"{kernel_name} ({wf})", code))
-        if release_result.security_dispatch_key:
-            security_dispatch = DispatchResult(
-                kernel_name="security",
-                dispatch_key=release_result.security_dispatch_key,
+        for wf, dk in release_result.security_dispatched:
+            security_dispatches.append(
+                DispatchResult(kernel_name=f"security ({wf})", dispatch_key=dk)
             )
-        if release_result.security_failed_code is not None:
-            security_failure = (
-                f"could not dispatch `{SECURITY_WORKFLOW}` "
-                f"(HTTP {release_result.security_failed_code})."
-            )
+        security_failed.extend(release_result.security_failed)
 
-    resolve_dispatch_run_urls(
-        api_base,
-        token,
-        repository,
-        default_branch,
-        [*dispatches, *([security_dispatch] if security_dispatch else [])],
-        workflows=[*RELEASE_WORKFLOWS, SECURITY_WORKFLOW]
-        if run_security
-        else RELEASE_WORKFLOWS,
-    )
-
-    comment_written = try_send_issue_comment(
-        api_base,
-        token,
-        issue_number,
-        format_result_comment(
-            command_summary,
-            mode_text,
-            target_branch,
-            pr_head_sha,
-            merge_result_message=merge_result_message,
-            dispatches=dispatches,
-            failed=failed,
-            security_dispatch=security_dispatch,
-            security_failure=security_failure,
-        ),
-        comment_id=status_comment_id,
-    )
-    if not comment_written:
-        print(
-            "Bot response could not be posted. Ensure workflow token has issues/pull-requests write permission.",
-            file=sys.stderr,
+    if not dry_run:
+        resolve_dispatch_run_urls(
+            api_base,
+            token,
+            repository,
+            default_branch,
+            [*dispatches, *security_dispatches],
+            workflows=(
+                [*WORKFLOWS["build"], *WORKFLOWS["security"]]
+                if run_security
+                else WORKFLOWS["build"]
+            ),
         )
+
+        comment_written = try_send_issue_comment(
+            api_base,
+            token,
+            issue_number,
+            format_result_comment(
+                command_summary,
+                mode_text,
+                target_branch,
+                pr_head_sha,
+                merge_result_message=merge_result_message,
+                dispatches=dispatches,
+                failed=failed,
+                security_dispatches=security_dispatches,
+                security_failed=security_failed,
+            ),
+            comment_id=status_comment_id,
+        )
+        if not comment_written:
+            print(
+                "Bot response could not be posted. Ensure workflow token has issues/pull-requests write permission.",
+                file=sys.stderr,
+            )
     return 1 if failed else 0
 
 
 if __name__ == "__main__":
+    if "--dry-run" in sys.argv:
+        sys.argv.remove("--dry-run")
+        raise SystemExit(main(dry_run=True))
     raise SystemExit(main())

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -1,9 +1,10 @@
 import io
 import os
 import sys
-import unittest
 import urllib.error
 from unittest import mock
+
+import pytest
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
@@ -24,103 +25,96 @@ def _workflows(actions):
     return sorted(a.workflow for a in actions)
 
 
+def _select(backends):
+    with mock.patch.object(dispatch, "read_backends", return_value=backends):
+        return dispatch.select_workflows("somekernel", notes=[])
+
+
 # Fallback routing when build.toml is unreadable or declares unknown backends.
-class SelectWorkflowsFallbackTest(unittest.TestCase):
-    def _select(self, backends):
-        with mock.patch.object(dispatch, "read_backends", return_value=backends):
-            return dispatch.select_workflows("somekernel", notes=[])
+def test_unreadable_backends_falls_back_to_all_builds():
+    assert _select(None) == set(dispatch.WORKFLOWS["build"])
 
-    def test_unreadable_backends_falls_back_to_all_builds(self):
-        self.assertEqual(self._select(None), set(dispatch.WORKFLOWS["build"]))
 
-    def test_unknown_backends_falls_back_to_all_builds(self):
-        self.assertEqual(
-            self._select(["totally-made-up"]), set(dispatch.WORKFLOWS["build"])
-        )
+def test_unknown_backends_falls_back_to_all_builds():
+    assert _select(["totally-made-up"]) == set(dispatch.WORKFLOWS["build"])
 
 
 # Pure planning: backends and flags -> the intended dispatch actions.
-class PlanDispatchTest(unittest.TestCase):
-    def test_status_context_planned_only_with_head_sha(self):
-        with_sha = [a for a in _plan(head_sha="abc").actions if a.kind == "build"]
-        without_sha = [a for a in _plan().actions if a.kind == "build"]
-        self.assertTrue(all(a.status_context for a in with_sha))
-        self.assertTrue(all(a.status_context is None for a in without_sha))
+def test_status_context_planned_only_with_head_sha():
+    with_sha = [a for a in _plan(head_sha="abc").actions if a.kind == "build"]
+    without_sha = [a for a in _plan().actions if a.kind == "build"]
+    assert all(a.status_context for a in with_sha)
+    assert all(a.status_context is None for a in without_sha)
 
-    def test_run_security_adds_security_actions(self):
-        plan = _plan(pr_number="7", run_security=True)
-        self.assertEqual(_kinds(plan), ["build", "security"])
 
-    def test_security_only_plans_only_security(self):
-        plan = dispatch.plan_dispatch(
-            security_only=True,
-            pr_number="42",
-            head_sha="deadbeef",
-            dispatch_key_prefix="pr42-",
-        )
-        self.assertEqual(_kinds(plan), ["security"])
-        self.assertEqual(
-            _workflows(plan.actions), sorted(dispatch.WORKFLOWS["security"])
-        )
-        for action in plan.actions:
-            self.assertTrue(action.dispatch_key.startswith("pr42-security-"))
-            self.assertEqual(action.body["inputs"]["pr_number"], "42")
-            self.assertEqual(action.body["inputs"]["head_sha"], "deadbeef")
+def test_run_security_adds_security_actions():
+    plan = _plan(pr_number="7", run_security=True)
+    assert _kinds(plan) == ["build", "security"]
+
+
+def test_security_only_plans_only_security():
+    plan = dispatch.plan_dispatch(
+        security_only=True,
+        pr_number="42",
+        head_sha="deadbeef",
+        dispatch_key_prefix="pr42-",
+    )
+    assert _kinds(plan) == ["security"]
+    assert _workflows(plan.actions) == sorted(dispatch.WORKFLOWS["security"])
+    for action in plan.actions:
+        assert action.dispatch_key.startswith("pr42-security-")
+        assert action.body["inputs"]["pr_number"] == "42"
+        assert action.body["inputs"]["head_sha"] == "deadbeef"
 
 
 # Orchestration: kernel-name validation and the dry-run no-I/O contract.
-class DispatchOrchestratorTest(unittest.TestCase):
-    def test_invalid_kernel_name_marks_all_builds_failed(self):
-        result = dispatch.dispatch("bad name!", token="", repo="owner/repo")
-        self.assertEqual(
-            sorted(wf for wf, _ in result.failed), sorted(dispatch.WORKFLOWS["build"])
-        )
-        self.assertEqual(result.dispatched, [])
+def test_invalid_kernel_name_marks_all_builds_failed():
+    result = dispatch.dispatch("bad name!", token="", repo="owner/repo")
+    assert sorted(wf for wf, _ in result.failed) == sorted(dispatch.WORKFLOWS["build"])
+    assert result.dispatched == []
 
-    def test_dry_run_projects_plan_and_performs_no_io(self):
-        forbidden = mock.Mock(
-            side_effect=AssertionError("dry run must not hit the API")
+
+def test_dry_run_projects_plan_and_performs_no_io():
+    forbidden = mock.Mock(side_effect=AssertionError("dry run must not hit the API"))
+    with (
+        mock.patch.object(dispatch, "read_backends", return_value=["cuda"]),
+        mock.patch.object(dispatch, "github_api_request", forbidden),
+    ):
+        result = dispatch.dispatch(
+            "somekernel",
+            token="",
+            repo="owner/repo",
+            pr_number="7",
+            run_security=True,
+            dry_run=True,
         )
-        with (
-            mock.patch.object(dispatch, "read_backends", return_value=["cuda"]),
-            mock.patch.object(dispatch, "github_api_request", forbidden),
-        ):
-            result = dispatch.dispatch(
-                "somekernel",
-                token="",
-                repo="owner/repo",
-                pr_number="7",
-                run_security=True,
-                dry_run=True,
-            )
-        forbidden.assert_not_called()
-        self.assertTrue(result.dispatched)
-        self.assertTrue(result.security_dispatched)
-        self.assertEqual(
-            len(result.dry_run_payloads),
-            len(result.dispatched) + len(result.security_dispatched),
-        )
+    forbidden.assert_not_called()
+    assert result.dispatched
+    assert result.security_dispatched
+    assert len(result.dry_run_payloads) == len(result.dispatched) + len(
+        result.security_dispatched
+    )
 
 
 # Execution: GitHub API dispatch calls and HTTP-failure handling.
-class ExecutePlanTest(unittest.TestCase):
-    def test_posts_dispatch_and_pending_status(self):
-        plan = _plan(backends=["cuda"], head_sha="abc")
-        api = mock.Mock(return_value=(204, ""))
-        with mock.patch.object(dispatch, "github_api_request", api):
-            result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
-        # One build action -> one dispatch POST + one pending-status POST.
-        self.assertEqual(api.call_count, 2)
-        self.assertEqual([wf for wf, _ in result.dispatched], ["build.yaml"])
-        self.assertEqual(result.failed, [])
+def test_posts_dispatch_and_pending_status():
+    plan = _plan(backends=["cuda"], head_sha="abc")
+    api = mock.Mock(return_value=(204, ""))
+    with mock.patch.object(dispatch, "github_api_request", api):
+        result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
+    # One build action -> one dispatch POST + one pending-status POST.
+    assert api.call_count == 2
+    assert [wf for wf, _ in result.dispatched] == ["build.yaml"]
+    assert result.failed == []
 
-    def test_records_http_failure(self):
-        plan = _plan(backends=["cuda"])  # no head_sha -> no pending-status POST
-        err = urllib.error.HTTPError("u", 500, "err", {}, io.BytesIO(b"boom"))
-        with mock.patch.object(dispatch, "github_api_request", side_effect=err):
-            result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
-        self.assertEqual(result.dispatched, [])
-        self.assertEqual([code for _, code in result.failed], [500])
+
+def test_records_http_failure():
+    plan = _plan(backends=["cuda"])  # no head_sha -> no pending-status POST
+    err = urllib.error.HTTPError("u", 500, "err", {}, io.BytesIO(b"boom"))
+    with mock.patch.object(dispatch, "github_api_request", side_effect=err):
+        result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
+    assert result.dispatched == []
+    assert [code for _, code in result.failed] == [500]
 
 
 # select_workflows: backend-union and Windows-gate cases (single-backend rows omitted).
@@ -133,19 +127,15 @@ ROUTING_TRUTH_TABLE = [
 ]
 
 
-class RoutingTruthTableTest(unittest.TestCase):
-    def test_truth_table(self):
-        for backends, windows_allowed, expected in ROUTING_TRUTH_TABLE:
-            kernel = "k"
-            allowlist = {kernel} if windows_allowed else set()
-            with self.subTest(backends=backends, windows_allowed=windows_allowed):
-                with (
-                    mock.patch.object(dispatch, "read_backends", return_value=backends),
-                    mock.patch.object(dispatch, "WINDOWS_KERNELS", allowlist),
-                ):
-                    self.assertEqual(
-                        dispatch.select_workflows(kernel, notes=[]), expected
-                    )
+@pytest.mark.parametrize("backends, windows_allowed, expected", ROUTING_TRUTH_TABLE)
+def test_truth_table(backends, windows_allowed, expected):
+    kernel = "k"
+    allowlist = {kernel} if windows_allowed else set()
+    with (
+        mock.patch.object(dispatch, "read_backends", return_value=backends),
+        mock.patch.object(dispatch, "WINDOWS_KERNELS", allowlist),
+    ):
+        assert dispatch.select_workflows(kernel, notes=[]) == expected
 
 
 # Invariants over every real kernel: assert properties, not exact per-kernel output.
@@ -162,50 +152,48 @@ def _discover_kernels():
     return kernels
 
 
-class AllKernelsPropertyTest(unittest.TestCase):
-    def setUp(self):
-        self._cwd = os.getcwd()
-        os.chdir(REPO_ROOT)
-        self.kernels = _discover_kernels()
+@pytest.fixture
+def kernels():
+    # read_backends/select_workflows resolve build.toml relative to cwd.
+    cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        yield _discover_kernels()
+    finally:
+        os.chdir(cwd)
 
-    def tearDown(self):
-        os.chdir(self._cwd)
 
-    def test_kernels_were_discovered(self):
-        # Guards against the sweep silently testing nothing (wrong cwd, etc.).
-        self.assertGreater(len(self.kernels), 0)
+def test_kernels_were_discovered(kernels):
+    # Guards against the sweep silently testing nothing (wrong cwd, etc.).
+    assert len(kernels) > 0
 
-    def test_every_build_toml_parses(self):
-        for kernel in self.kernels:
-            with self.subTest(kernel=kernel):
-                # Raises on malformed TOML; None (no backends declared) is valid.
-                dispatch.read_backends(kernel)
 
-    def test_every_kernel_routes_to_at_least_one_known_build(self):
-        build_workflows = set(dispatch.WORKFLOWS["build"])
-        for kernel in self.kernels:
-            with self.subTest(kernel=kernel):
-                workflows = dispatch.select_workflows(kernel, notes=[])
-                self.assertTrue(workflows, f"{kernel} routes to no build workflow")
-                self.assertTrue(
-                    workflows <= build_workflows,
-                    f"{kernel} routes to unknown workflow(s): "
-                    f"{workflows - build_workflows}",
-                )
+def test_every_build_toml_parses(kernels):
+    for kernel in kernels:
+        # Raises on malformed TOML; None (no backends declared) is valid.
+        dispatch.read_backends(kernel)
 
-    def test_no_kernel_declares_an_unknown_backend(self):
-        # An unmapped backend would silently never build; add it to BACKEND_TO_WORKFLOWS.
-        known = set(dispatch.BACKEND_TO_WORKFLOWS)
-        for kernel in self.kernels:
-            backends = dispatch.read_backends(kernel)
-            if backends is None:
-                continue
-            with self.subTest(kernel=kernel):
-                unknown = set(backends) - known
-                self.assertEqual(
-                    unknown, set(), f"{kernel} declares unmapped backend(s): {unknown}"
-                )
+
+def test_every_kernel_routes_to_at_least_one_known_build(kernels):
+    build_workflows = set(dispatch.WORKFLOWS["build"])
+    for kernel in kernels:
+        workflows = dispatch.select_workflows(kernel, notes=[])
+        assert workflows, f"{kernel} routes to no build workflow"
+        assert workflows <= build_workflows, (
+            f"{kernel} routes to unknown workflow(s): {workflows - build_workflows}"
+        )
+
+
+def test_no_kernel_declares_an_unknown_backend(kernels):
+    # An unmapped backend would silently never build; add it to BACKEND_TO_WORKFLOWS.
+    known = set(dispatch.BACKEND_TO_WORKFLOWS)
+    for kernel in kernels:
+        backends = dispatch.read_backends(kernel)
+        if backends is None:
+            continue
+        unknown = set(backends) - known
+        assert unknown == set(), f"{kernel} declares unmapped backend(s): {unknown}"
 
 
 if __name__ == "__main__":
-    unittest.main(buffer=True)
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -1,0 +1,211 @@
+import io
+import os
+import sys
+import unittest
+import urllib.error
+from unittest import mock
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+import dispatch  # noqa: E402
+
+
+def _plan(kernel="somekernel", backends=("cuda",), **kwargs):
+    with mock.patch.object(dispatch, "read_backends", return_value=list(backends)):
+        return dispatch.plan_dispatch(kernel, **kwargs)
+
+
+def _kinds(plan):
+    return sorted({a.kind for a in plan.actions})
+
+
+def _workflows(actions):
+    return sorted(a.workflow for a in actions)
+
+
+# Fallback routing when build.toml is unreadable or declares unknown backends.
+class SelectWorkflowsFallbackTest(unittest.TestCase):
+    def _select(self, backends):
+        with mock.patch.object(dispatch, "read_backends", return_value=backends):
+            return dispatch.select_workflows("somekernel", notes=[])
+
+    def test_unreadable_backends_falls_back_to_all_builds(self):
+        self.assertEqual(self._select(None), set(dispatch.WORKFLOWS["build"]))
+
+    def test_unknown_backends_falls_back_to_all_builds(self):
+        self.assertEqual(
+            self._select(["totally-made-up"]), set(dispatch.WORKFLOWS["build"])
+        )
+
+
+# Pure planning: backends and flags -> the intended dispatch actions.
+class PlanDispatchTest(unittest.TestCase):
+    def test_status_context_planned_only_with_head_sha(self):
+        with_sha = [a for a in _plan(head_sha="abc").actions if a.kind == "build"]
+        without_sha = [a for a in _plan().actions if a.kind == "build"]
+        self.assertTrue(all(a.status_context for a in with_sha))
+        self.assertTrue(all(a.status_context is None for a in without_sha))
+
+    def test_run_security_adds_security_actions(self):
+        plan = _plan(pr_number="7", run_security=True)
+        self.assertEqual(_kinds(plan), ["build", "security"])
+
+    def test_security_only_plans_only_security(self):
+        plan = dispatch.plan_dispatch(
+            security_only=True,
+            pr_number="42",
+            head_sha="deadbeef",
+            dispatch_key_prefix="pr42-",
+        )
+        self.assertEqual(_kinds(plan), ["security"])
+        self.assertEqual(
+            _workflows(plan.actions), sorted(dispatch.WORKFLOWS["security"])
+        )
+        for action in plan.actions:
+            self.assertTrue(action.dispatch_key.startswith("pr42-security-"))
+            self.assertEqual(action.body["inputs"]["pr_number"], "42")
+            self.assertEqual(action.body["inputs"]["head_sha"], "deadbeef")
+
+
+# Orchestration: kernel-name validation and the dry-run no-I/O contract.
+class DispatchOrchestratorTest(unittest.TestCase):
+    def test_invalid_kernel_name_marks_all_builds_failed(self):
+        result = dispatch.dispatch("bad name!", token="", repo="owner/repo")
+        self.assertEqual(
+            sorted(wf for wf, _ in result.failed), sorted(dispatch.WORKFLOWS["build"])
+        )
+        self.assertEqual(result.dispatched, [])
+
+    def test_dry_run_projects_plan_and_performs_no_io(self):
+        forbidden = mock.Mock(
+            side_effect=AssertionError("dry run must not hit the API")
+        )
+        with (
+            mock.patch.object(dispatch, "read_backends", return_value=["cuda"]),
+            mock.patch.object(dispatch, "github_api_request", forbidden),
+        ):
+            result = dispatch.dispatch(
+                "somekernel",
+                token="",
+                repo="owner/repo",
+                pr_number="7",
+                run_security=True,
+                dry_run=True,
+            )
+        forbidden.assert_not_called()
+        self.assertTrue(result.dispatched)
+        self.assertTrue(result.security_dispatched)
+        self.assertEqual(
+            len(result.dry_run_payloads),
+            len(result.dispatched) + len(result.security_dispatched),
+        )
+
+
+# Execution: GitHub API dispatch calls and HTTP-failure handling.
+class ExecutePlanTest(unittest.TestCase):
+    def test_posts_dispatch_and_pending_status(self):
+        plan = _plan(backends=["cuda"], head_sha="abc")
+        api = mock.Mock(return_value=(204, ""))
+        with mock.patch.object(dispatch, "github_api_request", api):
+            result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
+        # One build action -> one dispatch POST + one pending-status POST.
+        self.assertEqual(api.call_count, 2)
+        self.assertEqual([wf for wf, _ in result.dispatched], ["build.yaml"])
+        self.assertEqual(result.failed, [])
+
+    def test_records_http_failure(self):
+        plan = _plan(backends=["cuda"])  # no head_sha -> no pending-status POST
+        err = urllib.error.HTTPError("u", 500, "err", {}, io.BytesIO(b"boom"))
+        with mock.patch.object(dispatch, "github_api_request", side_effect=err):
+            result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
+        self.assertEqual(result.dispatched, [])
+        self.assertEqual([code for _, code in result.failed], [500])
+
+
+# select_workflows: backend-union and Windows-gate cases (single-backend rows omitted).
+ROUTING_TRUTH_TABLE = [
+    (["cuda"], False, {"build.yaml"}),
+    (["cuda"], True, {"build.yaml", "build-windows.yaml"}),
+    (["metal"], False, {"build-mac.yaml"}),
+    (["cuda", "metal"], False, {"build.yaml", "build-mac.yaml"}),
+    (["cuda", "metal"], True, {"build.yaml", "build-mac.yaml", "build-windows.yaml"}),
+]
+
+
+class RoutingTruthTableTest(unittest.TestCase):
+    def test_truth_table(self):
+        for backends, windows_allowed, expected in ROUTING_TRUTH_TABLE:
+            kernel = "k"
+            allowlist = {kernel} if windows_allowed else set()
+            with self.subTest(backends=backends, windows_allowed=windows_allowed):
+                with (
+                    mock.patch.object(dispatch, "read_backends", return_value=backends),
+                    mock.patch.object(dispatch, "WINDOWS_KERNELS", allowlist),
+                ):
+                    self.assertEqual(
+                        dispatch.select_workflows(kernel, notes=[]), expected
+                    )
+
+
+# Invariants over every real kernel: assert properties, not exact per-kernel output.
+REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIR))
+
+
+def _discover_kernels():
+    kernels = []
+    for name in sorted(os.listdir(REPO_ROOT)):
+        if not dispatch.KERNEL_NAME_RE.match(name):
+            continue
+        if os.path.exists(os.path.join(REPO_ROOT, name, "build.toml")):
+            kernels.append(name)
+    return kernels
+
+
+class AllKernelsPropertyTest(unittest.TestCase):
+    def setUp(self):
+        self._cwd = os.getcwd()
+        os.chdir(REPO_ROOT)
+        self.kernels = _discover_kernels()
+
+    def tearDown(self):
+        os.chdir(self._cwd)
+
+    def test_kernels_were_discovered(self):
+        # Guards against the sweep silently testing nothing (wrong cwd, etc.).
+        self.assertGreater(len(self.kernels), 0)
+
+    def test_every_build_toml_parses(self):
+        for kernel in self.kernels:
+            with self.subTest(kernel=kernel):
+                # Raises on malformed TOML; None (no backends declared) is valid.
+                dispatch.read_backends(kernel)
+
+    def test_every_kernel_routes_to_at_least_one_known_build(self):
+        build_workflows = set(dispatch.WORKFLOWS["build"])
+        for kernel in self.kernels:
+            with self.subTest(kernel=kernel):
+                workflows = dispatch.select_workflows(kernel, notes=[])
+                self.assertTrue(workflows, f"{kernel} routes to no build workflow")
+                self.assertTrue(
+                    workflows <= build_workflows,
+                    f"{kernel} routes to unknown workflow(s): "
+                    f"{workflows - build_workflows}",
+                )
+
+    def test_no_kernel_declares_an_unknown_backend(self):
+        # An unmapped backend would silently never build; add it to BACKEND_TO_WORKFLOWS.
+        known = set(dispatch.BACKEND_TO_WORKFLOWS)
+        for kernel in self.kernels:
+            backends = dispatch.read_backends(kernel)
+            if backends is None:
+                continue
+            with self.subTest(kernel=kernel):
+                unknown = set(backends) - known
+                self.assertEqual(
+                    unknown, set(), f"{kernel} declares unmapped backend(s): {unknown}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)

--- a/.github/scripts/test_pr_comment_kernel_bot.py
+++ b/.github/scripts/test_pr_comment_kernel_bot.py
@@ -1,7 +1,8 @@
 import os
 import subprocess
 import sys
-import unittest
+
+import pytest
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
@@ -9,138 +10,147 @@ sys.path.insert(0, SCRIPT_DIR)
 import pr_comment_kernel_bot as bot  # noqa: E402
 
 
-class ParseCommandTest(unittest.TestCase):
-    def test_build_with_kernels(self):
-        parsed = bot.parse_command("/kernel-bot build activation relu")
-        self.assertIsNone(parsed.error)
-        self.assertEqual(parsed.command, "build")
-        self.assertEqual(parsed.kernels, ["activation", "relu"])
-        self.assertIsNone(parsed.branch)
-
-    def test_security_needs_no_kernels(self):
-        parsed = bot.parse_command("/kernel-bot security")
-        self.assertIsNone(parsed.error)
-        self.assertEqual(parsed.command, "security")
-        self.assertEqual(parsed.kernels, [])
-
-    def test_build_without_kernels_is_error(self):
-        parsed = bot.parse_command("/kernel-bot build")
-        self.assertIsNotNone(parsed.error)
-        self.assertIsNone(parsed.command)
-
-    def test_unknown_command_is_error(self):
-        self.assertIsNotNone(bot.parse_command("/kernel-bot frobnicate foo").error)
-
-    def test_wrong_prefix_is_error(self):
-        self.assertIsNotNone(bot.parse_command("/not-kernel-bot build foo").error)
-
-    def test_too_few_tokens_is_error(self):
-        self.assertIsNotNone(bot.parse_command("/kernel-bot").error)
-
-    def test_branch_at_end_is_parsed(self):
-        parsed = bot.parse_command("/kernel-bot build foo --branch dev")
-        self.assertIsNone(parsed.error)
-        self.assertEqual(parsed.kernels, ["foo"])
-        self.assertEqual(parsed.branch, "dev")
-
-    def test_branch_not_at_end_is_error(self):
-        parsed = bot.parse_command("/kernel-bot build --branch dev foo")
-        self.assertIsNotNone(parsed.error)
-
-    def test_security_with_branch_only(self):
-        parsed = bot.parse_command("/kernel-bot security --branch dev")
-        self.assertIsNone(parsed.error)
-        self.assertEqual(parsed.command, "security")
-        self.assertEqual(parsed.kernels, [])
-        self.assertEqual(parsed.branch, "dev")
-
-    def test_duplicate_kernels_are_deduped(self):
-        parsed = bot.parse_command("/kernel-bot build foo foo bar")
-        self.assertEqual(parsed.kernels, ["foo", "bar"])
-
-    def test_invalid_kernel_name_is_error(self):
-        self.assertIsNotNone(bot.parse_command("/kernel-bot build bad/name").error)
-
-    def test_invalid_branch_name_is_error(self):
-        parsed = bot.parse_command("/kernel-bot build foo --branch bad~branch")
-        self.assertIsNotNone(parsed.error)
+def test_build_with_kernels():
+    parsed = bot.parse_command("/kernel-bot build activation relu")
+    assert parsed.error is None
+    assert parsed.command == "build"
+    assert parsed.kernels == ["activation", "relu"]
+    assert parsed.branch is None
 
 
-class CommentHelpersTest(unittest.TestCase):
-    def test_supported_characters(self):
-        self.assertTrue(
-            bot.comment_has_only_supported_characters("/kernel-bot build activation")
-        )
-        self.assertFalse(
-            bot.comment_has_only_supported_characters("/kernel-bot build `rm -rf`")
-        )
+def test_security_needs_no_kernels():
+    parsed = bot.parse_command("/kernel-bot security")
+    assert parsed.error is None
+    assert parsed.command == "security"
+    assert parsed.kernels == []
 
-    def test_make_dispatch_key_format(self):
-        key = bot.make_dispatch_key(42, "activation")
-        self.assertTrue(key.startswith("pr42-activation-"))
 
-    def test_pending_comment_lists_security_workflows(self):
-        text = bot.format_pending_comment(
-            "/kernel-bot security",
-            "security audit only",
-            "pr-42",
+def test_build_without_kernels_is_error():
+    parsed = bot.parse_command("/kernel-bot build")
+    assert parsed.error is not None
+    assert parsed.command is None
+
+
+def test_unknown_command_is_error():
+    assert bot.parse_command("/kernel-bot frobnicate foo").error is not None
+
+
+def test_wrong_prefix_is_error():
+    assert bot.parse_command("/not-kernel-bot build foo").error is not None
+
+
+def test_too_few_tokens_is_error():
+    assert bot.parse_command("/kernel-bot").error is not None
+
+
+def test_branch_at_end_is_parsed():
+    parsed = bot.parse_command("/kernel-bot build foo --branch dev")
+    assert parsed.error is None
+    assert parsed.kernels == ["foo"]
+    assert parsed.branch == "dev"
+
+
+def test_branch_not_at_end_is_error():
+    parsed = bot.parse_command("/kernel-bot build --branch dev foo")
+    assert parsed.error is not None
+
+
+def test_security_with_branch_only():
+    parsed = bot.parse_command("/kernel-bot security --branch dev")
+    assert parsed.error is None
+    assert parsed.command == "security"
+    assert parsed.kernels == []
+    assert parsed.branch == "dev"
+
+
+def test_duplicate_kernels_are_deduped():
+    parsed = bot.parse_command("/kernel-bot build foo foo bar")
+    assert parsed.kernels == ["foo", "bar"]
+
+
+def test_invalid_kernel_name_is_error():
+    assert bot.parse_command("/kernel-bot build bad/name").error is not None
+
+
+def test_invalid_branch_name_is_error():
+    parsed = bot.parse_command("/kernel-bot build foo --branch bad~branch")
+    assert parsed.error is not None
+
+
+def test_supported_characters():
+    assert bot.comment_has_only_supported_characters("/kernel-bot build activation")
+    assert not bot.comment_has_only_supported_characters("/kernel-bot build `rm -rf`")
+
+
+def test_make_dispatch_key_format():
+    key = bot.make_dispatch_key(42, "activation")
+    assert key.startswith("pr42-activation-")
+
+
+def test_pending_comment_lists_security_workflows():
+    text = bot.format_pending_comment(
+        "/kernel-bot security",
+        "security audit only",
+        "pr-42",
+        "abc123",
+        include_security=True,
+    )
+    assert "Security audit" in text
+    for wf in bot.WORKFLOWS["security"]:
+        assert wf in text
+
+
+def test_result_comment_renders_security_dispatch_and_failure():
+    dispatched = bot.DispatchResult(
+        kernel_name="security (security-audit.yml)",
+        dispatch_key="pr42-security-x",
+        action_url="https://example/run/1",
+    )
+    text = bot.format_result_comment(
+        "/kernel-bot security",
+        "security audit only",
+        "pr-42",
+        "abc123",
+        security_dispatches=[dispatched],
+        security_failed=[("security-audit.yml", 500)],
+    )
+    assert "https://example/run/1" in text
+    assert "Security audit failed" in text
+    assert "security-audit.yml (HTTP 500)" in text
+
+
+def _run_dry(comment, *extra):
+    return subprocess.run(
+        [
+            sys.executable,
+            os.path.join(SCRIPT_DIR, "pr_comment_kernel_bot.py"),
+            "--dry-run",
+            comment,
+            "--pr-number",
+            "42",
+            "--repo",
+            "owner/repo",
+            "--head-sha",
             "abc123",
-            include_security=True,
-        )
-        self.assertIn("Security audit", text)
-        for wf in bot.WORKFLOWS["security"]:
-            self.assertIn(wf, text)
-
-    def test_result_comment_renders_security_dispatch_and_failure(self):
-        dispatched = bot.DispatchResult(
-            kernel_name="security (security-audit.yml)",
-            dispatch_key="pr42-security-x",
-            action_url="https://example/run/1",
-        )
-        text = bot.format_result_comment(
-            "/kernel-bot security",
-            "security audit only",
-            "pr-42",
-            "abc123",
-            security_dispatches=[dispatched],
-            security_failed=[("security-audit.yml", 500)],
-        )
-        self.assertIn("https://example/run/1", text)
-        self.assertIn("Security audit failed", text)
-        self.assertIn("security-audit.yml (HTTP 500)", text)
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
 
-class DryRunSmokeTest(unittest.TestCase):
-    def _run(self, comment, *extra):
-        return subprocess.run(
-            [
-                sys.executable,
-                os.path.join(SCRIPT_DIR, "pr_comment_kernel_bot.py"),
-                "--dry-run",
-                comment,
-                "--pr-number",
-                "42",
-                "--repo",
-                "owner/repo",
-                "--head-sha",
-                "abc123",
-                *extra,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+def test_security_only_dry_run():
+    proc = _run_dry("/kernel-bot security")
+    assert proc.returncode == 0, proc.stderr
+    assert "security-audit.yml" in proc.stdout
 
-    def test_security_only_dry_run(self):
-        proc = self._run("/kernel-bot security")
-        self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertIn("security-audit.yml", proc.stdout)
 
-    def test_parse_error_dry_run_does_not_crash(self):
-        proc = self._run("/kernel-bot frobnicate")
-        self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertIn("Parse error", proc.stderr)
+def test_parse_error_dry_run_does_not_crash():
+    proc = _run_dry("/kernel-bot frobnicate")
+    assert proc.returncode == 0, proc.stderr
+    assert "Parse error" in proc.stderr
 
 
 if __name__ == "__main__":
-    unittest.main(buffer=True)
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/.github/scripts/test_pr_comment_kernel_bot.py
+++ b/.github/scripts/test_pr_comment_kernel_bot.py
@@ -1,0 +1,146 @@
+import os
+import subprocess
+import sys
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+import pr_comment_kernel_bot as bot  # noqa: E402
+
+
+class ParseCommandTest(unittest.TestCase):
+    def test_build_with_kernels(self):
+        parsed = bot.parse_command("/kernel-bot build activation relu")
+        self.assertIsNone(parsed.error)
+        self.assertEqual(parsed.command, "build")
+        self.assertEqual(parsed.kernels, ["activation", "relu"])
+        self.assertIsNone(parsed.branch)
+
+    def test_security_needs_no_kernels(self):
+        parsed = bot.parse_command("/kernel-bot security")
+        self.assertIsNone(parsed.error)
+        self.assertEqual(parsed.command, "security")
+        self.assertEqual(parsed.kernels, [])
+
+    def test_build_without_kernels_is_error(self):
+        parsed = bot.parse_command("/kernel-bot build")
+        self.assertIsNotNone(parsed.error)
+        self.assertIsNone(parsed.command)
+
+    def test_unknown_command_is_error(self):
+        self.assertIsNotNone(bot.parse_command("/kernel-bot frobnicate foo").error)
+
+    def test_wrong_prefix_is_error(self):
+        self.assertIsNotNone(bot.parse_command("/not-kernel-bot build foo").error)
+
+    def test_too_few_tokens_is_error(self):
+        self.assertIsNotNone(bot.parse_command("/kernel-bot").error)
+
+    def test_branch_at_end_is_parsed(self):
+        parsed = bot.parse_command("/kernel-bot build foo --branch dev")
+        self.assertIsNone(parsed.error)
+        self.assertEqual(parsed.kernels, ["foo"])
+        self.assertEqual(parsed.branch, "dev")
+
+    def test_branch_not_at_end_is_error(self):
+        parsed = bot.parse_command("/kernel-bot build --branch dev foo")
+        self.assertIsNotNone(parsed.error)
+
+    def test_security_with_branch_only(self):
+        parsed = bot.parse_command("/kernel-bot security --branch dev")
+        self.assertIsNone(parsed.error)
+        self.assertEqual(parsed.command, "security")
+        self.assertEqual(parsed.kernels, [])
+        self.assertEqual(parsed.branch, "dev")
+
+    def test_duplicate_kernels_are_deduped(self):
+        parsed = bot.parse_command("/kernel-bot build foo foo bar")
+        self.assertEqual(parsed.kernels, ["foo", "bar"])
+
+    def test_invalid_kernel_name_is_error(self):
+        self.assertIsNotNone(bot.parse_command("/kernel-bot build bad/name").error)
+
+    def test_invalid_branch_name_is_error(self):
+        parsed = bot.parse_command("/kernel-bot build foo --branch bad~branch")
+        self.assertIsNotNone(parsed.error)
+
+
+class CommentHelpersTest(unittest.TestCase):
+    def test_supported_characters(self):
+        self.assertTrue(
+            bot.comment_has_only_supported_characters("/kernel-bot build activation")
+        )
+        self.assertFalse(
+            bot.comment_has_only_supported_characters("/kernel-bot build `rm -rf`")
+        )
+
+    def test_make_dispatch_key_format(self):
+        key = bot.make_dispatch_key(42, "activation")
+        self.assertTrue(key.startswith("pr42-activation-"))
+
+    def test_pending_comment_lists_security_workflows(self):
+        text = bot.format_pending_comment(
+            "/kernel-bot security",
+            "security audit only",
+            "pr-42",
+            "abc123",
+            include_security=True,
+        )
+        self.assertIn("Security audit", text)
+        for wf in bot.WORKFLOWS["security"]:
+            self.assertIn(wf, text)
+
+    def test_result_comment_renders_security_dispatch_and_failure(self):
+        dispatched = bot.DispatchResult(
+            kernel_name="security (security-audit.yml)",
+            dispatch_key="pr42-security-x",
+            action_url="https://example/run/1",
+        )
+        text = bot.format_result_comment(
+            "/kernel-bot security",
+            "security audit only",
+            "pr-42",
+            "abc123",
+            security_dispatches=[dispatched],
+            security_failed=[("security-audit.yml", 500)],
+        )
+        self.assertIn("https://example/run/1", text)
+        self.assertIn("Security audit failed", text)
+        self.assertIn("security-audit.yml (HTTP 500)", text)
+
+
+class DryRunSmokeTest(unittest.TestCase):
+    def _run(self, comment, *extra):
+        return subprocess.run(
+            [
+                sys.executable,
+                os.path.join(SCRIPT_DIR, "pr_comment_kernel_bot.py"),
+                "--dry-run",
+                comment,
+                "--pr-number",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--head-sha",
+                "abc123",
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_security_only_dry_run(self):
+        proc = self._run("/kernel-bot security")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("security-audit.yml", proc.stdout)
+
+    def test_parse_error_dry_run_does_not_crash(self):
+        proc = self._run("/kernel-bot frobnicate")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("Parse error", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(buffer=True)


### PR DESCRIPTION
this PR refactors the kernel bot dispatch to split planning from execution, so dry runs don't hit the api and the logic is actually testable.

- split the work into `plan` and `execute`
- `plan_dispatch()` is pure: it reads build.toml, selects workflows, and builds the dispatch payloads/keys with no network calls, token, or repo.
- `execute_plan()` performs I/O, workflow dispatches and pending commit statuses.
- consolidates build and security dispatches
- `pr_comment_kernel_bot.py` now supports a `--dry-run` flag to allow testing locally
- added tests for dispatch and pr_comment_kernel_bot to avoid future regressions


run tests
```bash
python3 -m unittest discover -s .github/scripts -p "test_*.py"
```

using dry run for comment tests
```bash
python .github/scripts/pr_comment_kernel_bot.py --dry-run "/kernel-bot security" --pr-number 982
```

using dry run on the dispatch
```bash
python .github/scripts/dispatch.py --security-only --pr-number 982 --head-sha "$(gh pr view 982 --json headRefOid -q .headRefOid)" --dry-run
```