### PR TITLE
thrift-attention: add ThriftAttention Kernel Hub package

### DIFF
--- a/thrift-attention/CARD.md
+++ b/thrift-attention/CARD.md
@@ -1,0 +1,55 @@
+---
+library_name: kernels
+{% if license %}license: {{ license }}
+{% endif %}---
+
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+
+## How to use
+{% if functions %}
+
+```python
+# make sure `kernels` is installed: `pip install -U kernels`
+from kernels import get_kernel
+
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
+
+{{ functions[0] }}(...)
+```
+{% else %}
+
+Usage example not available.
+{% endif %}
+
+## Available functions
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
+
+## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
+
+No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}

--- a/thrift-attention/README.md
+++ b/thrift-attention/README.md
@@ -1,0 +1,35 @@
+---
+tags:
+- kernels
+- cuda
+---
+# ThriftAttention
+
+ThriftAttention: Selective Mixed Precision for Long-Context FP4 Attention
+
+[arxiv.org/abs/2605.23081](https://arxiv.org/pdf/2605.23081)
+
+This is the Kernel Hub package for [ThriftAttention](https://github.com/joesharratt1229/ThriftAttention).
+
+The goal is simple: make ThriftAttention load through Transformers with the Kernel Hub attention path.
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(
+    "Qwen/Qwen3-0.6B",
+    dtype=torch.bfloat16,
+    device_map="cuda",
+    attn_implementation="kernels-community/thrift-attention",
+)
+```
+
+This package exposes FlashAttention-style entry points for the Transformers loader:
+
+```python
+flash_attn_func
+flash_attn_varlen_func
+```
+
+ThriftAttention currently targets CUDA 12.8 or newer and SM120 GPUs.

--- a/thrift-attention/build.toml
+++ b/thrift-attention/build.toml
@@ -1,0 +1,44 @@
+[general]
+name = "thrift-attention"
+version = 1
+license = "Apache-2.0"
+backends = ["cuda"]
+
+[general.cuda]
+minver = "12.8"
+
+[general.hub]
+repo-id = "kernels-community/thrift-attention"
+
+[torch]
+src = [
+    "torch-ext/torch_binding.cpp",
+    "torch-ext/torch_binding.h",
+]
+
+[kernel.thrift_attention]
+backend = "cuda"
+cuda-capabilities = ["12.0a"]
+cuda-minver = "12.8"
+cuda-flags = [
+    "-O3",
+    "-use_fast_math",
+    "--ptxas-options=--gpu-name=sm_120a",
+]
+cxx-flags = ["-O3"]
+depends = ["torch"]
+include = ["csrc/include"]
+src = [
+    "csrc/include/thriftattention/sm120/cuda_common.cuh",
+    "csrc/cuda/sm120/nvfp4/fp4_attention.cu",
+    "csrc/cuda/sm120/nvfp4/single_query_fp4_attention.cu",
+    "csrc/cuda/sm120/nvfp4/thrift_attention.cu",
+    "csrc/cuda/sm120/nvfp4/single_query_attention.cu",
+    "csrc/cuda/sm120/nvfp4/quantization.cu",
+    "csrc/cuda/sm120/mxfp4/fp4_attention.cu",
+    "csrc/cuda/sm120/mxfp4/single_query_fp4_attention.cu",
+    "csrc/cuda/sm120/mxfp4/thrift_attention.cu",
+    "csrc/cuda/sm120/mxfp4/single_query_attention.cu",
+    "csrc/cuda/sm120/mxfp4/quantization.cu",
+    "csrc/cuda/sm120/shared/block_selection.cu",
+]

--- a/thrift-attention/csrc/cuda/sm120/mxfp4/fp4_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/mxfp4/fp4_attention.cu
@@ -1,0 +1,566 @@
+// SM120 MXFP4 attention baseline
+
+#include <cstdint>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV, int HEAD_DIM,
+         int HEAD_DIM_2, int SCALE_DIM,
+         int NUM_WARPS, int WARP_Q>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void fp4_attention_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+    const int v_kv = ta_cdiv(kv_capacity, 128) * 128;
+
+    Q += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM_2;
+    K += kv_bid * kv_capacity * HEAD_DIM_2;
+    V += kv_bid * HEAD_DIM * (v_kv / 2);
+
+    S_Q += (q_bid * q_len + q_block_id * BLOCK_Q) * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv * SCALE_DIM;
+    O += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+    const uint32_t Q_smem = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem = Q_sf_smem + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e8m0);
+    const uint32_t V_sf_smem = V_smem + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfQ_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    float rowmax[WARP_Q/MMA_M][2];
+    float rowsum[WARP_Q/MMA_M][2] = {};
+    float O_rmem[WARP_Q/MMA_M][HEAD_DIM/MMA_N][4] = {};
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q/MMA_M; mma_id_q++) {
+        rowmax[mma_id_q][0] = -FLT_MAX;
+        rowmax[mma_id_q][1] = -FLT_MAX;
+    }
+
+    // ---- load Q data global -> shared (swizzled) -> registers ----
+    ta_gmem_to_smem<BLOCK_Q, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(Q_smem, Q, tid, HEAD_DIM_2);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    // Pre-compute swizzled base address for Q ldmatrix.
+    // Row offsets that are multiples of 8 rows can be added (swizzle repeats every 8 rows).
+    // Column tile offsets use XOR: swizzle(base + col_delta) == swizzle(base) ^ col_delta.
+    uint32_t Q_ld_base;
+    {
+        const int row_off = warp_id * WARP_Q + (lane_id % 16);
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = ta_swizzle<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            uint32_t addr = Q_ld_base;
+            addr += mma_id_q * MMA_M * HEAD_DIM_2;  // row: MMA_M=16, 16%8==0
+            addr ^= mma_id_d * (MMA_K / 2);          // col via XOR
+            ta_ldmatrix_x4(Q_rmem[mma_id_q][mma_id_d], addr);
+        }
+
+    // ---- load Q scales global -> shared -> registers ----
+    ta_load_scales<BLOCK_Q, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(Q_sf_smem, S_Q, SCALE_DIM, tid);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + sf_row_q;
+            const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+            sfQ_rmem[mma_id_q][mma_id_d] = ta_ld_shared_u16(Q_sf_smem + offset);
+        }
+    }
+
+    // ---- KV loop ----
+    __syncthreads();
+    const uint32_t K_smem = __cvta_generic_to_shared(smem);
+    const uint32_t K_sf_smem = K_smem + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV);
+    const int max_kv_pos = q_block_id * BLOCK_Q + BLOCK_Q - 1;
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV + 1, total_kv_iters)
+        : total_kv_iters;
+
+    // Pre-compute base address for K ldmatrix.
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = ta_swizzle<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // Precompute per-thread query row offsets within the block.
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);       // rows 0-7 of MMA tile
+    const int q_row_lower = q_row_upper + 8;                         // rows 8-15 of MMA tile
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base = (lane_id % 4) * 2;                        // base key col within MMA_N tile
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_K];
+
+        const int k_block_start = kv_iter * BLOCK_KV;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV - 1) > q_block_start);
+
+        // Load K first; issue V in a second async group so QK can overlap
+        // with the V transfer.
+        ta_gmem_to_smem<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem, K, tid, HEAD_DIM_2);;
+        ta_load_scales<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(K_sf_smem, S_K, SCALE_DIM, tid);
+        asm volatile("cp.async.commit_group;");
+        ta_gmem_to_smem<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem, V, tid, v_kv / 2);
+        ta_load_scales<HEAD_DIM, BLOCK_KV / 32, TB_SIZE, __nv_fp8_e8m0>(V_sf_smem, S_V, v_kv / 32, tid);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 1;");
+        __syncthreads();
+
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            // ldmatrix_x4: lanes 0-15 cover mma_id_d=0, lanes 16-31 cover mma_id_d=1
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ta_ldmatrix_x4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ta_ldmatrix_x2(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        const int sf_row_k = (lane_id / 4);
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfK_rmem[mma_id_kv][mma_id_d] = ta_ld_shared_u16(K_sf_smem + offset);
+            }
+        }
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                    ta_mma_m16n8k64_mxfp4(
+                        Q_rmem[mma_id_q][mma_id_d],
+                        K_rmem[mma_id_kv][mma_id_d],
+                        sfQ_rmem[mma_id_q][mma_id_d],
+                        sfK_rmem[mma_id_kv][mma_id_d],
+                        S_rmem[mma_id_q][mma_id_kv]);
+
+        // ---- Apply causal mask on blocks overlapping the query tile ----
+        if constexpr (CAUSAL) {
+            if (needs_causal_mask) {
+                for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+                    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                        const int k_phys_0 = mma_id_kv * MMA_N + k_col_base;
+                        const int k_phys_1 = k_phys_0 + 1;
+                        const int k_col_0 = k_block_start + ta_kv_logical_from_physical(k_phys_0);
+                        const int k_col_1 = k_block_start + ta_kv_logical_from_physical(k_phys_1);
+
+                        // regs[0]: (q_row_upper, k_col_0), regs[1]: (q_row_upper, k_col_1)
+                        // regs[2]: (q_row_lower, k_col_0), regs[3]: (q_row_lower, k_col_1)
+                        if (k_col_0 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][0] = -INFINITY;
+                        if (k_col_1 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][1] = -INFINITY;
+                        if (k_col_0 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][2] = -INFINITY;
+                        if (k_col_1 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][3] = -INFINITY;
+                    }
+                }
+            }
+        }
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+            // apply softmax scale
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int reg_id = 0; reg_id < 4; reg_id++)
+                    S_rmem[mma_id_q][mma_id_kv][reg_id] *= softmax_scale;
+
+            // rowmax over this KV block
+            float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                float *regs = S_rmem[mma_id_q][mma_id_kv];
+                this_rowmax[0] = max(this_rowmax[0], max(regs[0], regs[1]));
+                this_rowmax[1] = max(this_rowmax[1], max(regs[2], regs[3]));
+            }
+            this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+            this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+            // new rowmax
+            this_rowmax[0] = max(this_rowmax[0], rowmax[mma_id_q][0]);
+            this_rowmax[1] = max(this_rowmax[1], rowmax[mma_id_q][1]);
+
+            // rescale previous O for new rowmax
+            float rescale[2];
+            rescale[0] = __expf(rowmax[mma_id_q][0] - this_rowmax[0]);
+            rescale[1] = __expf(rowmax[mma_id_q][1] - this_rowmax[1]);
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                O_rmem[mma_id_q][mma_id_d][0] *= rescale[0];
+                O_rmem[mma_id_q][mma_id_d][1] *= rescale[0];
+                O_rmem[mma_id_q][mma_id_d][2] *= rescale[1];
+                O_rmem[mma_id_q][mma_id_d][3] *= rescale[1];
+            }
+
+            // save new rowmax
+            rowmax[mma_id_q][0] = this_rowmax[0];
+            rowmax[mma_id_q][1] = this_rowmax[1];
+
+            // softmax numerator and rowsumexp
+            float this_rowsumexp[2] = {};
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                float *regs = S_rmem[mma_id_q][mma_id_kv];
+                regs[0] = __expf(regs[0] - rowmax[mma_id_q][0]);
+                regs[1] = __expf(regs[1] - rowmax[mma_id_q][0]);
+                regs[2] = __expf(regs[2] - rowmax[mma_id_q][1]);
+                regs[3] = __expf(regs[3] - rowmax[mma_id_q][1]);
+
+                this_rowsumexp[0] += regs[0] + regs[1];
+                this_rowsumexp[1] += regs[2] + regs[3];
+            }
+
+            // butterfly reduction within 4 threads
+            this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+            this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+            // accumulate to running rowsum
+            rowsum[mma_id_q][0] = rowsum[mma_id_q][0] * rescale[0] + this_rowsumexp[0];
+            rowsum[mma_id_q][1] = rowsum[mma_id_q][1] * rescale[1] + this_rowsumexp[1];
+
+            constexpr float FP4_RANGE = 6.0f;
+            constexpr float FP4_MAX = 6.0f;
+            float sf_P_upper[BLOCK_KV / MMA_N / 4];
+            float sf_P_lower[BLOCK_KV / MMA_N / 4];
+
+            for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+                const int t0 = 4 * blk;
+                const int t1 = t0 + 1;
+                const int t2 = t0 + 2;
+                const int t3 = t0 + 3;
+                const float gmax_upper = rowmax[mma_id_q][0];
+                const float gmax_lower = rowmax[mma_id_q][1];
+                const bool valid_upper = gmax_upper > -FLT_MAX * 0.5f;
+                const bool valid_lower = gmax_lower > -FLT_MAX * 0.5f;
+                const float inv_upper = valid_upper ? (FP4_MAX * __expf(rowmax[mma_id_q][0] - gmax_upper)) : 0.0f;
+                const float inv_lower = valid_lower ? (FP4_MAX * __expf(rowmax[mma_id_q][1] - gmax_lower)) : 0.0f;
+                sf_P_upper[blk] = valid_upper ? (FP4_RANGE / FP4_MAX * __expf(gmax_upper - rowmax[mma_id_q][0])) : 1.0f;
+                sf_P_lower[blk] = valid_lower ? (FP4_RANGE / FP4_MAX * __expf(gmax_lower - rowmax[mma_id_q][1])) : 1.0f;
+
+                S_rmem[mma_id_q][t0][0] *= inv_upper;
+                S_rmem[mma_id_q][t0][1] *= inv_upper;
+                S_rmem[mma_id_q][t1][0] *= inv_upper;
+                S_rmem[mma_id_q][t1][1] *= inv_upper;
+                S_rmem[mma_id_q][t0][2] *= inv_lower;
+                S_rmem[mma_id_q][t0][3] *= inv_lower;
+                S_rmem[mma_id_q][t1][2] *= inv_lower;
+                S_rmem[mma_id_q][t1][3] *= inv_lower;
+                S_rmem[mma_id_q][t2][0] *= inv_upper;
+                S_rmem[mma_id_q][t2][1] *= inv_upper;
+                S_rmem[mma_id_q][t3][0] *= inv_upper;
+                S_rmem[mma_id_q][t3][1] *= inv_upper;
+                S_rmem[mma_id_q][t2][2] *= inv_lower;
+                S_rmem[mma_id_q][t2][3] *= inv_lower;
+                S_rmem[mma_id_q][t3][2] *= inv_lower;
+                S_rmem[mma_id_q][t3][3] *= inv_lower;
+            }
+
+            for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+                int blk = 4 * g;
+                float *r0 = S_rmem[mma_id_q][blk];
+                float *r1 = S_rmem[mma_id_q][blk + 1];
+                float *r2 = S_rmem[mma_id_q][blk + 2];
+                float *r3 = S_rmem[mma_id_q][blk + 3];
+
+                S_fp4_rmem[mma_id_q][0][2 * g] = ta_cvt_8xf32_to_e2m1_packed(
+                    r0[1], r0[0], r1[1], r1[0],
+                    r2[1], r2[0], r3[1], r3[0]);
+                S_fp4_rmem[mma_id_q][0][2 * g + 1] = ta_cvt_8xf32_to_e2m1_packed(
+                    r0[3], r0[2], r1[3], r1[2],
+                    r2[3], r2[2], r3[3], r3[2]);
+            }
+
+            for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+                int base = mma_sc_id * 2;
+                uint32_t sfP_upper_packed = ta_cvt_2xf32_to_e8m0_packed(
+                    sf_P_upper[base + 1], sf_P_upper[base + 0]);
+
+                uint32_t sfP_lower_packed = ta_cvt_2xf32_to_e8m0_packed(
+                    sf_P_lower[base + 1], sf_P_lower[base + 0]);
+
+                S_fp4_s_rmem[mma_id_q][mma_sc_id] =
+                    (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+            }
+        }
+
+        // V layout in smem: [HEAD_DIM, BLOCK_KV/2], stride = BLOCK_KV/2 bytes.
+        // ldmatrix_x4: lanes 0-15 address tile mma_id_d, lanes 16-31 address tile mma_id_d+1.
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = ta_swizzle<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ta_ldmatrix_x4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        constexpr int V_SF_STRIDE = BLOCK_KV / 32;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfV_rmem[mma_id_kv][mma_id_d] = ta_ld_shared_u16(V_sf_smem + offset);
+            }
+
+        // MMA O += P @ V
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                    ta_mma_m16n8k64_mxfp4(
+                        S_fp4_rmem[mma_id_q][mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        S_fp4_s_rmem[mma_id_q][mma_id_kv],
+                        sfV_rmem[mma_id_kv][mma_id_d],
+                        O_rmem[mma_id_q][mma_id_d]);
+
+        K += BLOCK_KV * HEAD_DIM_2;
+        S_K += BLOCK_KV * SCALE_DIM;
+
+        V  += BLOCK_KV / 2;
+        S_V += BLOCK_KV / 32;
+    }
+
+    constexpr float FP4_RANGE_INV = 1.0f / 6.0f;
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            float norm0 = FP4_RANGE_INV / rowsum[mma_id_q][0];
+            float norm1 = FP4_RANGE_INV / rowsum[mma_id_q][1];
+
+            regs[0] *= norm0;
+            regs[1] *= norm0;
+            regs[2] *= norm1;
+            regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+        }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+static void launch_fp4_attention(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q, const __nv_fp8_e8m0* S_K, const __nv_fp8_e8m0* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_Q = 64;
+    constexpr int BLOCK_KV = 64;
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e8m0);
+    constexpr int v_phase_smem = HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 32) * sizeof(__nv_fp8_e8m0);
+    constexpr int k_phase_smem = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e8m0);
+    constexpr int smem_size = q_phase_smem + v_phase_smem > k_phase_smem
+                            ? q_phase_smem + v_phase_smem : k_phase_smem;
+
+    auto kernel = fp4_attention_kernel<T, CAUSAL, BLOCK_Q, BLOCK_KV, HEAD_DIM,
+                                       HEAD_DIM_2, SCALE_DIM,
+                                       NUM_WARPS, WARP_Q>;
+
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    kernel<<<num_blocks, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL>
+static void dispatch_fp4_attention(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+    if (head_dim == 64) {
+        launch_fp4_attention<T, CAUSAL, 64>(
+            Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+            kv_capacity, num_q_heads, num_kv_heads);
+    } else {
+        launch_fp4_attention<T, CAUSAL, 128>(
+            Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+            kv_capacity, num_q_heads, num_kv_heads);
+    }
+}
+
+template<typename T, bool CAUSAL>
+static void fp4_attention_mxfp4_typed(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+    auto S_Q = reinterpret_cast<const __nv_fp8_e8m0*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e8m0*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e8m0*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    dispatch_fp4_attention<T, CAUSAL>(
+        Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+        kv_capacity, num_q_heads, num_kv_heads, head_dim);
+}
+
+void fp4_attention_causal_mxfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_mxfp4_typed<__nv_bfloat16, true>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_mxfp4_typed<half, true>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}
+
+void fp4_attention_noncausal_mxfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_mxfp4_typed<__nv_bfloat16, false>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_mxfp4_typed<half, false>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/mxfp4/quantization.cu
+++ b/thrift-attention/csrc/cuda/sm120/mxfp4/quantization.cu
@@ -1,0 +1,719 @@
+#include <cstdint>
+#include <cstdio>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+constexpr int ELEMENTS_PER_THREAD = 32;
+
+__device__ inline uint8_t mxfp4_scale_to_e8m0(float scale) {
+    return __nv_cvt_float_to_e8m0(scale, __NV_SATFINITE, cudaRoundPosInf);
+}
+
+__device__ inline float mxfp4_e8m0_to_float(uint8_t bits) {
+    return float(reinterpret_cast<__nv_fp8_e8m0&>(bits));
+}
+
+template<typename T, int SEQ_PER_BLOCK, int THREADS_PER_HEAD>
+__global__
+void mxfp4_quantise_kernel(const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale, int bs, int seq_len, int head_dim)
+{
+    using Traits = PrecisionTraits<T>;
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid/num_seq_blocks;
+
+    const int seq_block_id = bid % num_seq_blocks;
+    const int seq_thread_id = tid / THREADS_PER_HEAD;
+    const int head_id = tid % THREADS_PER_HEAD;
+
+    X += (batch_id * seq_len *head_dim) + (seq_block_id * SEQ_PER_BLOCK + seq_thread_id) * head_dim + head_id * ELEMENTS_PER_THREAD;
+
+    const int seq_id = seq_block_id * SEQ_PER_BLOCK + seq_thread_id;
+
+    uint32_t X_reg[4][4];
+
+    if (seq_id < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X)
+        );
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8+32];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+48];\n\t"
+            : "=r"(X_reg[2][0]), "=r"(X_reg[2][1]), "=r"(X_reg[2][2]), "=r"(X_reg[2][3]),
+              "=r"(X_reg[3][0]), "=r"(X_reg[3][1]), "=r"(X_reg[3][2]), "=r"(X_reg[3][3])
+            : "l"(X)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+            X_reg[2][i] = 0;
+            X_reg[3][i] = 0;
+        }
+    }
+
+    // X_reg holds 32 16-bit values as 16 uint32_t lanes.
+    typename Traits::vec2* X_h2 = reinterpret_cast<typename Traits::vec2*>(X_reg);
+
+    typename Traits::vec2 local_max = Traits::abs2(X_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 16; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(X_h2[i]));
+    }
+
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    // compute scale factor: quantise to fp8, then recover for exact representable value
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8 = mxfp4_scale_to_e8m0(sf);
+    sf = mxfp4_e8m0_to_float(sf_fp8);
+
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    // scale and convert half -> float2
+    float2 X_f2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        X_f2[i] = Traits::to_float2(X_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    // convert to fp4 e2m1: 32 elements = 4 x uint32_t (8 nibbles each)
+    // swap .y/.x at call site so .x (even elem) lands in low nibble
+    uint32_t fp4_packed[4];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+    fp4_packed[2] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[8].y, X_f2[8].x, X_f2[9].y, X_f2[9].x,
+        X_f2[10].y, X_f2[10].x, X_f2[11].y, X_f2[11].x);
+    fp4_packed[3] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[12].y, X_f2[12].x, X_f2[13].y, X_f2[13].x,
+        X_f2[14].y, X_f2[14].x, X_f2[15].y, X_f2[15].x);
+
+    // store fp4 output: 32 fp4 values = 16 bytes per thread
+    // output layout: [bs, seq_len, head_dim/2] (each byte = 2 fp4 values)
+    if (seq_id < seq_len) {
+        __nv_fp4x2_e2m1* out = X_fp4 + batch_id * seq_len * (head_dim / 2)
+                              + seq_id * (head_dim / 2)
+                              + head_id * (ELEMENTS_PER_THREAD / 2);
+        reinterpret_cast<uint4*>(out)[0] = reinterpret_cast<uint4*>(fp4_packed)[0];
+
+        // store scale factor: 1 fp8 per 32 elements
+        // output layout: [bs, seq_len, head_dim/32]
+        X_scale[batch_id * seq_len * (head_dim / 32) + seq_id * (head_dim / 32) + head_id] =
+            reinterpret_cast<__nv_fp8_e8m0&>(sf_fp8);
+    }
+}
+
+// ---- launch wrapper ----
+
+template<typename T, int HEAD_DIM>
+static void mxfp4_quantise_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * THREADS_PER_HEAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+
+    mxfp4_quantise_kernel<T, SEQ_PER_BLOCK, THREADS_PER_HEAD>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, HEAD_DIM);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "mxfp4_quantise_kernel launch failed: %s\n", cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_mxfp4_quantise(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim) {
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e8m0*>(X_scale_raw);
+
+    if (head_dim == 64)
+        mxfp4_quantise_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len);
+    else if (head_dim == 128)
+        mxfp4_quantise_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len);
+    else
+        fprintf(stderr, "mxfp4_quantise: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void mxfp4_quantise(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_mxfp4_quantise<__nv_bfloat16>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    } else {
+        dispatch_mxfp4_quantise<half>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    }
+}
+
+template<typename T, int SEQ_PER_BLOCK, int THREADS_PER_HEAD>
+__global__
+void mxfp4_quantise_permute_seq_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len, int head_dim, bool inverse)
+{
+    using Traits = PrecisionTraits<T>;
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+    const int seq_thread_id = tid / THREADS_PER_HEAD;
+    const int head_id = tid % THREADS_PER_HEAD;
+
+    const int phys_seq_id = seq_block_id * SEQ_PER_BLOCK + seq_thread_id;
+    const int logical_local = ta_sage_perm_seq(seq_thread_id, inverse);
+    const int logical_seq_id = seq_block_id * SEQ_PER_BLOCK + logical_local;
+
+    const T* X_ptr = X + batch_id * seq_len * head_dim
+                   + logical_seq_id * head_dim
+                   + head_id * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[4][4];
+    if (logical_seq_id < seq_len && phys_seq_id < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8+32];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+48];\n\t"
+            : "=r"(X_reg[2][0]), "=r"(X_reg[2][1]), "=r"(X_reg[2][2]), "=r"(X_reg[2][3]),
+              "=r"(X_reg[3][0]), "=r"(X_reg[3][1]), "=r"(X_reg[3][2]), "=r"(X_reg[3][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+            X_reg[2][i] = 0;
+            X_reg[3][i] = 0;
+        }
+    }
+
+    typename Traits::vec2* X_h2 = reinterpret_cast<typename Traits::vec2*>(X_reg);
+
+    typename Traits::vec2 local_max = Traits::abs2(X_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 16; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(X_h2[i]));
+    }
+
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8 = mxfp4_scale_to_e8m0(sf);
+    sf = mxfp4_e8m0_to_float(sf_fp8);
+
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        X_f2[i] = Traits::to_float2(X_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[4];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+    fp4_packed[2] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[8].y, X_f2[8].x, X_f2[9].y, X_f2[9].x,
+        X_f2[10].y, X_f2[10].x, X_f2[11].y, X_f2[11].x);
+    fp4_packed[3] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[12].y, X_f2[12].x, X_f2[13].y, X_f2[13].x,
+        X_f2[14].y, X_f2[14].x, X_f2[15].y, X_f2[15].x);
+
+    if (phys_seq_id < seq_len) {
+        __nv_fp4x2_e2m1* out = X_fp4 + batch_id * seq_len * (head_dim / 2)
+                              + phys_seq_id * (head_dim / 2)
+                              + head_id * (ELEMENTS_PER_THREAD / 2);
+        reinterpret_cast<uint4*>(out)[0] = reinterpret_cast<uint4*>(fp4_packed)[0];
+
+        X_scale[batch_id * seq_len * (head_dim / 32) + phys_seq_id * (head_dim / 32) + head_id] =
+            reinterpret_cast<__nv_fp8_e8m0&>(sf_fp8);
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void mxfp4_quantise_permute_seq_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len, bool inverse) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * THREADS_PER_HEAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+
+    mxfp4_quantise_permute_seq_kernel<T, SEQ_PER_BLOCK, THREADS_PER_HEAD>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, HEAD_DIM, inverse);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "mxfp4_quantise_permute_seq_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_mxfp4_quantise_permute_seq(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse) {
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e8m0*>(X_scale_raw);
+
+    if (head_dim == 64)
+        mxfp4_quantise_permute_seq_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else if (head_dim == 128)
+        mxfp4_quantise_permute_seq_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else
+        fprintf(stderr, "mxfp4_quantise_permute_seq: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void mxfp4_quantise_permute_seq(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_mxfp4_quantise_permute_seq<__nv_bfloat16>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    } else {
+        dispatch_mxfp4_quantise_permute_seq<half>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    }
+}
+
+// ============================================================================
+// Transpose + quantise kernel
+// Reads  [bs, seq_len, HEAD_DIM]  (row-major, contiguous)
+// Writes [bs, HEAD_DIM, padded_seq/2]  (fp4x2) and [bs, HEAD_DIM, padded_seq/32]  (fp8 scale)
+// i.e. transposes the last two dims while quantising to MXFP4.
+// ============================================================================
+
+template<typename T, int HEAD_DIM, int SEQ_PER_BLOCK>
+__global__
+void mxfp4_quantise_transpose_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len, int padded_seq)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int THREADS_PER_SEQ  = SEQ_PER_BLOCK / ELEMENTS_PER_THREAD;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+
+    // --- Phase 1: Load input tile [SEQ_PER_BLOCK, HEAD_DIM] into shared mem ---
+    // Thread mapping (same as non-transpose kernel):
+    //   load_seq_local  = which row within the block   [0, SEQ_PER_BLOCK)
+    //   load_head_chunk = which 32-element chunk of d   [0, THREADS_PER_HEAD)
+    const int load_seq_local  = tid / THREADS_PER_HEAD;
+    const int load_head_chunk = tid % THREADS_PER_HEAD;
+    const int load_seq_global = seq_block_id * SEQ_PER_BLOCK + load_seq_local;
+
+    const T* X_ptr = X + batch_id * seq_len * HEAD_DIM
+                   + load_seq_global * HEAD_DIM
+                   + load_head_chunk * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[4][4];
+    if (load_seq_global < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8+32];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+48];\n\t"
+            : "=r"(X_reg[2][0]), "=r"(X_reg[2][1]), "=r"(X_reg[2][2]), "=r"(X_reg[2][3]),
+              "=r"(X_reg[3][0]), "=r"(X_reg[3][1]), "=r"(X_reg[3][2]), "=r"(X_reg[3][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+            X_reg[2][i] = 0;
+            X_reg[3][i] = 0;
+        }
+    }
+
+    // smem layout: [SEQ_PER_BLOCK][HEAD_DIM]
+    __shared__ T smem[SEQ_PER_BLOCK * HEAD_DIM];
+
+    T* smem_row = smem + load_seq_local * HEAD_DIM + load_head_chunk * ELEMENTS_PER_THREAD;
+    *reinterpret_cast<uint4*>(smem_row)      = *reinterpret_cast<uint4*>(X_reg[0]);
+    *reinterpret_cast<uint4*>(smem_row + 8)  = *reinterpret_cast<uint4*>(X_reg[1]);
+    *reinterpret_cast<uint4*>(smem_row + 16) = *reinterpret_cast<uint4*>(X_reg[2]);
+    *reinterpret_cast<uint4*>(smem_row + 24) = *reinterpret_cast<uint4*>(X_reg[3]);
+
+    __syncthreads();
+
+    // --- Phase 2: Read transposed — 32 elements along seq for one head_dim pos ---
+    // Thread mapping after transpose:
+    //   dim_id    = which head_dim position   [0, HEAD_DIM)
+    //   seq_chunk = which 32-element group     [0, THREADS_PER_SEQ)
+    const int dim_id    = tid / THREADS_PER_SEQ;
+    const int seq_chunk = tid % THREADS_PER_SEQ;
+
+    typename Traits::vec2 vals_h2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        int s0 = seq_chunk * ELEMENTS_PER_THREAD + 2 * i;
+        int s1 = s0 + 1;
+        vals_h2[i] = Traits::make_vec2(smem[s0 * HEAD_DIM + dim_id],
+                                       smem[s1 * HEAD_DIM + dim_id]);
+    }
+
+    // --- Quantise (identical to non-transpose kernel) ---
+    typename Traits::vec2 local_max = Traits::abs2(vals_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 16; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(vals_h2[i]));
+    }
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8 = mxfp4_scale_to_e8m0(sf);
+    sf = mxfp4_e8m0_to_float(sf_fp8);
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        X_f2[i] = Traits::to_float2(vals_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[4];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+    fp4_packed[2] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[8].y, X_f2[8].x, X_f2[9].y, X_f2[9].x,
+        X_f2[10].y, X_f2[10].x, X_f2[11].y, X_f2[11].x);
+    fp4_packed[3] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[12].y, X_f2[12].x, X_f2[13].y, X_f2[13].x,
+        X_f2[14].y, X_f2[14].x, X_f2[15].y, X_f2[15].x);
+
+    // --- Store in transposed layout ---
+    // fp4 output: [bs, HEAD_DIM, padded_seq / 2]
+    const int seq_offset = seq_block_id * SEQ_PER_BLOCK + seq_chunk * ELEMENTS_PER_THREAD;
+
+    __nv_fp4x2_e2m1* out = X_fp4 + batch_id * HEAD_DIM * (padded_seq / 2)
+                          + dim_id * (padded_seq / 2)
+                          + seq_offset / 2;
+    reinterpret_cast<uint4*>(out)[0] = reinterpret_cast<uint4*>(fp4_packed)[0];
+
+    // scale output: [bs, HEAD_DIM, padded_seq / 32]
+    X_scale[batch_id * HEAD_DIM * (padded_seq / 32)
+            + dim_id * (padded_seq / 32)
+            + seq_block_id * (SEQ_PER_BLOCK / 32) + seq_chunk] =
+        reinterpret_cast<__nv_fp8_e8m0&>(sf_fp8);
+}
+
+// ---- launch wrapper (transpose) ----
+
+template<typename T, int HEAD_DIM>
+static void mxfp4_quantise_transpose_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * HEAD_DIM / ELEMENTS_PER_THREAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int padded_seq = ta_cdiv(seq_len, SEQ_PER_BLOCK) * SEQ_PER_BLOCK;
+
+    mxfp4_quantise_transpose_kernel<T, HEAD_DIM, SEQ_PER_BLOCK>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, padded_seq);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "mxfp4_quantise_transpose_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_mxfp4_quantise_transpose(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim) {
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e8m0*>(X_scale_raw);
+
+    if (head_dim == 64)
+        mxfp4_quantise_transpose_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len);
+    else if (head_dim == 128)
+        mxfp4_quantise_transpose_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len);
+    else
+        fprintf(stderr, "mxfp4_quantise_transpose: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void mxfp4_quantise_transpose(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_mxfp4_quantise_transpose<__nv_bfloat16>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    } else {
+        dispatch_mxfp4_quantise_transpose<half>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    }
+}
+
+template<typename T, int HEAD_DIM, int SEQ_PER_BLOCK>
+__global__
+void mxfp4_quantise_transpose_permute_seq_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len, int padded_seq, bool inverse)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int THREADS_PER_SEQ  = SEQ_PER_BLOCK / ELEMENTS_PER_THREAD;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+
+    const int load_phys_local = tid / THREADS_PER_HEAD;
+    const int load_head_chunk = tid % THREADS_PER_HEAD;
+    const int load_logical_local = ta_sage_perm_seq(load_phys_local, inverse);
+    const int load_logical_global = seq_block_id * SEQ_PER_BLOCK + load_logical_local;
+    const int load_phys_global = seq_block_id * SEQ_PER_BLOCK + load_phys_local;
+
+    const T* X_ptr = X + batch_id * seq_len * HEAD_DIM
+                   + load_logical_global * HEAD_DIM
+                   + load_head_chunk * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[4][4];
+    if (load_logical_global < seq_len && load_phys_global < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8+32];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+48];\n\t"
+            : "=r"(X_reg[2][0]), "=r"(X_reg[2][1]), "=r"(X_reg[2][2]), "=r"(X_reg[2][3]),
+              "=r"(X_reg[3][0]), "=r"(X_reg[3][1]), "=r"(X_reg[3][2]), "=r"(X_reg[3][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+            X_reg[2][i] = 0;
+            X_reg[3][i] = 0;
+        }
+    }
+
+    __shared__ T smem[SEQ_PER_BLOCK * HEAD_DIM];
+    T* smem_row = smem + load_phys_local * HEAD_DIM + load_head_chunk * ELEMENTS_PER_THREAD;
+    *reinterpret_cast<uint4*>(smem_row)      = *reinterpret_cast<uint4*>(X_reg[0]);
+    *reinterpret_cast<uint4*>(smem_row + 8)  = *reinterpret_cast<uint4*>(X_reg[1]);
+    *reinterpret_cast<uint4*>(smem_row + 16) = *reinterpret_cast<uint4*>(X_reg[2]);
+    *reinterpret_cast<uint4*>(smem_row + 24) = *reinterpret_cast<uint4*>(X_reg[3]);
+
+    __syncthreads();
+
+    const int dim_id    = tid / THREADS_PER_SEQ;
+    const int seq_chunk = tid % THREADS_PER_SEQ;
+
+    typename Traits::vec2 vals_h2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        int s0 = seq_chunk * ELEMENTS_PER_THREAD + 2 * i;
+        int s1 = s0 + 1;
+        vals_h2[i] = Traits::make_vec2(smem[s0 * HEAD_DIM + dim_id],
+                                       smem[s1 * HEAD_DIM + dim_id]);
+    }
+
+    typename Traits::vec2 local_max = Traits::abs2(vals_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 16; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(vals_h2[i]));
+    }
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8 = mxfp4_scale_to_e8m0(sf);
+    sf = mxfp4_e8m0_to_float(sf_fp8);
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) {
+        X_f2[i] = Traits::to_float2(vals_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[4];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+    fp4_packed[2] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[8].y, X_f2[8].x, X_f2[9].y, X_f2[9].x,
+        X_f2[10].y, X_f2[10].x, X_f2[11].y, X_f2[11].x);
+    fp4_packed[3] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[12].y, X_f2[12].x, X_f2[13].y, X_f2[13].x,
+        X_f2[14].y, X_f2[14].x, X_f2[15].y, X_f2[15].x);
+
+    const int seq_offset = seq_block_id * SEQ_PER_BLOCK + seq_chunk * ELEMENTS_PER_THREAD;
+
+    __nv_fp4x2_e2m1* out = X_fp4 + batch_id * HEAD_DIM * (padded_seq / 2)
+                          + dim_id * (padded_seq / 2)
+                          + seq_offset / 2;
+    reinterpret_cast<uint4*>(out)[0] = reinterpret_cast<uint4*>(fp4_packed)[0];
+
+    X_scale[batch_id * HEAD_DIM * (padded_seq / 32)
+            + dim_id * (padded_seq / 32)
+            + seq_block_id * (SEQ_PER_BLOCK / 32) + seq_chunk] =
+        reinterpret_cast<__nv_fp8_e8m0&>(sf_fp8);
+}
+
+template<typename T, int HEAD_DIM>
+static void mxfp4_quantise_transpose_permute_seq_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e8m0* X_scale,
+    int bs, int seq_len, bool inverse) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * HEAD_DIM / ELEMENTS_PER_THREAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int padded_seq = ta_cdiv(seq_len, SEQ_PER_BLOCK) * SEQ_PER_BLOCK;
+
+    mxfp4_quantise_transpose_permute_seq_kernel<T, HEAD_DIM, SEQ_PER_BLOCK>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, padded_seq, inverse);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "mxfp4_quantise_transpose_permute_seq_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_mxfp4_quantise_transpose_permute_seq(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse) {
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e8m0*>(X_scale_raw);
+
+    if (head_dim == 64)
+        mxfp4_quantise_transpose_permute_seq_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else if (head_dim == 128)
+        mxfp4_quantise_transpose_permute_seq_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else
+        fprintf(stderr, "mxfp4_quantise_transpose_permute_seq: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void mxfp4_quantise_transpose_permute_seq(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_mxfp4_quantise_transpose_permute_seq<__nv_bfloat16>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    } else {
+        dispatch_mxfp4_quantise_transpose_permute_seq<half>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/mxfp4/single_query_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/mxfp4/single_query_attention.cu
@@ -1,0 +1,1827 @@
+// SM120 mixed-precision single-query attention.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+__device__ inline
+void ldmatrix_x4_sqmxfp4mix(uint32_t reg[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+         : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_sqmxfp4mix(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_trans_sqmxfp4mix(uint32_t reg[2], uint32_t addr) {
+    asm volatile(
+        "ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
+        : "=r"(reg[0]), "=r"(reg[1])
+        : "r"(addr));
+}
+
+__device__ inline
+uint32_t ld_shared_e8m0x2_sqmxfp4mix(uint32_t addr) {
+    uint16_t value;
+    asm volatile("ld.shared.u16 %0, [%1];"
+        : "=h"(value)
+        : "r"(addr));
+    return static_cast<uint32_t>(value);
+}
+
+__device__ __forceinline__
+void mma_m16n8k16_f16_sqmxfp4mix(
+    const uint32_t (&A)[4],
+    const uint32_t (&B)[2],
+    float (&D)[4]) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
+}
+
+// keep your existing mma_m16n8k64_mxfp4_sqmxfp4mix(...) and conversion helpers
+
+template <int STRIDE>
+__device__
+uint32_t swizzle_sqmxfp4mix(uint32_t index) {
+    if constexpr (STRIDE == 16)
+        return index;
+    uint32_t row_idx = (index / STRIDE) % 8;
+    uint32_t bits_to_xor = row_idx / max(64 / STRIDE, 1);
+    return index ^ (bits_to_xor << 4);
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_sqmxfp4mix(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int num_iters = (HEIGHT * WIDTH) / (num_elements * TB_SIZE);
+
+    for (int iter = 0; iter < num_iters; iter++) {
+        const int index = (iter * TB_SIZE + tid) * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+
+        uint32_t dst_addr = swizzle_sqmxfp4mix<WIDTH * (int)sizeof(T)>(
+            dst + (row * WIDTH + col) * sizeof(T));
+        const T *src_addr = src + (row * src_stride + col);
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void load_scales_sqmxfp4mix(uint32_t dst, const T *src, int src_stride, int tid) {
+    constexpr int cp_size = WIDTH * sizeof(T);
+    static_assert(cp_size < 16);
+
+    auto load_row = [&](int row) {
+        const uint32_t dst_addr = dst + row * WIDTH * sizeof(T);
+        const T *src_addr = src + row * src_stride;
+        if constexpr (cp_size == 2) {
+            uint16_t value;
+            asm volatile("ld.global.u16 %0, [%1];"
+                : "=h"(value)
+                : "l"(src_addr));
+            asm volatile("st.shared.u16 [%0], %1;"
+                :: "r"(dst_addr), "h"(value));
+        } else {
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(cp_size));
+        }
+    };
+
+    for (int iter = 0; iter < HEIGHT / TB_SIZE; iter++)
+        load_row(iter * TB_SIZE + tid);
+
+    if constexpr (HEIGHT % TB_SIZE != 0) {
+        const int row = HEIGHT / TB_SIZE * TB_SIZE + tid;
+        if (row < HEIGHT)
+            load_row(row);
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_linear_sqmxfp4mix(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int total_vectors = (HEIGHT * WIDTH) / num_elements;
+
+    for (int vec = tid; vec < total_vectors; vec += TB_SIZE) {
+        const int index = vec * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+        const uint32_t dst_addr = dst + (row * WIDTH + col) * (int)sizeof(T);
+        const T *src_addr = src + row * src_stride + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+constexpr int WARP_SIZE_sqmxfp4mix = 32;
+
+static int single_query_target_split_ctas_sqmxfp4mix(int total_kv_blocks) {
+    if (const char* env = std::getenv("SAGE_MIXED_SPLIT_CTAS")) {
+        const int v = std::atoi(env);
+        if (v > 0) return v;
+    }
+    return (total_kv_blocks <= 512) ? 384
+         : (total_kv_blocks <= 1024) ? 384
+         : 896;
+}
+
+__host__ __device__ inline
+int cdiv_sqmxfp4mix(int a, int b) { return (a + b - 1) / b; }
+
+__device__ __forceinline__
+bool block_in_topk_sqmxfp4mix(const int32_t* topk_row, int topk_count, int block_id)
+{
+    bool hit = false;
+    for (int i = 0; i < topk_count; i++)
+        hit |= (topk_row[i] == block_id);
+    return hit;
+}
+
+__device__ __forceinline__
+bool range_has_topk_sqmxfp4mix(const int32_t* topk_row, int topk_count, int block_begin, int block_end)
+{
+    bool hit = false;
+    for (int i = 0; i < topk_count; i++) {
+        const int b = topk_row[i];
+        hit |= (b >= block_begin) && (b < block_end);
+    }
+    return hit;
+}
+
+__device__ inline
+uint32_t cvt_8xf32_to_e2m1_packed_sqmxfp4mix(float f0, float f1, float f2, float f3,
+                                     float f4, float f5, float f6, float f7) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 a0, a1, a2, a3;\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a0, %1, %2;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a1, %3, %4;\n\t"
+        "mov.b16 lo, {a0, a1};\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a2, %5, %6;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a3, %7, %8;\n\t"
+        "mov.b16 hi, {a2, a3};\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3),
+          "f"(f4), "f"(f5), "f"(f6), "f"(f7)
+    );
+    return packed;
+}
+
+__device__ inline
+uint32_t cvt_2xf32_to_e8m0_packed_sqmxfp4mix(float f0, float f1) {
+    return ta_cvt_2xf32_to_e8m0_packed(f0, f1);
+}
+
+__device__ inline
+void mma_m16n8k64_mxfp4_sqmxfp4mix(uint32_t A[4], uint32_t B[2], uint32_t sf_A, uint32_t sf_B, float D[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4"
+        ".block_scale.scale_vec::2X.f32.e2m1.e2m1.f32.ue8m0 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]),
+          "r"(sf_A), "h"(byte_id), "h"(thread_id),
+          "r"(sf_B), "h"(byte_id), "h"(thread_id));
+}
+
+
+template<typename T, int HEAD_DIM, int BLOCK_Q = 16>
+__device__ __forceinline__
+void load_q_fp16_to_regs_single_query_sqmxfp4mix(
+    uint32_t (&Q_rmem)[HEAD_DIM / 16][4],
+    uint32_t Q_smem,
+    const T* Q_ptr,
+    int lane_id,
+    int q_len)
+{
+    constexpr int MMA_K = 16;
+    constexpr int ROW_BYTES = HEAD_DIM * (int)sizeof(T);
+    constexpr int TOTAL_BYTES = BLOCK_Q * ROW_BYTES;
+    constexpr int LOAD_UNIT = 16;  // cp.async.cg copies 16 bytes
+    constexpr int TOTAL_CHUNKS = TOTAL_BYTES / LOAD_UNIT;
+
+    static_assert(HEAD_DIM % MMA_K == 0);
+    static_assert(ROW_BYTES % LOAD_UNIT == 0);
+
+    // Zero the entire BLOCK_Q × HEAD_DIM staging area, then load valid rows.
+    // 32 lanes cooperate; each lane handles multiple 16-byte chunks.
+    for (int chunk = lane_id; chunk < TOTAL_CHUNKS; chunk += WARP_SIZE_sqmxfp4mix) {
+        const int byte_off = chunk * LOAD_UNIT;
+        const int row = byte_off / ROW_BYTES;
+        const int col = byte_off % ROW_BYTES;
+        uint32_t dst = swizzle_sqmxfp4mix<ROW_BYTES>(Q_smem + row * ROW_BYTES + col);
+
+        if (row < q_len) {
+            const char* src = reinterpret_cast<const char*>(Q_ptr + row * HEAD_DIM) + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst), "l"(src));
+        } else {
+            // Zero-fill rows beyond q_len so the MMA sees zeros
+            asm volatile("st.shared.v4.b32 [%0], {%1, %2, %3, %4};"
+                :: "r"(dst), "r"(0), "r"(0), "r"(0), "r"(0));
+        }
+    }
+
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    // ldmatrix layout for A operand of mma.m16n8k16.row.col
+    const uint32_t Q_ld_base = swizzle_sqmxfp4mix<ROW_BYTES>(
+        Q_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+    #pragma unroll
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * MMA_K * (int)sizeof(T);
+        ldmatrix_x4_sqmxfp4mix(Q_rmem[mma_id_d], addr);
+    }
+}
+
+
+template<typename T, int BLOCK_KV, int BLOCK_KV_STEP, int HEAD_DIM,
+         bool USE_LOWER_ROWS = true, int O_REGS = 4>
+__device__ __forceinline__
+void attention_inner_loop_fp16_mxfp4(
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][O_REGS],
+    uint32_t Q_rmem[HEAD_DIM / 16][4],
+    uint32_t K_smem,
+    uint32_t V_smem,
+    const T*& K_ptr,
+    const T*& V_ptr,
+    const int lane_id,
+    const float softmax_scale)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int MMA_K = 16;
+    constexpr int MMA_N = 8;
+    constexpr float FP4_RANGE = 6.0f;  // keep final normalization compatible
+
+    static_assert(BLOCK_KV % BLOCK_KV_STEP == 0);
+    static_assert(BLOCK_KV_STEP % MMA_K == 0);
+    static_assert(HEAD_DIM % MMA_K == 0);
+    static_assert(HEAD_DIM % MMA_N == 0);
+
+    const uint32_t K_ld_base = swizzle_sqmxfp4mix<HEAD_DIM * (int)sizeof(T)>(
+        K_smem + ((lane_id % 8) * HEAD_DIM + (lane_id / 8) * 8) * (int)sizeof(T));
+
+    const uint32_t V_ld_base = swizzle_sqmxfp4mix<HEAD_DIM * (int)sizeof(T)>(
+        V_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+    for (int kv_sub = 0; kv_sub < BLOCK_KV; kv_sub += BLOCK_KV_STEP) {
+        gmem_to_smem_sqmxfp4mix<BLOCK_KV_STEP, HEAD_DIM, WARP_SIZE_sqmxfp4mix, T>(
+            K_smem, K_ptr, lane_id, HEAD_DIM);
+        gmem_to_smem_sqmxfp4mix<BLOCK_KV_STEP, HEAD_DIM, WARP_SIZE_sqmxfp4mix, T>(
+            V_smem, V_ptr, lane_id, HEAD_DIM);
+
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        uint32_t K_rmem[BLOCK_KV_STEP / MMA_N][HEAD_DIM / MMA_K][2];
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                uint32_t addr = K_ld_base;
+                addr += mma_id_kv * MMA_N * HEAD_DIM * (int)sizeof(T);
+                addr ^= mma_id_d * MMA_K * (int)sizeof(T);
+                ldmatrix_x2_sqmxfp4mix(K_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        float S_rmem[BLOCK_KV_STEP / MMA_N][4] = {};
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                Traits::mma(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+            }
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int reg_id = 0; reg_id < 4; reg_id++) {
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+            }
+        }
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            float* r = S_rmem[mma_id_kv];
+            this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+            if constexpr (USE_LOWER_ROWS)
+                this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+        if constexpr (USE_LOWER_ROWS) {
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        if constexpr (USE_LOWER_ROWS)
+            this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale0 = __expf(rowmax[0] - this_rowmax[0]);
+        float rescale1 = 1.0f;
+        if constexpr (USE_LOWER_ROWS)
+            rescale1 = __expf(rowmax[1] - this_rowmax[1]);
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale0;
+            O_rmem[mma_id_d][1] *= rescale0;
+            if constexpr (USE_LOWER_ROWS && O_REGS == 4) {
+                O_rmem[mma_id_d][2] *= rescale1;
+                O_rmem[mma_id_d][3] *= rescale1;
+            }
+        }
+
+        rowmax[0] = this_rowmax[0];
+        if constexpr (USE_LOWER_ROWS)
+            rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        uint32_t P_rmem[BLOCK_KV_STEP / MMA_K][4];
+
+        for (int mma_blk = 0; mma_blk < BLOCK_KV_STEP / MMA_K; mma_blk++) {
+            const int t0 = 2 * mma_blk + 0;
+            const int t1 = 2 * mma_blk + 1;
+
+            float* r0 = S_rmem[t0];
+            float* r1 = S_rmem[t1];
+
+            r0[0] = __expf(r0[0] - rowmax[0]);
+            r0[1] = __expf(r0[1] - rowmax[0]);
+
+            r1[0] = __expf(r1[0] - rowmax[0]);
+            r1[1] = __expf(r1[1] - rowmax[0]);
+
+            this_rowsumexp[0] += r0[0] + r0[1] + r1[0] + r1[1];
+            if constexpr (USE_LOWER_ROWS) {
+                r0[2] = __expf(r0[2] - rowmax[1]);
+                r0[3] = __expf(r0[3] - rowmax[1]);
+                r1[2] = __expf(r1[2] - rowmax[1]);
+                r1[3] = __expf(r1[3] - rowmax[1]);
+                this_rowsumexp[1] += r0[2] + r0[3] + r1[2] + r1[3];
+            } else {
+                r0[2] = 0.0f; r0[3] = 0.0f;
+                r1[2] = 0.0f; r1[3] = 0.0f;
+            }
+
+            typename Traits::vec2* p = reinterpret_cast<typename Traits::vec2*>(P_rmem[mma_blk]);
+            p[0] = Traits::pack2(r0[0] * FP4_RANGE, r0[1] * FP4_RANGE);
+            p[1] = Traits::pack2(r0[2] * FP4_RANGE, r0[3] * FP4_RANGE);
+            p[2] = Traits::pack2(r1[0] * FP4_RANGE, r1[1] * FP4_RANGE);
+            p[3] = Traits::pack2(r1[2] * FP4_RANGE, r1[3] * FP4_RANGE);
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+
+        rowsum[0] = rowsum[0] * rescale0 + this_rowsumexp[0];
+        if constexpr (USE_LOWER_ROWS) {
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+            rowsum[1] = rowsum[1] * rescale1 + this_rowsumexp[1];
+        }
+
+        uint32_t V_rmem[BLOCK_KV_STEP / MMA_K][HEAD_DIM / MMA_N][2];
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                uint32_t addr = V_ld_base;
+                addr += mma_id_kv * MMA_K * HEAD_DIM * (int)sizeof(T);
+                addr ^= mma_id_d * MMA_N * (int)sizeof(T);
+                ldmatrix_x2_trans_sqmxfp4mix(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_K; mma_id_kv++) {
+                if constexpr (O_REGS == 4) {
+                    Traits::mma(
+                        P_rmem[mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        O_rmem[mma_id_d]);
+                } else {
+                    float d[4] = {O_rmem[mma_id_d][0], O_rmem[mma_id_d][1], 0.0f, 0.0f};
+                    Traits::mma(
+                        P_rmem[mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        d);
+                    O_rmem[mma_id_d][0] = d[0];
+                    O_rmem[mma_id_d][1] = d[1];
+                }
+            }
+        }
+
+        K_ptr += BLOCK_KV_STEP * HEAD_DIM;
+        V_ptr += BLOCK_KV_STEP * HEAD_DIM;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Separated load / compute helpers for FP4 attention.
+// Used by the split kernel for double-buffering; the combined
+// attention_inner_loop_fp4_mxfp4 below calls them sequentially.
+// ---------------------------------------------------------------------------
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__device__ __forceinline__
+void load_kv_fp4_async_sqmxfp4mix(
+    uint32_t K_smem, uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    const __nv_fp4x2_e2m1* K_ptr,
+    const __nv_fp4x2_e2m1* V_ptr,
+    const __nv_fp8_e8m0* SK_ptr,
+    const __nv_fp8_e8m0* SV_ptr,
+    int lane_id, int v_kv)
+{
+    gmem_to_smem_sqmxfp4mix<BLOCK_KV, HEAD_DIM_2, WARP_SIZE_sqmxfp4mix, __nv_fp4x2_e2m1>(K_smem,    K_ptr,  lane_id, HEAD_DIM_2);
+    load_scales_sqmxfp4mix <BLOCK_KV, SCALE_DIM,  WARP_SIZE_sqmxfp4mix, __nv_fp8_e8m0>  (K_sf_smem, SK_ptr, SCALE_DIM, lane_id);
+    gmem_to_smem_sqmxfp4mix<HEAD_DIM, BLOCK_KV/2, WARP_SIZE_sqmxfp4mix, __nv_fp4x2_e2m1>(V_smem,    V_ptr,  lane_id, v_kv / 2);
+    load_scales_sqmxfp4mix <HEAD_DIM, BLOCK_KV / 32,WARP_SIZE_sqmxfp4mix, __nv_fp8_e8m0>  (V_sf_smem, SV_ptr, v_kv / 32, lane_id);
+    asm volatile("cp.async.commit_group;");
+}
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM,
+         bool USE_LOWER_ROWS = true, int O_REGS = 4>
+__device__ __forceinline__
+void compute_kv_fp4_sqmxfp4mix(
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][O_REGS],
+    uint32_t Q_rmem[HEAD_DIM / 64][4],
+    uint32_t sfQ_rmem[HEAD_DIM / 64],
+    uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    uint32_t K_ld_base,
+    const int lane_id,
+    const float softmax_scale)
+{
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    // ---- K → registers ----
+    uint32_t K_rmem [BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+
+    if constexpr (HEAD_DIM / MMA_K >= 2) {
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+            ldmatrix_x4_sqmxfp4mix(K_rmem[mma_id_kv][0], addr);
+        }
+    } else {
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                uint32_t addr = K_ld_base;
+                addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                addr ^= mma_id_d * (MMA_K / 2);
+                ldmatrix_x2_sqmxfp4mix(K_rmem[mma_id_kv][mma_id_d], addr);
+            }
+    }
+
+    // ---- K scales → registers ----
+    const int sf_row_k = lane_id / 4;
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            const int row = mma_id_kv * MMA_N + sf_row_k;
+            const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+            sfK_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4mix(K_sf_smem + offset);
+        }
+
+    // ---- QK^T MMA → S_rmem (float) ----
+    float S_rmem[BLOCK_KV / MMA_N][4] = {};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+            mma_m16n8k64_mxfp4_sqmxfp4mix(
+                Q_rmem[mma_id_d],
+                K_rmem[mma_id_kv][mma_id_d],
+                sfQ_rmem[mma_id_d],
+                sfK_rmem[mma_id_kv][mma_id_d],
+                S_rmem[mma_id_kv]);
+
+    // ---- Online softmax ----
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int reg_id = 0; reg_id < 4; reg_id++)
+            S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+    float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        float *r = S_rmem[mma_id_kv];
+        this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+        if constexpr (USE_LOWER_ROWS)
+            this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+    }
+    this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+    this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+    if constexpr (USE_LOWER_ROWS) {
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+    }
+
+    this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+    if constexpr (USE_LOWER_ROWS)
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+    float rescale0 = __expf(rowmax[0] - this_rowmax[0]);
+    float rescale1 = 1.0f;
+    if constexpr (USE_LOWER_ROWS)
+        rescale1 = __expf(rowmax[1] - this_rowmax[1]);
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        O_rmem[mma_id_d][0] *= rescale0;  O_rmem[mma_id_d][1] *= rescale0;
+        if constexpr (USE_LOWER_ROWS && O_REGS == 4) {
+            O_rmem[mma_id_d][2] *= rescale1;  O_rmem[mma_id_d][3] *= rescale1;
+        }
+    }
+    rowmax[0] = this_rowmax[0];
+    if constexpr (USE_LOWER_ROWS)
+        rowmax[1] = this_rowmax[1];
+
+    float this_rowsumexp[2] = {};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        float *r = S_rmem[mma_id_kv];
+        r[0] = __expf(r[0] - rowmax[0]);  r[1] = __expf(r[1] - rowmax[0]);
+        this_rowsumexp[0] += r[0] + r[1];
+        if constexpr (USE_LOWER_ROWS) {
+            r[2] = __expf(r[2] - rowmax[1]);  r[3] = __expf(r[3] - rowmax[1]);
+            this_rowsumexp[1] += r[2] + r[3];
+        } else {
+            r[2] = 0.0f;  r[3] = 0.0f;
+        }
+    }
+    this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+    this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+    rowsum[0] = rowsum[0] * rescale0 + this_rowsumexp[0];
+    if constexpr (USE_LOWER_ROWS) {
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+        rowsum[1] = rowsum[1] * rescale1 + this_rowsumexp[1];
+    }
+
+    // ---- Quantise S → FP4 for P@V ----
+    constexpr float FP4_RANGE = 6.0f;
+    constexpr float FP4_MAX   = 6.0f;
+
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        S_rmem[mma_id_kv][0] *= FP4_RANGE;
+        S_rmem[mma_id_kv][1] *= FP4_RANGE;
+        if constexpr (USE_LOWER_ROWS) {
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        } else {
+            S_rmem[mma_id_kv][2] = 0.0f;
+            S_rmem[mma_id_kv][3] = 0.0f;
+        }
+    }
+
+    float sf_P_upper[BLOCK_KV / MMA_N / 4];
+    float sf_P_lower[BLOCK_KV / MMA_N / 4];
+    for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+        int t0 = 4 * blk, t1 = t0 + 1, t2 = t0 + 2, t3 = t0 + 3;
+        float amax_upper = max(
+            max(max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])),
+            max(max(S_rmem[t2][0], S_rmem[t2][1]),
+                max(S_rmem[t3][0], S_rmem[t3][1])));
+        amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+        amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+        sf_P_upper[blk] = amax_upper / FP4_MAX;
+        if constexpr (USE_LOWER_ROWS) {
+            float amax_lower = max(
+                max(max(S_rmem[t0][2], S_rmem[t0][3]),
+                    max(S_rmem[t1][2], S_rmem[t1][3])),
+                max(max(S_rmem[t2][2], S_rmem[t2][3]),
+                    max(S_rmem[t3][2], S_rmem[t3][3])));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+        } else {
+            sf_P_lower[blk] = 1.0f;
+        }
+    }
+
+    for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+        float inv_upper = 1.0f / sf_P_upper[blk];
+        int t0 = 4 * blk, t1 = t0 + 1, t2 = t0 + 2, t3 = t0 + 3;
+        S_rmem[t0][0] *= inv_upper;  S_rmem[t0][1] *= inv_upper;
+        S_rmem[t1][0] *= inv_upper;  S_rmem[t1][1] *= inv_upper;
+        S_rmem[t2][0] *= inv_upper;  S_rmem[t2][1] *= inv_upper;
+        S_rmem[t3][0] *= inv_upper;  S_rmem[t3][1] *= inv_upper;
+        if constexpr (USE_LOWER_ROWS) {
+            float inv_lower = 1.0f / sf_P_lower[blk];
+            S_rmem[t0][2] *= inv_lower;  S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;  S_rmem[t1][3] *= inv_lower;
+            S_rmem[t2][2] *= inv_lower;  S_rmem[t2][3] *= inv_lower;
+            S_rmem[t3][2] *= inv_lower;  S_rmem[t3][3] *= inv_lower;
+        }
+    }
+
+    // Shuffle S into MMA-compatible layout
+    uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+    const int qid = lane_id & 3;
+    for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+        for (int r = 0; r < 4; r++) {
+            float send, recv;
+            send = (qid & 1) ? S_rmem[g*4+0][r] : S_rmem[g*4+1][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+            if (qid & 1) S_rmem[g*4+0][r] = recv; else S_rmem[g*4+1][r] = recv;
+
+            send = (qid & 1) ? S_rmem[g*4+2][r] : S_rmem[g*4+3][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+            if (qid & 1) S_rmem[g*4+2][r] = recv; else S_rmem[g*4+3][r] = recv;
+
+            send = (qid & 2) ? S_rmem[g*4+0][r] : S_rmem[g*4+2][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+            if (qid & 2) S_rmem[g*4+0][r] = recv; else S_rmem[g*4+2][r] = recv;
+
+            send = (qid & 2) ? S_rmem[g*4+1][r] : S_rmem[g*4+3][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+            if (qid & 2) S_rmem[g*4+1][r] = recv; else S_rmem[g*4+3][r] = recv;
+        }
+
+        float *r0 = S_rmem[g*4], *r1 = S_rmem[g*4+1],
+              *r2 = S_rmem[g*4+2], *r3 = S_rmem[g*4+3];
+        S_fp4_rmem[0][2*g]   = cvt_8xf32_to_e2m1_packed_sqmxfp4mix(r0[1],r0[0],r1[1],r1[0], r2[1],r2[0],r3[1],r3[0]);
+        S_fp4_rmem[0][2*g+1] = cvt_8xf32_to_e2m1_packed_sqmxfp4mix(r0[3],r0[2],r1[3],r1[2], r2[3],r2[2],r3[3],r3[2]);
+    }
+
+    uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+    for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+        int base = mma_sc_id * 2;
+        uint32_t sfP_upper_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4mix(
+            sf_P_upper[base+1], sf_P_upper[base+0]);
+        uint32_t sfP_lower_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4mix(
+            sf_P_lower[base+1], sf_P_lower[base+0]);
+        S_fp4_s_rmem[mma_sc_id] = (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+    }
+
+    // ---- V → registers ----
+    uint32_t V_rmem [BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+            const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+            const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+            uint32_t addr = swizzle_sqmxfp4mix<BLOCK_KV / 2>(
+                V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+            ldmatrix_x4_sqmxfp4mix(V_rmem[mma_id_kv][mma_id_d], addr);
+        }
+
+    constexpr int V_SF_STRIDE = BLOCK_KV / 32;
+    const int sf_col_v = lane_id / 4;
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int hd_col = mma_id_d * MMA_N + sf_col_v;
+            const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+            sfV_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4mix(V_sf_smem + offset);
+        }
+
+    // ---- O += P @ V ----
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            if constexpr (O_REGS == 4) {
+                mma_m16n8k64_mxfp4_sqmxfp4mix(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+            } else {
+                float d[4] = {O_rmem[mma_id_d][0], O_rmem[mma_id_d][1], 0.0f, 0.0f};
+                mma_m16n8k64_mxfp4_sqmxfp4mix(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    d);
+                O_rmem[mma_id_d][0] = d[0];
+                O_rmem[mma_id_d][1] = d[1];
+            }
+        }
+}
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__device__ __forceinline__
+void attention_inner_loop_fp4_mxfp4(
+    // Persistent accumulator state (read-modify-write across iterations)
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][4],  // HEAD_DIM / MMA_N, MMA_N=8
+
+    // Q register tiles (loaded once before the loop)
+    uint32_t Q_rmem[HEAD_DIM / 64][4],   // HEAD_DIM / MMA_K
+    uint32_t sfQ_rmem[HEAD_DIM / 64],
+
+    // KV smem base addresses (warp-private regions)
+    uint32_t K_smem, uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    uint32_t K_ld_base,
+
+    // KV global-memory pointers (advanced at end of each iteration)
+    const __nv_fp4x2_e2m1*& K_ptr,
+    const __nv_fp4x2_e2m1*& V_ptr,
+    const __nv_fp8_e8m0*&   SK_ptr,
+    const __nv_fp8_e8m0*&   SV_ptr,
+
+    // Per-call constants
+    const int lane_id,
+    const float softmax_scale,
+    const int v_kv)
+{
+    load_kv_fp4_async_sqmxfp4mix<BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+        K_smem, K_sf_smem, V_smem, V_sf_smem,
+        K_ptr, V_ptr, SK_ptr, SV_ptr, lane_id, v_kv);
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    compute_kv_fp4_sqmxfp4mix<BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+        K_sf_smem, V_smem, V_sf_smem, K_ld_base,
+        lane_id, softmax_scale);
+
+    K_ptr  += BLOCK_KV * HEAD_DIM_2;
+    SK_ptr += BLOCK_KV * SCALE_DIM;
+    V_ptr  += BLOCK_KV / 2;
+    SV_ptr += BLOCK_KV / 32;
+}
+
+template<
+    typename T,
+    int BLOCK_KV_FP16,
+    int BLOCK_KV_FP4,
+    int HEAD_DIM,
+    int HEAD_DIM_2,
+    int SCALE_DIM,
+    int NUM_WARPS,
+    int KV_SMEM_PER_WARP>
+__launch_bounds__(NUM_WARPS * WARP_SIZE_sqmxfp4mix, 1)
+__global__
+void thrift_attention_single_query_cta_kernel(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmxfp4mix;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    // Stride uses capacity (allocation), loop bounds use kv_len (logical).
+    const int v_kv = cdiv_sqmxfp4mix(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / WARP_SIZE_sqmxfp4mix;
+    const int lane_id = tid % WARP_SIZE_sqmxfp4mix;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    Q_fp16 += bid * q_len       * HEAD_DIM;
+    K_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+    V_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+
+    const int32_t* topk_row = top_k + bid * topk_count;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: cooperatively load Q_fp4 + scales into smem ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem so unused rows (q_len..15) are zero
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncthreads();
+
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmxfp4mix<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto* src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto* src_addr = S_Q + row * SCALE_DIM;
+            if constexpr (SF_ROW_BYTES == 2) {
+                uint16_t value;
+                asm volatile("ld.global.u16 %0, [%1];"
+                    : "=h"(value)
+                    : "l"(src_addr));
+                asm volatile("st.shared.u16 [%0], %1;"
+                    :: "r"(dst_addr), "h"(value));
+            } else {
+                asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                    :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+            }
+        }
+    }
+
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmxfp4mix<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+        ldmatrix_x4_sqmxfp4mix(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        const uint32_t offset =
+            (sf_row_q * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+        sfQ_rmem[mma_id_d] = ld_shared_e8m0x2_sqmxfp4mix(Q_sf_smem + offset);
+    }
+
+    __syncthreads();
+
+    // ---- Phase 2: warp-private KV processing ----
+    const uint32_t warp_kv_base = __cvta_generic_to_shared(smem) + warp_id * KV_SMEM_PER_WARP;
+
+    // FP4 layout in warp-private smem
+    const uint32_t K_smem_fp4    = warp_kv_base;
+    const uint32_t K_sf_smem     = K_smem_fp4 + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem_fp4    = K_sf_smem + BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+    const uint32_t V_sf_smem     = V_smem_fp4 + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    // FP16 layout in warp-private smem
+    const uint32_t K_smem_fp16   = warp_kv_base;
+    const uint32_t V_smem_fp16   = K_smem_fp16 + BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T);
+
+    const int total_kv_blocks = cdiv_sqmxfp4mix(kv_len, BLOCK_KV_FP4);
+    const int blocks_per_warp = cdiv_sqmxfp4mix(total_kv_blocks, NUM_WARPS);
+    const int kv_block_start = warp_id * blocks_per_warp;
+    const int kv_block_end   = (kv_block_start + blocks_per_warp < total_kv_blocks)
+                             ? (kv_block_start + blocks_per_warp)
+                             : total_kv_blocks;
+    const int num_kv_iters   = (kv_block_start < total_kv_blocks)
+                             ? (kv_block_end - kv_block_start)
+                             : 0;
+
+    const bool warp_has_fp16 = range_has_topk_sqmxfp4mix(topk_row, topk_count, kv_block_start, kv_block_end);
+
+    uint32_t K_ld_base_fp4;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base_fp4 = swizzle_sqmxfp4mix<HEAD_DIM_2>(K_smem_fp4 + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // Phase 2a: process all FP4 blocks first (no FP16 registers live)
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        const int global_block_id = kv_block_start + kv_iter;
+        if (warp_has_fp16 && block_in_topk_sqmxfp4mix(topk_row, topk_count, global_block_id))
+            continue;
+
+        const __nv_fp4x2_e2m1* K_ptr_iter = K + global_block_id * BLOCK_KV_FP4 * HEAD_DIM_2;
+        const __nv_fp4x2_e2m1* V_ptr_iter = V + global_block_id * BLOCK_KV_FP4 / 2;
+        const __nv_fp8_e8m0*   SK_ptr_iter = S_K + global_block_id * BLOCK_KV_FP4 * SCALE_DIM;
+        const __nv_fp8_e8m0*   SV_ptr_iter = S_V + global_block_id * BLOCK_KV_FP4 / 32;
+
+        attention_inner_loop_fp4_mxfp4<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+            rowmax, rowsum, O_rmem,
+            Q_rmem, sfQ_rmem,
+            K_smem_fp4, K_sf_smem,
+            V_smem_fp4, V_sf_smem,
+            K_ld_base_fp4,
+            K_ptr_iter, V_ptr_iter,
+            SK_ptr_iter, SV_ptr_iter,
+            lane_id, softmax_scale, v_kv);
+    }
+
+    // Phase 2b: process FP16 (top-k) blocks — Q FP16 loaded once
+    if (warp_has_fp16) {
+        uint32_t Q_fp16_rmem[HEAD_DIM / 16][4];
+        load_q_fp16_to_regs_single_query_sqmxfp4mix<T, HEAD_DIM, BLOCK_Q>(
+            Q_fp16_rmem, K_smem_fp16, Q_fp16, lane_id, q_len);
+
+        for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+            const int global_block_id = kv_block_start + kv_iter;
+            if (!block_in_topk_sqmxfp4mix(topk_row, topk_count, global_block_id))
+                continue;
+
+            const T* K_fp16_ptr_iter = K_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+            const T* V_fp16_ptr_iter = V_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+
+            attention_inner_loop_fp16_mxfp4<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM>(
+                rowmax, rowsum, O_rmem,
+                Q_fp16_rmem,
+                K_smem_fp16, V_smem_fp16,
+                K_fp16_ptr_iter, V_fp16_ptr_iter,
+                lane_id, softmax_scale);
+        }
+    }
+
+    // ---- Phase 3: CTA reduction ----
+    __syncthreads();
+
+    float* reduce_base = reinterpret_cast<float*>(smem);
+    float* rowmax_smem = reduce_base;
+    float* rowsum_smem = rowmax_smem + NUM_WARPS * BLOCK_Q;
+    float* O_part_smem = rowsum_smem + NUM_WARPS * BLOCK_Q;
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        rowmax_smem[warp_id * BLOCK_Q + row]     = rowmax[0];
+        rowmax_smem[warp_id * BLOCK_Q + row + 8] = rowmax[1];
+        rowsum_smem[warp_id * BLOCK_Q + row]     = rowsum[0];
+        rowsum_smem[warp_id * BLOCK_Q + row + 8] = rowsum[1];
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float* regs = O_rmem[mma_id_d];
+
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col]           = regs[0];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col + 1]       = regs[1];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col]     = regs[2];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col + 1] = regs[3];
+    }
+
+    __syncthreads();
+
+    constexpr float FP4_RANGE_INV = 1.0f / (6.0f);
+
+    if (tid < BLOCK_Q) {
+        const int row = tid;
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = max(global_max, rowmax_smem[w * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        float rsc[NUM_WARPS];
+        for (int w = 0; w < NUM_WARPS; w++) {
+            rsc[w] = __expf(rowmax_smem[w * BLOCK_Q + row] - global_max);
+            sum_acc += rowsum_smem[w * BLOCK_Q + row] * rsc[w];
+        }
+
+        float norm = FP4_RANGE_INV / sum_acc;
+        for (int w = 0; w < NUM_WARPS; w++)
+            rowmax_smem[w * BLOCK_Q + row] = rsc[w];
+        rowsum_smem[row] = norm;
+    }
+
+    __syncthreads();
+
+    constexpr int TOTAL_PAIRS = BLOCK_Q * (HEAD_DIM / 2);
+
+    for (int pair = tid; pair < TOTAL_PAIRS; pair += TB_SIZE) {
+        const int elem = pair * 2;
+        const int row = elem / HEAD_DIM;
+        const int col = elem % HEAD_DIM;
+
+        float norm = rowsum_smem[row];
+        float acc0 = 0.0f, acc1 = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++) {
+            float rsc = rowmax_smem[w * BLOCK_Q + row];
+            const float* src = &O_part_smem[w * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col];
+            acc0 += src[0] * rsc;
+            acc1 += src[1] * rsc;
+        }
+
+        if (row < q_len) {
+            typename Traits::vec2 result = Traits::pack2(acc0 * norm, acc1 * norm);
+            *reinterpret_cast<typename Traits::vec2*>(&O[row * HEAD_DIM + col]) = result;
+        }
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void thrift_attention_single_query_cta_launch(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_KV_FP4 = 64;
+    constexpr int BLOCK_KV_FP16 = 32;
+    constexpr int BLOCK_Q = 16;
+    constexpr int NUM_WARPS = 4;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmxfp4mix;
+
+    constexpr int q_phase_smem_fp4 =
+        BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+
+    constexpr int q_phase_smem_fp16 =
+        BLOCK_Q * HEAD_DIM * (int)sizeof(T);
+
+    constexpr int q_phase_smem =
+        (q_phase_smem_fp16 > q_phase_smem_fp4) ? q_phase_smem_fp16 : q_phase_smem_fp4;
+
+    constexpr int kv_smem_per_warp_fp4 =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    constexpr int kv_smem_per_warp_fp16 =
+        BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T) * 2;
+
+    constexpr int kv_smem_per_warp =
+        (kv_smem_per_warp_fp4 > kv_smem_per_warp_fp16) ? kv_smem_per_warp_fp4 : kv_smem_per_warp_fp16;
+
+    constexpr int kv_phase_smem = NUM_WARPS * kv_smem_per_warp;
+
+    constexpr int reduce_smem =
+        (int)sizeof(float) * (NUM_WARPS * BLOCK_Q * 2 + NUM_WARPS * BLOCK_Q * HEAD_DIM);
+
+    constexpr int smem_12 = (q_phase_smem > kv_phase_smem) ? q_phase_smem : kv_phase_smem;
+    constexpr int smem_size = (smem_12 > reduce_smem) ? smem_12 : reduce_smem;
+
+    auto kernel =
+        thrift_attention_single_query_cta_kernel<
+            T,
+            BLOCK_KV_FP16,
+            BLOCK_KV_FP4,
+            HEAD_DIM,
+            HEAD_DIM_2,
+            SCALE_DIM,
+            NUM_WARPS,
+            kv_smem_per_warp>;
+
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q_fp16,
+        K_fp16,
+        V_fp16,
+        top_k,
+        topk_count,
+        Q_fp4,
+        K_fp4,
+        V_fp4,
+        S_Q,
+        S_K,
+        S_V,
+        O,
+        bs,
+        q_len,
+        kv_len,
+        kv_capacity,
+        num_q_heads,
+        num_kv_heads);
+
+}
+
+// ---------------------------------------------------------------------------
+// Split-KV mixed-precision single-query kernel.
+// Grid: (num_kv_splits, bs).  Each block is a single warp that processes a
+// contiguous range of KV blocks (FP16 for top-k, FP4 for the rest), writes
+// partial (O, rowmax, rowsum) to a global workspace, then the last block to
+// finish reduces all partials and writes the final FP16 output.
+//
+// Optimisations over the naive version:
+//   1. Bitmask for O(1) top-k lookup instead of O(topk_count) linear scan
+//   2. Double-buffered FP4 KV loads (overlaps gmem latency with MMA compute)
+//   3. float2 vectorised partial-O stores
+//   4. Two-pass smem-assisted reduction (precompute per-row rescale once)
+// ---------------------------------------------------------------------------
+template<
+    typename T,
+    int BLOCK_KV_FP16,
+    int BLOCK_KV_FP4,
+    int HEAD_DIM,
+    int HEAD_DIM_2,
+    int SCALE_DIM,
+    bool UPPER_ONLY = false>
+__launch_bounds__(WARP_SIZE_sqmxfp4mix)
+__global__
+void thrift_attention_single_query_split_kernel(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    float* O_partial,
+    float* rowmax_partial,
+    float* rowsum_partial,
+    T* O_final,
+    int* split_counter,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_kv_splits,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4mix;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    // Size of one FP4 KV buffer in smem (bytes)
+    constexpr int FP4_BUF_BYTES =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqmxfp4mix(kv_capacity, 128) * 128;
+
+    const int split_id = blockIdx.x;
+    const int bid = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    const int total_kv_blocks = cdiv_sqmxfp4mix(kv_len, BLOCK_KV_FP4);
+    const int kv_block_start = (split_id * total_kv_blocks) / num_kv_splits;
+    const int kv_block_end = ((split_id + 1) * total_kv_blocks) / num_kv_splits;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+
+    Q_fp16 += bid * q_len       * HEAD_DIM;
+    K_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+    V_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+
+    const int partial_offset = bid * num_kv_splits + split_id;
+    O_partial      += partial_offset * q_len * HEAD_DIM;
+    rowmax_partial += partial_offset * q_len;
+    rowsum_partial += partial_offset * q_len;
+
+    const int32_t* topk_row = top_k + bid * topk_count;
+
+    // ---- Optimisation 1: build local bitmask for O(1) top-k lookup ----
+    constexpr int TOPK_MASK_WORDS = 4;  // 128 bits — covers up to 128 blocks/split
+    constexpr int TOPK_MASK_BITS  = TOPK_MASK_WORDS * 32;
+    uint32_t topk_local_mask[TOPK_MASK_WORDS] = {};
+
+    const int num_kv_iters = kv_block_end - kv_block_start;
+
+    for (int i = lane_id; i < topk_count; i += WARP_SIZE_sqmxfp4mix) {
+        int b = topk_row[i] - kv_block_start;
+        if (b >= 0 && b < min(num_kv_iters, TOPK_MASK_BITS))
+            topk_local_mask[b >> 5] |= (1u << (b & 31));
+    }
+    #pragma unroll
+    for (int w = 0; w < TOPK_MASK_WORDS; w++) {
+        #pragma unroll
+        for (int delta = WARP_SIZE_sqmxfp4mix / 2; delta > 0; delta >>= 1)
+            topk_local_mask[w] |= __shfl_down_sync(0xffffffffu, topk_local_mask[w], delta);
+        topk_local_mask[w] = __shfl_sync(0xffffffffu, topk_local_mask[w], 0);
+    }
+
+    const bool range_has_fp16 = (num_kv_iters <= TOPK_MASK_BITS)
+        ? ((topk_local_mask[0] | topk_local_mask[1] |
+            topk_local_mask[2] | topk_local_mask[3]) != 0)
+        : range_has_topk_sqmxfp4mix(topk_row, topk_count, kv_block_start, kv_block_end);
+
+    // Helper lambda: O(1) top-k test for local block index
+    auto is_topk = [&](int local_idx) -> bool {
+        if (local_idx < TOPK_MASK_BITS)
+            return (topk_local_mask[local_idx >> 5] >> (local_idx & 31)) & 1;
+        return block_in_topk_sqmxfp4mix(topk_row, topk_count, kv_block_start + local_idx);
+    };
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q_fp4 + scales → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[2] = {-FLT_MAX, -FLT_MAX};
+    float rowsum[2] = {};
+    constexpr int O_REGS = UPPER_ONLY ? 2 : 4;
+    float O_rmem[HEAD_DIM / MMA_N][O_REGS] = {};
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmxfp4mix<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            if constexpr (SF_ROW_BYTES == 2) {
+                uint16_t value;
+                asm volatile("ld.global.u16 %0, [%1];"
+                    : "=h"(value)
+                    : "l"(src_addr));
+                asm volatile("st.shared.u16 [%0], %1;"
+                    :: "r"(dst_addr), "h"(value));
+            } else {
+                asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                    :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+            }
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmxfp4mix<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+        ldmatrix_x4_sqmxfp4mix(Q_rmem[mma_id_d], addr);
+    }
+    __syncwarp();
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        const uint32_t offset =
+            (sf_row_q * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+        sfQ_rmem[mma_id_d] = ld_shared_e8m0x2_sqmxfp4mix(Q_sf_smem + offset);
+    }
+
+    // ---- Phase 2: KV loop ----
+    __syncwarp();
+
+    // ---- Optimisation 2: double-buffered FP4 smem layout ----
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    uint32_t K_smem_buf[2], K_sf_buf[2], V_smem_buf[2], V_sf_buf[2], K_ld_buf[2];
+    for (int b = 0; b < 2; b++) {
+        K_smem_buf[b] = smem_base + b * FP4_BUF_BYTES;
+        K_sf_buf[b]   = K_smem_buf[b] + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+        V_smem_buf[b] = K_sf_buf[b]   + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0);
+        V_sf_buf[b]   = V_smem_buf[b] + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_buf[b] = swizzle_sqmxfp4mix<HEAD_DIM_2>(K_smem_buf[b] + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // FP16 smem layout (overlaps buffer region — used only after FP4 is done)
+    const uint32_t K_smem_fp16 = smem_base;
+    const uint32_t V_smem_fp16 = K_smem_fp16 + BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T);
+
+    // ---- Double-buffered FP4 loop ----
+    {
+        // Find first non-topk block
+        int cur_iter = -1;
+        if (range_has_fp16) {
+            for (int i = 0; i < num_kv_iters; i++) {
+                if (!is_topk(i)) { cur_iter = i; break; }
+            }
+        } else {
+            if (num_kv_iters > 0) cur_iter = 0;
+        }
+
+        if (cur_iter >= 0) {
+            int cur_buf = 0;
+            int gid = kv_block_start + cur_iter;
+
+            // Preload first FP4 block
+            load_kv_fp4_async_sqmxfp4mix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+                K_smem_buf[0], K_sf_buf[0], V_smem_buf[0], V_sf_buf[0],
+                K + gid * BLOCK_KV_FP4 * HEAD_DIM_2,
+                V + gid * BLOCK_KV_FP4 / 2,
+                S_K + gid * BLOCK_KV_FP4 * SCALE_DIM,
+                S_V + gid * BLOCK_KV_FP4 / 32,
+                lane_id, v_kv);
+
+            while (cur_iter >= 0) {
+                // Find next non-topk block
+                int next_iter = -1;
+                for (int j = cur_iter + 1; j < num_kv_iters; j++) {
+                    if (!range_has_fp16 || !is_topk(j)) {
+                        next_iter = j;
+                        break;
+                    }
+                }
+
+                // Preload next block into alternate buffer
+                if (next_iter >= 0) {
+                    int next_gid = kv_block_start + next_iter;
+                    load_kv_fp4_async_sqmxfp4mix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+                        K_smem_buf[1 - cur_buf], K_sf_buf[1 - cur_buf],
+                        V_smem_buf[1 - cur_buf], V_sf_buf[1 - cur_buf],
+                        K + next_gid * BLOCK_KV_FP4 * HEAD_DIM_2,
+                        V + next_gid * BLOCK_KV_FP4 / 2,
+                        S_K + next_gid * BLOCK_KV_FP4 * SCALE_DIM,
+                        S_V + next_gid * BLOCK_KV_FP4 / 32,
+                        lane_id, v_kv);
+                }
+
+                // Wait for current buffer's load to complete
+                if (next_iter >= 0) {
+                    asm volatile("cp.async.wait_group %0;" :: "n"(1));
+                } else {
+                    asm volatile("cp.async.wait_all;");
+                }
+                __syncwarp();
+
+                // Compute attention on current buffer.  GQA single-query usually
+                // has q_len=4, so instantiate a variant that skips lower-half
+                // scalar softmax/packing work for rows 8..15.
+                if constexpr (UPPER_ONLY) {
+                    compute_kv_fp4_sqmxfp4mix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, false, 2>(
+                        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+                        K_sf_buf[cur_buf], V_smem_buf[cur_buf], V_sf_buf[cur_buf],
+                        K_ld_buf[cur_buf],
+                        lane_id, softmax_scale);
+                } else {
+                    compute_kv_fp4_sqmxfp4mix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, true, 4>(
+                        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+                        K_sf_buf[cur_buf], V_smem_buf[cur_buf], V_sf_buf[cur_buf],
+                        K_ld_buf[cur_buf],
+                        lane_id, softmax_scale);
+                }
+
+                cur_buf = 1 - cur_buf;
+                cur_iter = next_iter;
+            }
+        }
+    }
+
+    // FP16 (top-k) blocks — Q FP16 loaded once
+    if (range_has_fp16) {
+        uint32_t Q_fp16_rmem[HEAD_DIM / 16][4];
+        load_q_fp16_to_regs_single_query_sqmxfp4mix<T, HEAD_DIM, BLOCK_Q>(
+            Q_fp16_rmem, K_smem_fp16, Q_fp16, lane_id, q_len);
+
+        for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+            if (!is_topk(kv_iter))
+                continue;
+
+            const int global_block_id = kv_block_start + kv_iter;
+            const T* K_fp16_ptr_iter = K_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+            const T* V_fp16_ptr_iter = V_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+
+            if constexpr (UPPER_ONLY) {
+                attention_inner_loop_fp16_mxfp4<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM, false, 2>(
+                    rowmax, rowsum, O_rmem,
+                    Q_fp16_rmem,
+                    K_smem_fp16, V_smem_fp16,
+                    K_fp16_ptr_iter, V_fp16_ptr_iter,
+                    lane_id, softmax_scale);
+            } else {
+                attention_inner_loop_fp16_mxfp4<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM, true, 4>(
+                    rowmax, rowsum, O_rmem,
+                    Q_fp16_rmem,
+                    K_smem_fp16, V_smem_fp16,
+                    K_fp16_ptr_iter, V_fp16_ptr_iter,
+                lane_id, softmax_scale);
+            }
+        }
+    }
+
+    // ---- Phase 3: Write partials to global memory ----
+    // Optimisation 3: float2 vectorised stores
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        if (row < q_len) {
+            *reinterpret_cast<float2*>(&O_partial[row * HEAD_DIM + col]) =
+                make_float2(regs[0], regs[1]);
+        }
+        if constexpr (!UPPER_ONLY) {
+        if (row + 8 < q_len) {
+            *reinterpret_cast<float2*>(&O_partial[(row + 8) * HEAD_DIM + col]) =
+                make_float2(regs[2], regs[3]);
+        }
+        }
+    }
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        if (row < q_len) {
+            rowmax_partial[row] = rowmax[0];
+            rowsum_partial[row] = rowsum[0];
+        }
+        if constexpr (!UPPER_ONLY) {
+        if (row + 8 < q_len) {
+            rowmax_partial[row + 8] = rowmax[1];
+            rowsum_partial[row + 8] = rowsum[1];
+        }
+        }
+    }
+
+    // ---- Fused reduction: last split to finish reduces all partials ----
+    __threadfence();
+
+    int completed = 0;
+    if (lane_id == 0)
+        completed = atomicAdd(&split_counter[bid], 1);
+    completed = __shfl_sync(0xFFFFFFFF, completed, 0);
+
+    if (completed != num_kv_splits - 1)
+        return;
+
+    // ---- Optimisation 4: two-pass smem-assisted reduction ----
+    constexpr float FP4_RANGE_INV = 1.0f / (6.0f);
+    const float* batch_O = O_partial - split_id * q_len * HEAD_DIM;
+    const float* batch_rowmax = rowmax_partial - split_id * q_len;
+    const float* batch_rowsum = rowsum_partial - split_id * q_len;
+
+    // Pass 1: 16 threads compute per-row rescale factors + norms → smem
+    // Layout: rsc_smem[s * q_len + row], then norm_smem[row]
+    float* rsc_smem  = reinterpret_cast<float*>(smem);
+    float* norm_smem = rsc_smem + num_kv_splits * q_len;
+
+    if (lane_id < q_len) {
+        const int row = lane_id;
+        float global_max = -FLT_MAX;
+        for (int s = 0; s < num_kv_splits; s++)
+            global_max = max(global_max, batch_rowmax[s * q_len + row]);
+
+        float sum_acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = __expf(batch_rowmax[s * q_len + row] - global_max);
+            rsc_smem[s * q_len + row] = rsc;
+            sum_acc += batch_rowsum[s * q_len + row] * rsc;
+        }
+        norm_smem[row] = FP4_RANGE_INV / sum_acc;
+    }
+    __syncwarp();
+
+    // Pass 2: reduce only the valid q_len rows.  Qwen-style grouped single-query
+    // passes q_len=4, so reducing the full m16 tile mostly moves dead data.
+    const int valid_elems = q_len * HEAD_DIM;
+    for (int flat_idx = lane_id; flat_idx < valid_elems; flat_idx += TB_SIZE) {
+        const int row = flat_idx / HEAD_DIM;
+        const int col = flat_idx % HEAD_DIM;
+
+        float acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = rsc_smem[s * q_len + row];
+            acc += batch_O[s * q_len * HEAD_DIM + row * HEAD_DIM + col] * rsc;
+        }
+
+        float norm = norm_smem[row];
+        O_final[bid * q_len * HEAD_DIM + row * HEAD_DIM + col] =
+            Traits::from_float(acc * norm);
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void thrift_attention_single_query_split_launch(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    float* workspace,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_KV_FP4 = 64;
+    constexpr int BLOCK_KV_FP16 = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4mix;
+
+    const int total_kv_blocks = cdiv_sqmxfp4mix(kv_len, BLOCK_KV_FP4);
+    const int target_split_ctas = single_query_target_split_ctas_sqmxfp4mix(total_kv_blocks);
+    int num_kv_splits = max(1, min(total_kv_blocks, cdiv_sqmxfp4mix(target_split_ctas, bs)));
+    num_kv_splits = min(num_kv_splits, total_kv_blocks);
+
+    float* O_partial      = workspace;
+    float* rowmax_partial = O_partial + bs * num_kv_splits * q_len * HEAD_DIM;
+    float* rowsum_partial = rowmax_partial + bs * num_kv_splits * q_len;
+    int* split_counter    = reinterpret_cast<int*>(rowsum_partial + bs * num_kv_splits * q_len);
+
+    cudaMemsetAsync(split_counter, 0, bs * sizeof(int));
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+
+    // Single FP4 buffer size (K + K_scales + V_transposed + V_scales)
+    constexpr int kv_smem_fp4_single =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    // Double-buffered FP4
+    constexpr int kv_smem_fp4 = kv_smem_fp4_single * 2;
+
+    constexpr int kv_smem_fp16 = BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T) * 2;
+
+    constexpr int kv_smem = (kv_smem_fp4 > kv_smem_fp16) ? kv_smem_fp4 : kv_smem_fp16;
+    constexpr int smem_size = (q_phase_smem > kv_smem) ? q_phase_smem : kv_smem;
+
+    dim3 grid(num_kv_splits, bs);
+    if (q_len <= 8) {
+        auto kernel = thrift_attention_single_query_split_kernel<
+            T, BLOCK_KV_FP16, BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, true>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        kernel<<<grid, TB_SIZE, smem_size>>>(
+            Q_fp16, K_fp16, V_fp16,
+            top_k, topk_count,
+            Q_fp4, K_fp4, V_fp4,
+            S_Q, S_K, S_V,
+            O_partial, rowmax_partial, rowsum_partial,
+            O, split_counter,
+            bs, q_len, kv_len, kv_capacity, num_kv_splits,
+            num_q_heads, num_kv_heads);
+    } else {
+        auto kernel = thrift_attention_single_query_split_kernel<
+            T, BLOCK_KV_FP16, BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, false>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        kernel<<<grid, TB_SIZE, smem_size>>>(
+            Q_fp16, K_fp16, V_fp16,
+            top_k, topk_count,
+            Q_fp4, K_fp4, V_fp4,
+            S_Q, S_K, S_V,
+            O_partial, rowmax_partial, rowsum_partial,
+            O, split_counter,
+            bs, q_len, kv_len, kv_capacity, num_kv_splits,
+            num_q_heads, num_kv_heads);
+    }
+
+}
+
+template<typename T>
+static void thrift_attention_single_query_mxfp4_typed(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const int32_t* top_k,
+    int topk_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim)
+{
+    auto Q_fp16 = reinterpret_cast<const T*>(Q_fp16_raw);
+    auto K_fp16 = reinterpret_cast<const T*>(K_fp16_raw);
+    auto V_fp16 = reinterpret_cast<const T*>(V_fp16_raw);
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+
+    auto S_Q = reinterpret_cast<const __nv_fp8_e8m0*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e8m0*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e8m0*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    constexpr int BLOCK_KV_FP4 = 64;
+    const int total_kv_blocks = cdiv_sqmxfp4mix(kv_len, BLOCK_KV_FP4);
+
+    if (total_kv_blocks < 128) {
+        // CTA-cooperative: up to kv_len=8192
+        if (head_dim == 64) {
+            thrift_attention_single_query_cta_launch<T, 64>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        } else {
+            thrift_attention_single_query_cta_launch<T, 128>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        }
+    } else {
+        // Split-KV: kv_len > 4096
+        auto workspace = reinterpret_cast<float*>(workspace_raw);
+        if (head_dim == 64) {
+            thrift_attention_single_query_split_launch<T, 64>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O, workspace,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        } else {
+            thrift_attention_single_query_split_launch<T, 128>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O, workspace,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        }
+    }
+}
+
+void thrift_attention_single_query_mxfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const int32_t* top_k,
+    int topk_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_single_query_mxfp4_typed<__nv_bfloat16>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, top_k, topk_count,
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            workspace_raw, bs, q_len, kv_len, kv_capacity, num_q_heads,
+            num_kv_heads, head_dim);
+    } else {
+        thrift_attention_single_query_mxfp4_typed<half>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, top_k, topk_count,
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            workspace_raw, bs, q_len, kv_len, kv_capacity, num_q_heads,
+            num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/mxfp4/single_query_fp4_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/mxfp4/single_query_fp4_attention.cu
@@ -1,0 +1,1851 @@
+// SM120 MXFP4 single-query attention baseline.
+
+#include <cstdint>
+#include <cstdio>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+__device__ inline
+void ldmatrix_x4_sqmxfp4(uint32_t reg[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+         : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_sqmxfp4(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+__device__ inline
+uint32_t ld_shared_e8m0x2_sqmxfp4(uint32_t addr) {
+    uint16_t value;
+    asm volatile("ld.shared.u16 %0, [%1];"
+        : "=h"(value)
+        : "r"(addr));
+    return static_cast<uint32_t>(value);
+}
+
+// Swizzle shared memory addresses to avoid bank conflicts during ldmatrix.
+// XORs bits 4-6 of the byte address based on (row_index % 8), so that
+// consecutive rows land on different bank groups.
+// STRIDE = row width in bytes.
+template <int STRIDE>
+__device__
+uint32_t swizzle_sqmxfp4(uint32_t index) {
+    if constexpr (STRIDE == 16)
+        return index;
+    uint32_t row_idx = (index / STRIDE) % 8;
+    uint32_t bits_to_xor = row_idx / max(64 / STRIDE, 1);
+    return index ^ (bits_to_xor << 4);
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_sqmxfp4(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int num_iters = (HEIGHT * WIDTH) / (num_elements * TB_SIZE);
+
+    for (int iter = 0; iter < num_iters; iter++) {
+        const int index = (iter * TB_SIZE + tid) * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+
+        uint32_t dst_addr = swizzle_sqmxfp4<WIDTH * (int)sizeof(T)>(
+            dst + (row * WIDTH + col) * sizeof(T));
+        const T *src_addr = src + (row * src_stride + col);
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void load_scales_sqmxfp4(uint32_t dst, const T *src, int src_stride, int tid) {
+  constexpr int cp_size = WIDTH * sizeof(T);
+  static_assert(cp_size < 16);
+
+  auto load_row = [&](int row) {
+    const uint32_t dst_addr = dst + row * WIDTH * sizeof(T);
+    const T *src_addr = src + row * src_stride;
+    if constexpr (cp_size == 2) {
+      uint16_t value;
+      asm volatile("ld.global.u16 %0, [%1];"
+          : "=h"(value)
+          : "l"(src_addr));
+      asm volatile("st.shared.u16 [%0], %1;"
+          :: "r"(dst_addr), "h"(value));
+    } else {
+      asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+          :: "r"(dst_addr), "l"(src_addr), "n"(cp_size));
+    }
+  };
+
+  for (int iter = 0; iter < HEIGHT / TB_SIZE; iter++)
+    load_row(iter * TB_SIZE + tid);
+
+  if constexpr (HEIGHT % TB_SIZE != 0) {
+    const int row = HEIGHT / TB_SIZE * TB_SIZE + tid;
+    if (row < HEIGHT)
+      load_row(row);
+  }
+}
+
+__device__ inline
+uint32_t cvt_8xf32_to_e2m1_packed_sqmxfp4(float f0, float f1, float f2, float f3,
+                                     float f4, float f5, float f6, float f7) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 a0, a1, a2, a3;\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a0, %1, %2;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a1, %3, %4;\n\t"
+        "mov.b16 lo, {a0, a1};\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a2, %5, %6;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a3, %7, %8;\n\t"
+        "mov.b16 hi, {a2, a3};\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3),
+          "f"(f4), "f"(f5), "f"(f6), "f"(f7)
+    );
+    return packed;
+}
+
+__device__ inline
+uint32_t cvt_2xf32_to_e8m0_packed_sqmxfp4(float f0, float f1) {
+    return ta_cvt_2xf32_to_e8m0_packed(f0, f1);
+}
+
+__device__ inline
+void mma_m16n8k64_mxfp4_sqmxfp4(uint32_t A[4], uint32_t B[2], uint32_t sf_A, uint32_t sf_B, float D[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4"
+        ".block_scale.scale_vec::2X.f32.e2m1.e2m1.f32.ue8m0 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]),
+          "r"(sf_A), "h"(byte_id), "h"(thread_id),
+          "r"(sf_B), "h"(byte_id), "h"(thread_id));
+}
+
+constexpr int WARP_SIZE_sqmxfp4 = 32;
+
+__host__ __device__ inline
+int cdiv_sqmxfp4(int a, int b) { return (a + b - 1) / b; }
+
+__host__ __device__ inline
+int sage_perm32_sqmxfp4(int x) {
+    return (x / 8) * 2 + ((x % 8) / 2) * 8 + (x % 2);
+}
+
+__host__ __device__ inline
+int sage_perm_seq_sqmxfp4(int x) {
+    const int base = (x / 32) * 32;
+    return base + sage_perm32_sqmxfp4(x & 31);
+}
+
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__launch_bounds__(WARP_SIZE_sqmxfp4)
+__global__
+void fp4_attention_single_query_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    float* O_partial,       // [bs, num_kv_splits, 16, HEAD_DIM]
+    float* rowmax_partial,  // [bs, num_kv_splits, 16]
+    float* rowsum_partial,  // [bs, num_kv_splits, 16]
+    T* O_final,             // [bs, q_len, HEAD_DIM]
+    int* split_counter,     // [bs] — zeroed before launch
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_kv_splits,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    // Size of one FP4 KV buffer in smem (bytes)
+    constexpr int FP4_BUF_BYTES =
+        BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0)
+      + HEAD_DIM * (BLOCK_KV / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    // V/S_V are transposed; per-row stride uses capacity, not logical kv_len.
+    const int v_kv = cdiv_sqmxfp4(kv_capacity, 128) * 128;
+
+    const int split_id = blockIdx.x;
+    const int bid = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    // Compute KV range for this split
+    const int total_kv_blocks = cdiv_sqmxfp4(kv_len, BLOCK_KV);
+    const int kv_block_start = (split_id * total_kv_blocks) / num_kv_splits;
+    const int kv_block_end = ((split_id + 1) * total_kv_blocks) / num_kv_splits;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2 + kv_block_start * BLOCK_KV * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2) + kv_block_start * BLOCK_KV / 2;
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM  + kv_block_start * BLOCK_KV * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM  + kv_block_start * BLOCK_KV / 32;
+
+    const int partial_offset = bid * num_kv_splits + split_id;
+    O_partial      += partial_offset * BLOCK_Q * HEAD_DIM;
+    rowmax_partial += partial_offset * BLOCK_Q;
+    rowsum_partial += partial_offset * BLOCK_Q;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q data + scales into smem → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            if constexpr (SF_ROW_BYTES == 2) {
+                uint16_t value;
+                asm volatile("ld.global.u16 %0, [%1];"
+                    : "=h"(value)
+                    : "l"(src_addr));
+                asm volatile("st.shared.u16 [%0], %1;"
+                    :: "r"(dst_addr), "h"(value));
+            } else {
+                asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                    :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+            }
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqmxfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+        sfQ_rmem[mma_id_d] = ld_shared_e8m0x2_sqmxfp4(Q_sf_smem + offset);
+    }
+
+    // ---- Phase 2: Double-buffered KV loop ----
+    __syncwarp();
+
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    // Two smem buffers for double-buffering
+    uint32_t K_smem_buf[2], K_sf_buf[2], V_smem_buf[2], V_sf_buf[2], K_ld_buf[2];
+    for (int b = 0; b < 2; b++) {
+        K_smem_buf[b] = smem_base + b * FP4_BUF_BYTES;
+        K_sf_buf[b]   = K_smem_buf[b] + BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+        V_smem_buf[b] = K_sf_buf[b]   + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0);
+        V_sf_buf[b]   = V_smem_buf[b] + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_buf[b] = swizzle_sqmxfp4<HEAD_DIM_2>(K_smem_buf[b] + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    const int num_kv_iters = kv_block_end - kv_block_start;
+
+    // Helper: start async load of KV block at offset iter into buffer buf
+    auto start_kv_load = [&](int buf, int iter) {
+        const auto* Kp  = K   + iter * BLOCK_KV * HEAD_DIM_2;
+        const auto* Vp  = V   + iter * BLOCK_KV / 2;
+        const auto* SKp = S_K + iter * BLOCK_KV * SCALE_DIM;
+        const auto* SVp = S_V + iter * BLOCK_KV / 32;
+        gmem_to_smem_sqmxfp4<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem_buf[buf], Kp, tid, HEAD_DIM_2);
+        load_scales_sqmxfp4<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(K_sf_buf[buf], SKp, SCALE_DIM, tid);
+        gmem_to_smem_sqmxfp4<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem_buf[buf], Vp, tid, v_kv / 2);
+        load_scales_sqmxfp4<HEAD_DIM, BLOCK_KV / 32, TB_SIZE, __nv_fp8_e8m0>(V_sf_buf[buf], SVp, v_kv / 32, tid);
+        asm volatile("cp.async.commit_group;");
+    };
+
+    // Preload first block
+    if (num_kv_iters > 0)
+        start_kv_load(0, 0);
+
+    int cur_buf = 0;
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        // Preload next block into alternate buffer
+        if (kv_iter + 1 < num_kv_iters)
+            start_kv_load(1 - cur_buf, kv_iter + 1);
+
+        // Wait for current buffer
+        if (kv_iter + 1 < num_kv_iters) {
+            asm volatile("cp.async.wait_group %0;" :: "n"(1));
+        } else {
+            asm volatile("cp.async.wait_all;");
+        }
+        __syncwarp();
+
+        // Aliases for current buffer
+        const uint32_t cur_K_sf  = K_sf_buf[cur_buf];
+        const uint32_t cur_V     = V_smem_buf[cur_buf];
+        const uint32_t cur_V_sf  = V_sf_buf[cur_buf];
+        const uint32_t cur_K_ld  = K_ld_buf[cur_buf];
+
+        // K → registers
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = cur_K_ld + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqmxfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = cur_K_ld;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqmxfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        // K scales → registers
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfK_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(cur_K_sf + offset);
+            }
+
+        // QK^T MMA
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        // ---- online softmax (no causal mask) ----
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 6.0f;
+        constexpr float FP4_MAX = 6.0f;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= FP4_RANGE;
+            S_rmem[mma_id_kv][1] *= FP4_RANGE;
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        }
+
+        float sf_P_upper[BLOCK_KV / MMA_N / 4];
+        float sf_P_lower[BLOCK_KV / MMA_N / 4];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+            int t0 = 4 * blk;
+            int t1 = t0 + 1;
+            int t2 = t0 + 2;
+            int t3 = t0 + 3;
+
+            float amax_upper = max(
+                max(max(S_rmem[t0][0], S_rmem[t0][1]),
+                    max(S_rmem[t1][0], S_rmem[t1][1])),
+                max(max(S_rmem[t2][0], S_rmem[t2][1]),
+                    max(S_rmem[t3][0], S_rmem[t3][1]))
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(max(S_rmem[t0][2], S_rmem[t0][3]),
+                    max(S_rmem[t1][2], S_rmem[t1][3])),
+                max(max(S_rmem[t2][2], S_rmem[t2][3]),
+                    max(S_rmem[t3][2], S_rmem[t3][3]))
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t2][0] *= inv_upper;
+            S_rmem[t2][1] *= inv_upper;
+            S_rmem[t3][0] *= inv_upper;
+            S_rmem[t3][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+            S_rmem[t2][2] *= inv_lower;
+            S_rmem[t2][3] *= inv_lower;
+            S_rmem[t3][2] *= inv_lower;
+            S_rmem[t3][3] *= inv_lower;
+        }
+
+        // Reorder lanes so the following MMA consumes contiguous probability fragments.
+        const int qid = lane_id & 3;
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 2;
+            uint32_t sfP_upper_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0]);
+
+            uint32_t sfP_lower_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        // V → registers
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqmxfp4<BLOCK_KV / 2>(
+                    cur_V + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqmxfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        // V scales → registers
+        constexpr int V_SF_STRIDE = BLOCK_KV / 32;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfV_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(cur_V_sf + offset);
+            }
+
+        // O += P @ V
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        cur_buf = 1 - cur_buf;
+    }
+
+    // ---- Phase 3: Write partials — float2 vectorised stores ----
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        *reinterpret_cast<float2*>(&O_partial[(row + 0) * HEAD_DIM + col]) =
+            make_float2(regs[0], regs[1]);
+        *reinterpret_cast<float2*>(&O_partial[(row + 8) * HEAD_DIM + col]) =
+            make_float2(regs[2], regs[3]);
+    }
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        rowmax_partial[row + 0] = rowmax[0];
+        rowmax_partial[row + 8] = rowmax[1];
+        rowsum_partial[row + 0] = rowsum[0];
+        rowsum_partial[row + 8] = rowsum[1];
+    }
+
+    // ---- Fused reduction: last block to finish reduces all partials ----
+    __threadfence();
+
+    int completed = 0;
+    if (lane_id == 0)
+        completed = atomicAdd(&split_counter[bid], 1);
+    completed = __shfl_sync(0xFFFFFFFF, completed, 0);
+
+    if (completed != num_kv_splits - 1)
+        return;
+
+    // ---- Two-pass smem-assisted reduction ----
+    constexpr float FP4_RANGE_INV = 1.0f / (6.0f);
+    constexpr int ELEMS_PER_THREAD = (BLOCK_Q * HEAD_DIM) / TB_SIZE;
+
+    const float* batch_O = O_partial - split_id * BLOCK_Q * HEAD_DIM;
+    const float* batch_rowmax = rowmax_partial - split_id * BLOCK_Q;
+    const float* batch_rowsum = rowsum_partial - split_id * BLOCK_Q;
+
+    // Pass 1: 16 threads compute per-row rescale factors + norms → smem
+    float* rsc_smem  = reinterpret_cast<float*>(smem);
+    float* norm_smem = rsc_smem + num_kv_splits * BLOCK_Q;
+
+    if (lane_id < BLOCK_Q) {
+        const int row = lane_id;
+        float global_max = -FLT_MAX;
+        for (int s = 0; s < num_kv_splits; s++)
+            global_max = max(global_max, batch_rowmax[s * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = __expf(batch_rowmax[s * BLOCK_Q + row] - global_max);
+            rsc_smem[s * BLOCK_Q + row] = rsc;
+            sum_acc += batch_rowsum[s * BLOCK_Q + row] * rsc;
+        }
+        norm_smem[row] = FP4_RANGE_INV / sum_acc;
+    }
+    __syncwarp();
+
+    // Pass 2: all 32 threads reduce O elements using precomputed factors
+    for (int elem = 0; elem < ELEMS_PER_THREAD; elem++) {
+        const int flat_idx = lane_id + elem * TB_SIZE;
+        const int row = flat_idx / HEAD_DIM;
+        const int col = flat_idx % HEAD_DIM;
+
+        float acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = rsc_smem[s * BLOCK_Q + row];
+            acc += batch_O[s * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col] * rsc;
+        }
+
+        if (row < q_len) {
+            float norm = norm_smem[row];
+            O_final[bid * q_len * HEAD_DIM + row * HEAD_DIM + col] =
+                Traits::from_float(acc * norm);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode kernel: no-split fast path. One block per batch element, processes
+// all KV blocks, writes FP16 output directly. No workspace, no atomics.
+// Handles unpadded Q (q_len rows, typically 1 for single-query).
+// Grid: (bs,)
+// ---------------------------------------------------------------------------
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__launch_bounds__(WARP_SIZE_sqmxfp4)
+__global__
+void fp4_attention_single_query_nosplit_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqmxfp4(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q data + scales into smem → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            if constexpr (SF_ROW_BYTES == 2) {
+                uint16_t value;
+                asm volatile("ld.global.u16 %0, [%1];"
+                    : "=h"(value)
+                    : "l"(src_addr));
+                asm volatile("st.shared.u16 [%0], %1;"
+                    :: "r"(dst_addr), "h"(value));
+            } else {
+                asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                    :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+            }
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqmxfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+        sfQ_rmem[mma_id_d] = ld_shared_e8m0x2_sqmxfp4(Q_sf_smem + offset);
+    }
+
+    // ---- Phase 2: KV loop (all blocks) ----
+    __syncwarp();
+
+    const uint32_t K_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t K_sf_smem = K_smem    + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem    = K_sf_smem + BLOCK_KV * SCALE_DIM  * sizeof(__nv_fp8_e8m0);
+    const uint32_t V_sf_smem = V_smem    + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = swizzle_sqmxfp4<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    const int total_kv_blocks = cdiv_sqmxfp4(kv_len, BLOCK_KV);
+
+    for (int kv_iter = 0; kv_iter < total_kv_blocks; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        gmem_to_smem_sqmxfp4<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem, K, tid, HEAD_DIM_2);
+        load_scales_sqmxfp4<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(K_sf_smem, S_K, SCALE_DIM, tid);
+        gmem_to_smem_sqmxfp4<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem, V, tid, v_kv / 2);
+        load_scales_sqmxfp4<HEAD_DIM, BLOCK_KV / 32, TB_SIZE, __nv_fp8_e8m0>(V_sf_smem, S_V, v_kv / 32, tid);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqmxfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqmxfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfK_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(K_sf_smem + offset);
+            }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 6.0f;
+        constexpr float inv_sP1 = FP4_RANGE;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= inv_sP1;
+            S_rmem[mma_id_kv][1] *= inv_sP1;
+            S_rmem[mma_id_kv][2] *= inv_sP1;
+            S_rmem[mma_id_kv][3] *= inv_sP1;
+        }
+
+        constexpr float FP4_MAX = 6.0f;
+        float sf_P_upper[BLOCK_KV / MMA_N / 4];
+        float sf_P_lower[BLOCK_KV / MMA_N / 4];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+            int t0 = 4 * blk;
+            int t1 = t0 + 1;
+            int t2 = t0 + 2;
+            int t3 = t0 + 3;
+
+            float amax_upper = max(
+                max(max(S_rmem[t0][0], S_rmem[t0][1]),
+                    max(S_rmem[t1][0], S_rmem[t1][1])),
+                max(max(S_rmem[t2][0], S_rmem[t2][1]),
+                    max(S_rmem[t3][0], S_rmem[t3][1]))
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(max(S_rmem[t0][2], S_rmem[t0][3]),
+                    max(S_rmem[t1][2], S_rmem[t1][3])),
+                max(max(S_rmem[t2][2], S_rmem[t2][3]),
+                    max(S_rmem[t3][2], S_rmem[t3][3]))
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+        }
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+            int t0 = 4 * blk;
+            int t1 = t0 + 1;
+            int t2 = t0 + 2;
+            int t3 = t0 + 3;
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t2][0] *= inv_upper;
+            S_rmem[t2][1] *= inv_upper;
+            S_rmem[t3][0] *= inv_upper;
+            S_rmem[t3][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+            S_rmem[t2][2] *= inv_lower;
+            S_rmem[t2][3] *= inv_lower;
+            S_rmem[t3][2] *= inv_lower;
+            S_rmem[t3][3] *= inv_lower;
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 2;
+            uint32_t sfP_upper_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0]);
+
+            uint32_t sfP_lower_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqmxfp4<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqmxfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        constexpr int V_SF_STRIDE = BLOCK_KV / 32;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfV_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(V_sf_smem + offset);
+            }
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        K   += BLOCK_KV * HEAD_DIM_2;
+        S_K += BLOCK_KV * SCALE_DIM;
+        V   += BLOCK_KV / 2;
+        S_V += BLOCK_KV / 32;
+    }
+
+    // ---- Phase 3: normalize and write FP16 output directly ----
+    constexpr float FP4_RANGE_INV = 1.0f / (6.0f);
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+
+        float *regs = O_rmem[mma_id_d];
+
+        float norm0 = FP4_RANGE_INV / rowsum[0];
+        float norm1 = FP4_RANGE_INV / rowsum[1];
+
+        regs[0] *= norm0;
+        regs[1] *= norm0;
+        regs[2] *= norm1;
+        regs[3] *= norm1;
+
+        if (row < q_len)
+            reinterpret_cast<typename Traits::vec2*>(O + row * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+        if (row + 8 < q_len)
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode kernel: CTA-cooperative version. NUM_WARPS warps per block, each
+// warp processes a disjoint chunk of KV blocks independently using its own
+// smem region, then all warps reduce (O, rowmax, rowsum) via shared memory.
+// No workspace allocation needed — reduction is entirely intra-CTA.
+// Grid: (bs,)
+// ---------------------------------------------------------------------------
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM, int NUM_WARPS>
+__launch_bounds__(NUM_WARPS * WARP_SIZE_sqmxfp4, 1)
+__global__
+void fp4_attention_single_query_cta_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmxfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqmxfp4(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / WARP_SIZE_sqmxfp4;
+    const int lane_id = tid % WARP_SIZE_sqmxfp4;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: cooperatively load Q data + scales into smem ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q smem, then load valid rows (all threads cooperate)
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncthreads();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            if constexpr (SF_ROW_BYTES == 2) {
+                uint16_t value;
+                asm volatile("ld.global.u16 %0, [%1];"
+                    : "=h"(value)
+                    : "l"(src_addr));
+                asm volatile("st.shared.u16 [%0], %1;"
+                    :: "r"(dst_addr), "h"(value));
+            } else {
+                asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                    :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+            }
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    // Each warp reads Q into registers (same smem, only lane_id matters)
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmxfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqmxfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+        sfQ_rmem[mma_id_d] = ld_shared_e8m0x2_sqmxfp4(Q_sf_smem + offset);
+    }
+
+    // ---- Phase 2: each warp processes its KV chunk independently ----
+    __syncthreads();
+
+    // Per-warp KV smem: [warp0: K|Ksf|V|Vsf] [warp1: ...] ...
+    constexpr int KV_SMEM_PER_WARP = BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + BLOCK_KV * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0)
+                                    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + HEAD_DIM * (BLOCK_KV / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    const uint32_t warp_kv_base = __cvta_generic_to_shared(smem) + warp_id * KV_SMEM_PER_WARP;
+    const uint32_t K_smem    = warp_kv_base;
+    const uint32_t K_sf_smem = K_smem    + BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem    = K_sf_smem + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e8m0);
+    const uint32_t V_sf_smem = V_smem    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    // Divide KV blocks evenly across warps
+    const int total_kv_blocks = cdiv_sqmxfp4(kv_len, BLOCK_KV);
+    const int blocks_per_warp = cdiv_sqmxfp4(total_kv_blocks, NUM_WARPS);
+    const int kv_block_start = warp_id * blocks_per_warp;
+    const int kv_block_end = min(kv_block_start + blocks_per_warp, total_kv_blocks);
+    const int num_kv_iters = (kv_block_start < total_kv_blocks)
+                           ? (kv_block_end - kv_block_start) : 0;
+
+    // Per-warp pointers offset to this warp's starting KV block
+    const __nv_fp4x2_e2m1* K_ptr = K + kv_block_start * BLOCK_KV * HEAD_DIM_2;
+    const __nv_fp4x2_e2m1* V_ptr = V + kv_block_start * BLOCK_KV / 2;
+    const __nv_fp8_e8m0* SK_ptr = S_K + kv_block_start * BLOCK_KV * SCALE_DIM;
+    const __nv_fp8_e8m0* SV_ptr = S_V + kv_block_start * BLOCK_KV / 32;
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = swizzle_sqmxfp4<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        // Each warp loads its own KV block into its own smem region
+        gmem_to_smem_sqmxfp4<BLOCK_KV, HEAD_DIM_2, WARP_SIZE_sqmxfp4, __nv_fp4x2_e2m1>(K_smem, K_ptr, lane_id, HEAD_DIM_2);
+        load_scales_sqmxfp4<BLOCK_KV, SCALE_DIM, WARP_SIZE_sqmxfp4, __nv_fp8_e8m0>(K_sf_smem, SK_ptr, SCALE_DIM, lane_id);
+        gmem_to_smem_sqmxfp4<HEAD_DIM, BLOCK_KV / 2, WARP_SIZE_sqmxfp4, __nv_fp4x2_e2m1>(V_smem, V_ptr, lane_id, v_kv / 2);
+        load_scales_sqmxfp4<HEAD_DIM, BLOCK_KV / 32, WARP_SIZE_sqmxfp4, __nv_fp8_e8m0>(V_sf_smem, SV_ptr, v_kv / 32, lane_id);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        // K → registers
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqmxfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqmxfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        // K scales → registers
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfK_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(K_sf_smem + offset);
+            }
+
+        // QK^T MMA
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        // ---- online softmax ----
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        float p_group_max_upper[BLOCK_KV / MMA_N / 2];
+        float p_group_max_lower[BLOCK_KV / MMA_N / 2];
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            p_group_max_upper[blk] = gmax_upper;
+            p_group_max_lower[blk] = gmax_lower;
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 6.0f;
+        constexpr float FP4_MAX = 6.0f;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= FP4_RANGE;
+            S_rmem[mma_id_kv][1] *= FP4_RANGE;
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        }
+
+        float sf_P_upper[BLOCK_KV / MMA_N / 4];
+        float sf_P_lower[BLOCK_KV / MMA_N / 4];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 4; blk++) {
+            int t0 = 4 * blk;
+            int t1 = t0 + 1;
+            int t2 = t0 + 2;
+            int t3 = t0 + 3;
+
+            float amax_upper = max(
+                max(max(S_rmem[t0][0], S_rmem[t0][1]),
+                    max(S_rmem[t1][0], S_rmem[t1][1])),
+                max(max(S_rmem[t2][0], S_rmem[t2][1]),
+                    max(S_rmem[t3][0], S_rmem[t3][1]))
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(max(S_rmem[t0][2], S_rmem[t0][3]),
+                    max(S_rmem[t1][2], S_rmem[t1][3])),
+                max(max(S_rmem[t2][2], S_rmem[t2][3]),
+                    max(S_rmem[t3][2], S_rmem[t3][3]))
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t2][0] *= inv_upper;
+            S_rmem[t2][1] *= inv_upper;
+            S_rmem[t3][0] *= inv_upper;
+            S_rmem[t3][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+            S_rmem[t2][2] *= inv_lower;
+            S_rmem[t2][3] *= inv_lower;
+            S_rmem[t3][2] *= inv_lower;
+            S_rmem[t3][3] *= inv_lower;
+        }
+
+        const int qid = lane_id & 3;
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqmxfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 2;
+            uint32_t sfP_upper_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0]);
+
+            uint32_t sfP_lower_packed = cvt_2xf32_to_e8m0_packed_sqmxfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        // V → registers
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqmxfp4<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqmxfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        // V scales → registers
+        constexpr int V_SF_STRIDE = BLOCK_KV / 32;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfV_rmem[mma_id_kv][mma_id_d] = ld_shared_e8m0x2_sqmxfp4(V_sf_smem + offset);
+            }
+
+        // O += P @ V
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_mxfp4_sqmxfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        K_ptr  += BLOCK_KV * HEAD_DIM_2;
+        SK_ptr += BLOCK_KV * SCALE_DIM;
+        V_ptr  += BLOCK_KV / 2;
+        SV_ptr += BLOCK_KV / 32;
+    }
+
+    // ---- Phase 3: CTA-level reduction via shared memory ----
+    __syncthreads();
+
+    // Reduction smem layout:
+    //   rowmax [NUM_WARPS][BLOCK_Q]           — float
+    //   rowsum [NUM_WARPS][BLOCK_Q]           — float
+    //   O_part [NUM_WARPS][BLOCK_Q][HEAD_DIM] — float
+    float* reduce_base = reinterpret_cast<float*>(smem);
+    float* rowmax_smem = reduce_base;
+    float* rowsum_smem = rowmax_smem + NUM_WARPS * BLOCK_Q;
+    float* O_part_smem = rowsum_smem + NUM_WARPS * BLOCK_Q;
+
+    // Each warp writes its per-row rowmax/rowsum
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;  // 0..7
+        rowmax_smem[warp_id * BLOCK_Q + row]     = rowmax[0];
+        rowmax_smem[warp_id * BLOCK_Q + row + 8] = rowmax[1];
+        rowsum_smem[warp_id * BLOCK_Q + row]     = rowsum[0];
+        rowsum_smem[warp_id * BLOCK_Q + row + 8] = rowsum[1];
+    }
+
+    // Each warp writes its partial O
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col]           = regs[0];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col + 1]       = regs[1];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col]     = regs[2];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col + 1] = regs[3];
+    }
+
+    __syncthreads();
+
+    // Precompute per-row rescale weights and normalization factor.
+    // One thread per row: computes global_max, per-warp rescale, and final norm.
+    // Reuses rowmax_smem for weights, rowsum_smem[0..BLOCK_Q-1] for norm.
+    constexpr float FP4_RANGE_INV = 1.0f / (6.0f);
+
+    if (tid < BLOCK_Q) {
+        const int row = tid;
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = max(global_max, rowmax_smem[w * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        float rsc[NUM_WARPS];
+        for (int w = 0; w < NUM_WARPS; w++) {
+            rsc[w] = __expf(rowmax_smem[w * BLOCK_Q + row] - global_max);
+            sum_acc += rowsum_smem[w * BLOCK_Q + row] * rsc[w];
+        }
+
+        float norm = FP4_RANGE_INV / sum_acc;
+        for (int w = 0; w < NUM_WARPS; w++)
+            rowmax_smem[w * BLOCK_Q + row] = rsc[w];
+        rowsum_smem[row] = norm;
+    }
+
+    __syncthreads();
+
+    // All threads: weighted sum of warp partials + vectorised FP16 output
+    constexpr int TOTAL_PAIRS = BLOCK_Q * (HEAD_DIM / 2);
+
+    for (int pair = tid; pair < TOTAL_PAIRS; pair += TB_SIZE) {
+        const int elem = pair * 2;
+        const int row = elem / HEAD_DIM;
+        const int col = elem % HEAD_DIM;
+
+        float norm = rowsum_smem[row];
+        float acc0 = 0.0f, acc1 = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++) {
+            float rsc = rowmax_smem[w * BLOCK_Q + row];
+            const float* src = &O_part_smem[w * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col];
+            acc0 += src[0] * rsc;
+            acc1 += src[1] * rsc;
+        }
+
+        if (row < q_len) {
+            typename Traits::vec2 result = Traits::pack2(acc0 * norm, acc1 * norm);
+            *reinterpret_cast<typename Traits::vec2*>(&O[row * HEAD_DIM + col]) = result;
+        }
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_nosplit_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q, const __nv_fp8_e8m0* S_K, const __nv_fp8_e8m0* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4;
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e8m0);
+    constexpr int kv_phase_smem = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e8m0)
+                                + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 32) * sizeof(__nv_fp8_e8m0);
+    constexpr int smem_size = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+
+    auto kernel = fp4_attention_single_query_nosplit_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+}
+
+// CTA-cooperative launch: multiple warps per block, shared-memory reduction
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_cta_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q, const __nv_fp8_e8m0* S_K, const __nv_fp8_e8m0* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int NUM_WARPS = 4;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmxfp4;
+
+    // Smem: max of Q phase, KV phase (per-warp regions), reduction phase
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+    constexpr int kv_smem_per_warp = BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + BLOCK_KV * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0)
+                                    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + HEAD_DIM * (BLOCK_KV / 32) * (int)sizeof(__nv_fp8_e8m0);
+    constexpr int kv_phase_smem = NUM_WARPS * kv_smem_per_warp;
+    constexpr int reduce_smem = (int)sizeof(float) * (NUM_WARPS * BLOCK_Q * 2
+                              + NUM_WARPS * BLOCK_Q * HEAD_DIM);
+    constexpr int smem_12 = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+    constexpr int smem_size = smem_12 > reduce_smem ? smem_12 : reduce_smem;
+
+    auto kernel = fp4_attention_single_query_cta_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, NUM_WARPS>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+}
+
+// Split-KV launch: multiple blocks per batch element, requires workspace
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_split_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q, const __nv_fp8_e8m0* S_K, const __nv_fp8_e8m0* S_V,
+    T* O, float* workspace, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqmxfp4;
+
+    const int total_kv_blocks = cdiv_sqmxfp4(kv_len, BLOCK_KV);
+    int num_kv_splits = max(1, min(total_kv_blocks, cdiv_sqmxfp4(256, bs)));
+    num_kv_splits = min(num_kv_splits, total_kv_blocks);
+
+    float* O_partial      = workspace;
+    float* rowmax_partial = O_partial + bs * num_kv_splits * BLOCK_Q * HEAD_DIM;
+    float* rowsum_partial = rowmax_partial + bs * num_kv_splits * BLOCK_Q;
+    int* split_counter    = reinterpret_cast<int*>(rowsum_partial + bs * num_kv_splits * BLOCK_Q);
+
+    cudaMemsetAsync(split_counter, 0, bs * sizeof(int));
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e8m0);
+    constexpr int kv_phase_smem_single = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e8m0)
+                                + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 32) * sizeof(__nv_fp8_e8m0);
+    constexpr int kv_phase_smem = kv_phase_smem_single * 2;  // double-buffer
+    constexpr int smem_size = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+
+    auto kernel = fp4_attention_single_query_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    dim3 grid(num_kv_splits, bs);
+    kernel<<<grid, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V,
+        O_partial, rowmax_partial, rowsum_partial,
+        O, split_counter,
+        bs, q_len, kv_len, kv_capacity, num_kv_splits, num_q_heads, num_kv_heads);
+}
+
+template<typename T>
+static void fp4_attention_single_query_mxfp4_typed(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+    auto S_Q = reinterpret_cast<const __nv_fp8_e8m0*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e8m0*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e8m0*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    constexpr int BLOCK_KV = 64;
+    const int total_kv_blocks = cdiv_sqmxfp4(kv_len, BLOCK_KV);
+
+    if (total_kv_blocks <= 4) {
+        if (head_dim == 64)
+            fp4_attention_single_query_nosplit_launch<T, 64>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+        else
+            fp4_attention_single_query_nosplit_launch<T, 128>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    } else {
+        if (head_dim == 64)
+            fp4_attention_single_query_cta_launch<T, 64>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+        else
+            fp4_attention_single_query_cta_launch<T, 128>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    }
+}
+
+void fp4_attention_single_query_mxfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_single_query_mxfp4_typed<__nv_bfloat16>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw, workspace_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_single_query_mxfp4_typed<half>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw, workspace_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/mxfp4/thrift_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/mxfp4/thrift_attention.cu
@@ -1,0 +1,1071 @@
+#include <cstdint>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+// ===========================================================================
+// Mixed-precision attention kernel.
+// FP4 is used for non-selected KV blocks; FP16 is used for selected KV blocks.
+// Grid: (batch * heads * query_blocks), one CTA per query tile.
+// ===========================================================================
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV_FP4, int HEAD_DIM,
+         int HEAD_DIM_2, int SCALE_DIM,
+         int NUM_WARPS, int WARP_Q>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void thrift_attention_kernel(
+    const T* Q_fp16_in,
+    const T* K_fp16_in,
+    const T* V_fp16_in,
+    const unsigned long long* topk_mask_in,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+    const int v_kv = ta_cdiv(kv_capacity, 128) * 128;
+
+    Q   += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM * (v_kv / 2);
+    S_Q += (q_bid * q_len + q_block_id * BLOCK_Q) * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv * SCALE_DIM;
+    O   += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    rowmax_state += q_bid * q_len + q_block_id * BLOCK_Q;
+    rowsum_state += q_bid * q_len + q_block_id * BLOCK_Q;
+
+    Q_fp16_in += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    K_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    V_fp16_in += kv_bid * kv_len * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Persistent register state ----
+    uint32_t Q_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[WARP_Q / MMA_M][2];
+    float rowsum[WARP_Q / MMA_M][2] = {};
+    float O_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        rowmax[mma_id_q][0] = -FLT_MAX;
+        rowmax[mma_id_q][1] = -FLT_MAX;
+    }
+
+    // ==================== PHASE 1: Load Q FP4 + scales -> registers ====================
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    ta_gmem_to_smem<BLOCK_Q, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(Q_smem, Q, tid, HEAD_DIM_2);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    {
+        const int row_off = warp_id * WARP_Q + (lane_id % 16);
+        const int col_off = (lane_id / 16) * 16;
+        uint32_t Q_ld_base = ta_swizzle<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                uint32_t addr = Q_ld_base;
+                addr += mma_id_q * MMA_M * HEAD_DIM_2;
+                addr ^= mma_id_d * (MMA_K_FP4 / 2);
+                ta_ldmatrix_x4(Q_rmem[mma_id_q][mma_id_d], addr);
+            }
+    }
+
+    ta_load_scales<BLOCK_Q, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(Q_sf_smem, S_Q, SCALE_DIM, tid);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    {
+        int sf_row_q = 0;
+        if (lane_id % 4 == 0)      sf_row_q = (lane_id / 4);
+        else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                const int row = warp_id * WARP_Q + mma_id_q * MMA_M + sf_row_q;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                sfQ_rmem[mma_id_q][mma_id_d] = ta_ld_shared_u16(Q_sf_smem + offset);
+            }
+    }
+
+    // ==================== PHASE 1b: Build per-query-block top-k mask ====================
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int max_kv_pos = q_block_start + BLOCK_Q - 1;
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV_FP4);
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV_FP4 + 1, total_kv_iters)
+        : total_kv_iters;
+
+
+    constexpr int TOPK_UNIT_TOKENS = 64;
+    constexpr int TOPK_UNITS_PER_ITER = BLOCK_KV_FP4 / TOPK_UNIT_TOKENS;
+    static_assert(BLOCK_KV_FP4 == 64 || BLOCK_KV_FP4 == 128,
+                  "attention top-k bitset assumes 64-token top-k units");
+    const int total_topk_units = ta_cdiv(kv_len, TOPK_UNIT_TOKENS);
+
+    constexpr int MAX_KV_BLOCK_WORDS = 32;  // 2048 * 64 tokens
+    const int num_kv_words = min(min(ta_cdiv(total_topk_units, 64), topk_word_count), MAX_KV_BLOCK_WORDS);
+    __shared__ unsigned long long topk_mask[MAX_KV_BLOCK_WORDS];
+    if (tid < MAX_KV_BLOCK_WORDS) {
+        const int64_t mask_row =
+            (static_cast<int64_t>(q_bid) * num_q_blocks + q_block_id) * topk_word_count;
+        topk_mask[tid] = (tid < num_kv_words)
+            ? topk_mask_in[mask_row + tid]
+            : 0ULL;
+    }
+    __syncthreads();
+
+    // ==================== PHASE 2: FP4 non-selected KV pass ====================
+
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    // FP4 smem addresses
+    const uint32_t K_smem_fp4    = smem_base;
+    const uint32_t K_sf_smem     = K_smem_fp4 + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem_fp4    = K_sf_smem + BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+    const uint32_t V_sf_smem_fp4 = V_smem_fp4 + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t K_ld_base_fp4;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base_fp4 = ta_swizzle<HEAD_DIM_2>(K_smem_fp4 + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);
+    const int q_row_lower = q_row_upper + 8;
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base  = (lane_id % 4) * 2;
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        bool is_topk = false;
+        #pragma unroll
+        for (int u = 0; u < TOPK_UNITS_PER_ITER; u++) {
+            const int topk_unit = kv_iter * TOPK_UNITS_PER_ITER + u;
+            const int topk_word = topk_unit >> 6;
+            is_topk |= (topk_word < MAX_KV_BLOCK_WORDS) &&
+                       ((topk_mask[topk_word] >> (topk_unit & 63)) & 1ULL);
+        }
+        const int k_block_start = kv_iter * BLOCK_KV_FP4;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV_FP4 - 1) > q_block_start);
+
+        if (is_topk) {
+            continue;
+        } else {
+            // ---- FP4 path: process 64 KV rows ----
+            const __nv_fp4x2_e2m1* K_ptr = K + kv_iter * BLOCK_KV_FP4 * HEAD_DIM_2;
+            const __nv_fp8_e8m0*   SK_ptr = S_K + kv_iter * BLOCK_KV_FP4 * SCALE_DIM;
+            const __nv_fp4x2_e2m1* V_ptr = V + kv_iter * BLOCK_KV_FP4 / 2;
+            const __nv_fp8_e8m0*   SV_ptr = S_V + kv_iter * BLOCK_KV_FP4 / 32;
+
+            // K load (group 1)
+            ta_gmem_to_smem<BLOCK_KV_FP4, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem_fp4, K_ptr, tid, HEAD_DIM_2);
+            ta_load_scales<BLOCK_KV_FP4, SCALE_DIM, TB_SIZE, __nv_fp8_e8m0>(K_sf_smem, SK_ptr, SCALE_DIM, tid);
+            asm volatile("cp.async.commit_group;");
+            // V load (group 2) — overlaps with QK^T compute
+            ta_gmem_to_smem<HEAD_DIM, BLOCK_KV_FP4 / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem_fp4, V_ptr, tid, v_kv / 2);
+            ta_load_scales<HEAD_DIM, BLOCK_KV_FP4 / 32, TB_SIZE, __nv_fp8_e8m0>(V_sf_smem_fp4, SV_ptr, v_kv / 32, tid);
+            asm volatile("cp.async.commit_group;");
+            // Wait for K only (V still in flight)
+            asm volatile("cp.async.wait_group 1;");
+            __syncthreads();
+
+            uint32_t K_rmem[BLOCK_KV_FP4 / MMA_N][HEAD_DIM / MMA_K_FP4][2];
+            uint32_t sfK_rmem[BLOCK_KV_FP4 / MMA_N][HEAD_DIM / MMA_K_FP4];
+
+            if constexpr (HEAD_DIM / MMA_K_FP4 >= 2) {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    uint32_t addr = K_ld_base_fp4 + mma_id_kv * MMA_N * HEAD_DIM_2;
+                    ta_ldmatrix_x4(K_rmem[mma_id_kv][0], addr);
+                }
+            } else {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                        uint32_t addr = K_ld_base_fp4;
+                        addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+                        ta_ldmatrix_x2(K_rmem[mma_id_kv][mma_id_d], addr);
+                    }
+            }
+
+            const int sf_row_k = lane_id / 4;
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                    const int row = mma_id_kv * MMA_N + sf_row_k;
+                    const uint32_t offset = (row * SCALE_DIM + mma_id_d * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                    sfK_rmem[mma_id_kv][mma_id_d] = ta_ld_shared_u16(K_sf_smem + offset);
+                }
+
+            float S_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_N][4] = {};
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++)
+                        ta_mma_m16n8k64_mxfp4(
+                            Q_rmem[mma_id_q][mma_id_d],
+                            K_rmem[mma_id_kv][mma_id_d],
+                            sfQ_rmem[mma_id_q][mma_id_d],
+                            sfK_rmem[mma_id_kv][mma_id_d],
+                            S_rmem[mma_id_q][mma_id_kv]);
+
+            if constexpr (CAUSAL) {
+                if (needs_causal_mask) {
+                    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                            const int k_phys_0 = mma_id_kv * MMA_N + k_col_base;
+                            const int k_phys_1 = k_phys_0 + 1;
+                            const int k_col_0 = k_block_start + ta_kv_logical_from_physical(k_phys_0);
+                            const int k_col_1 = k_block_start + ta_kv_logical_from_physical(k_phys_1);
+                            if (k_col_0 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][0] = -INFINITY;
+                            if (k_col_1 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][1] = -INFINITY;
+                            if (k_col_0 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][2] = -INFINITY;
+                            if (k_col_1 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][3] = -INFINITY;
+                        }
+                }
+            }
+
+            uint32_t S_fp4_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_K_FP4][4];
+            uint32_t S_fp4_s_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_K_FP4];
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int reg_id = 0; reg_id < 4; reg_id++)
+                        S_rmem[mma_id_q][mma_id_kv][reg_id] *= softmax_scale;
+
+                float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    float *r = S_rmem[mma_id_q][mma_id_kv];
+                    this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+                    this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+                }
+                this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+                this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+                this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+                this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+                this_rowmax[0] = max(this_rowmax[0], rowmax[mma_id_q][0]);
+                this_rowmax[1] = max(this_rowmax[1], rowmax[mma_id_q][1]);
+
+                float rescale[2] = {
+                    __expf(rowmax[mma_id_q][0] - this_rowmax[0]),
+                    __expf(rowmax[mma_id_q][1] - this_rowmax[1])
+                };
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                    O_rmem[mma_id_q][mma_id_d][0] *= rescale[0];
+                    O_rmem[mma_id_q][mma_id_d][1] *= rescale[0];
+                    O_rmem[mma_id_q][mma_id_d][2] *= rescale[1];
+                    O_rmem[mma_id_q][mma_id_d][3] *= rescale[1];
+                }
+                rowmax[mma_id_q][0] = this_rowmax[0];
+                rowmax[mma_id_q][1] = this_rowmax[1];
+
+                float this_rowsumexp[2] = {};
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    float *r = S_rmem[mma_id_q][mma_id_kv];
+                    r[0] = __expf(r[0] - rowmax[mma_id_q][0]);
+                    r[1] = __expf(r[1] - rowmax[mma_id_q][0]);
+                    r[2] = __expf(r[2] - rowmax[mma_id_q][1]);
+                    r[3] = __expf(r[3] - rowmax[mma_id_q][1]);
+                    this_rowsumexp[0] += r[0] + r[1];
+                    this_rowsumexp[1] += r[2] + r[3];
+                }
+                this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+                this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+                this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+                this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+                rowsum[mma_id_q][0] = rowsum[mma_id_q][0] * rescale[0] + this_rowsumexp[0];
+                rowsum[mma_id_q][1] = rowsum[mma_id_q][1] * rescale[1] + this_rowsumexp[1];
+
+                constexpr float FP4_RANGE = 6.0f;
+                constexpr float FP4_MAX   = 6.0f;
+
+                float sf_P_upper[BLOCK_KV_FP4 / MMA_N / 4];
+                float sf_P_lower[BLOCK_KV_FP4 / MMA_N / 4];
+                for (int blk = 0; blk < BLOCK_KV_FP4 / MMA_N / 4; blk++) {
+                    const int t0 = 4 * blk, t1 = t0 + 1, t2 = t0 + 2, t3 = t0 + 3;
+                    const float gmax_upper = rowmax[mma_id_q][0];
+                    const float gmax_lower = rowmax[mma_id_q][1];
+                    const bool valid_upper = gmax_upper > -FLT_MAX * 0.5f;
+                    const bool valid_lower = gmax_lower > -FLT_MAX * 0.5f;
+                    const float inv_upper = valid_upper ? (FP4_MAX * __expf(rowmax[mma_id_q][0] - gmax_upper)) : 0.0f;
+                    const float inv_lower = valid_lower ? (FP4_MAX * __expf(rowmax[mma_id_q][1] - gmax_lower)) : 0.0f;
+                    sf_P_upper[blk] = valid_upper ? (FP4_RANGE / FP4_MAX * __expf(gmax_upper - rowmax[mma_id_q][0])) : 1.0f;
+                    sf_P_lower[blk] = valid_lower ? (FP4_RANGE / FP4_MAX * __expf(gmax_lower - rowmax[mma_id_q][1])) : 1.0f;
+                    S_rmem[mma_id_q][t0][0] *= inv_upper;  S_rmem[mma_id_q][t0][1] *= inv_upper;
+                    S_rmem[mma_id_q][t1][0] *= inv_upper;  S_rmem[mma_id_q][t1][1] *= inv_upper;
+                    S_rmem[mma_id_q][t0][2] *= inv_lower;  S_rmem[mma_id_q][t0][3] *= inv_lower;
+                    S_rmem[mma_id_q][t1][2] *= inv_lower;  S_rmem[mma_id_q][t1][3] *= inv_lower;
+                    S_rmem[mma_id_q][t2][0] *= inv_upper;  S_rmem[mma_id_q][t2][1] *= inv_upper;
+                    S_rmem[mma_id_q][t3][0] *= inv_upper;  S_rmem[mma_id_q][t3][1] *= inv_upper;
+                    S_rmem[mma_id_q][t2][2] *= inv_lower;  S_rmem[mma_id_q][t2][3] *= inv_lower;
+                    S_rmem[mma_id_q][t3][2] *= inv_lower;  S_rmem[mma_id_q][t3][3] *= inv_lower;
+                }
+
+                for (int g = 0; g < BLOCK_KV_FP4 / MMA_N / 4; g++) {
+                    float *r0 = S_rmem[mma_id_q][g*4], *r1 = S_rmem[mma_id_q][g*4+1],
+                          *r2 = S_rmem[mma_id_q][g*4+2], *r3 = S_rmem[mma_id_q][g*4+3];
+                    S_fp4_rmem[mma_id_q][0][2*g]   = ta_cvt_8xf32_to_e2m1_packed(
+                        r0[1],r0[0],r1[1],r1[0], r2[1],r2[0],r3[1],r3[0]);
+                    S_fp4_rmem[mma_id_q][0][2*g+1] = ta_cvt_8xf32_to_e2m1_packed(
+                        r0[3],r0[2],r1[3],r1[2], r2[3],r2[2],r3[3],r3[2]);
+                }
+
+                for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV_FP4 / MMA_K_FP4; mma_sc_id++) {
+                    int base = mma_sc_id * 2;
+                    uint32_t sfP_upper_packed = ta_cvt_2xf32_to_e8m0_packed(
+                        sf_P_upper[base+1], sf_P_upper[base+0]);
+                    uint32_t sfP_lower_packed = ta_cvt_2xf32_to_e8m0_packed(
+                        sf_P_lower[base+1], sf_P_lower[base+0]);
+                    S_fp4_s_rmem[mma_id_q][mma_sc_id] =
+                        (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+                }
+            }
+
+            // Wait for V load to complete
+            asm volatile("cp.async.wait_group 0;");
+            __syncthreads();
+
+            uint32_t V_rmem[BLOCK_KV_FP4 / MMA_K_FP4][HEAD_DIM / MMA_N][2];
+            uint32_t sfV_rmem[BLOCK_KV_FP4 / MMA_K_FP4][HEAD_DIM / MMA_N];
+
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                    const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                    const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                    uint32_t addr = ta_swizzle<BLOCK_KV_FP4 / 2>(
+                        V_smem_fp4 + n_idx * (BLOCK_KV_FP4 / 2) + k_byte_offset);
+                    ta_ldmatrix_x4(V_rmem[mma_id_kv][mma_id_d], addr);
+                }
+
+            constexpr int V_SF_STRIDE = BLOCK_KV_FP4 / 32;
+            const int sf_col_v = lane_id / 4;
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                    const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                    const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 2) * (uint32_t)sizeof(__nv_fp8_e8m0);
+                    sfV_rmem[mma_id_kv][mma_id_d] = ta_ld_shared_u16(V_sf_smem_fp4 + offset);
+                }
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+                    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                        ta_mma_m16n8k64_mxfp4(
+                            S_fp4_rmem[mma_id_q][mma_id_kv],
+                            V_rmem[mma_id_kv][mma_id_d],
+                            S_fp4_s_rmem[mma_id_q][mma_id_kv],
+                            sfV_rmem[mma_id_kv][mma_id_d],
+                            O_rmem[mma_id_q][mma_id_d]);
+
+            __syncthreads();
+        }
+    }
+
+    // ==================== PHASE 3: Save FP4 partial state + output ====================
+    constexpr float FP4_RANGE_INV = 1.0f / 6.0f;
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        if ((lane_id & 3) == 0) {
+            const int row_upper = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int row_lower = row_upper + 8;
+            rowmax_state[row_upper] = rowmax[mma_id_q][0];
+            rowmax_state[row_lower] = rowmax[mma_id_q][1];
+            rowsum_state[row_upper] = rowsum[mma_id_q][0];
+            rowsum_state[row_lower] = rowsum[mma_id_q][1];
+        }
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            const float norm0 = rowsum[mma_id_q][0] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][0]
+                : 0.0f;
+            const float norm1 = rowsum[mma_id_q][1] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][1]
+                : 0.0f;
+
+            regs[0] *= norm0;  regs[1] *= norm0;
+            regs[2] *= norm1;  regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+    }
+}
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV_FP4, int HEAD_DIM,
+         int NUM_WARPS, int WARP_Q, int TOPK_BUCKET>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void thrift_attention_fp16_finalize_kernel(
+    const T* Q_fp16_in,
+    const T* K_fp16_in,
+    const T* V_fp16_in,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    const float* rowmax_state,
+    const float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K_FP16 = 16;
+    constexpr int MMA_N = 8;
+    constexpr float FP4_RANGE = 6.0f;
+    constexpr float FP4_RANGE_INV = 1.0f / FP4_RANGE;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q_fp16_in += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    K_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    V_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    O += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    rowmax_state += q_bid * q_len + q_block_id * BLOCK_Q;
+    rowsum_state += q_bid * q_len + q_block_id * BLOCK_Q;
+
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int max_kv_pos = q_block_start + BLOCK_Q - 1;
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV_FP4);
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV_FP4 + 1, total_kv_iters)
+        : total_kv_iters;
+
+    const int32_t* selected_row =
+        selected_blocks + (static_cast<int64_t>(q_bid) * num_q_blocks + q_block_id) * topk_count;
+
+    float rowmax[WARP_Q / MMA_M][2];
+    float rowsum[WARP_Q / MMA_M][2];
+    float O_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4];
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+        rowmax[mma_id_q][0] = rowmax_state[row];
+        rowmax[mma_id_q][1] = rowmax_state[row + 8];
+        rowsum[mma_id_q][0] = rowsum_state[row];
+        rowsum[mma_id_q][1] = rowsum_state[row + 8];
+
+        const float partial_scale0 = rowsum[mma_id_q][0] * FP4_RANGE;
+        const float partial_scale1 = rowsum[mma_id_q][1] * FP4_RANGE;
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            const T* upper = O + row * HEAD_DIM + col;
+            const T* lower = O + (row + 8) * HEAD_DIM + col;
+            O_rmem[mma_id_q][mma_id_d][0] = Traits::to_float(upper[0]) * partial_scale0;
+            O_rmem[mma_id_q][mma_id_d][1] = Traits::to_float(upper[1]) * partial_scale0;
+            O_rmem[mma_id_q][mma_id_d][2] = Traits::to_float(lower[0]) * partial_scale1;
+            O_rmem[mma_id_q][mma_id_d][3] = Traits::to_float(lower[1]) * partial_scale1;
+        }
+    }
+
+    extern __shared__ uint8_t smem[];
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+    const uint32_t Q_fp16_smem = smem_base;
+    const uint32_t KV_fp16_smem = smem_base;
+
+    constexpr int Q_FP16_ROW_BYTES = HEAD_DIM * (int)sizeof(T);
+    constexpr int Q_FP16_TOTAL_BYTES = BLOCK_Q * Q_FP16_ROW_BYTES;
+    constexpr int Q_FP16_TOTAL_CHUNKS = Q_FP16_TOTAL_BYTES / 16;
+
+    for (int chunk = tid; chunk < Q_FP16_TOTAL_CHUNKS; chunk += TB_SIZE) {
+        const int byte_off = chunk * 16;
+        const int row = byte_off / Q_FP16_ROW_BYTES;
+        const int col = byte_off % Q_FP16_ROW_BYTES;
+        uint32_t dst = ta_swizzle<Q_FP16_ROW_BYTES>(Q_fp16_smem + row * Q_FP16_ROW_BYTES + col);
+        const char* src = reinterpret_cast<const char*>(Q_fp16_in + row * HEAD_DIM) + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;" :: "r"(dst), "l"(src));
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    uint32_t Q_fp16_rmem[HEAD_DIM / MMA_K_FP16][4];
+    {
+        const int q_row = warp_id * WARP_Q + (lane_id % 16);
+        const int q_col_bytes = (lane_id / 16) * 8 * (int)sizeof(T);
+        uint32_t Q_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            Q_fp16_smem + q_row * Q_FP16_ROW_BYTES + q_col_bytes);
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++) {
+            uint32_t addr = Q_fp16_ld_base;
+            addr ^= mma_id_d * MMA_K_FP16 * (int)sizeof(T);
+            ta_ldmatrix_x4(Q_fp16_rmem[mma_id_d], addr);
+        }
+    }
+    __syncthreads();
+
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);
+    const int q_row_lower = q_row_upper + 8;
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base = (lane_id % 4) * 2;
+
+    const int selected_limit = min(min(topk_count, TOPK_BUCKET), num_kv_iters);
+    for (int selected_idx = 0; selected_idx < selected_limit; selected_idx++) {
+        const int kv_iter = selected_row[selected_idx];
+        if (kv_iter < 0 || kv_iter >= num_kv_iters) {
+            continue;
+        }
+
+        constexpr int FP16_ROWS = BLOCK_KV_FP4;
+        constexpr int FP16_N_TILES = FP16_ROWS / MMA_N;
+        constexpr int FP16_PV_CHUNKS = FP16_ROWS / MMA_K_FP16;
+
+        const int k_block_start = kv_iter * BLOCK_KV_FP4;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV_FP4 - 1) > q_block_start);
+
+        const T* K_fp16_ptr = K_fp16_in + kv_iter * FP16_ROWS * HEAD_DIM;
+        ta_gmem_to_smem<FP16_ROWS, HEAD_DIM, TB_SIZE, T>(
+            KV_fp16_smem, K_fp16_ptr, tid, HEAD_DIM);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncthreads();
+
+        uint32_t K_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            KV_fp16_smem + ((lane_id % 8) * HEAD_DIM + (lane_id / 8) * 8) * (int)sizeof(T));
+
+        float S_fp16[FP16_N_TILES][4] = {};
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+            uint32_t K_tile[HEAD_DIM / MMA_K_FP16][2];
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++) {
+                uint32_t addr = K_fp16_ld_base
+                    + mma_id_kv * MMA_N * Q_FP16_ROW_BYTES;
+                addr ^= mma_id_d * MMA_K_FP16 * (int)sizeof(T);
+                ta_ldmatrix_x2(K_tile[mma_id_d], addr);
+            }
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++)
+                Traits::mma(
+                    Q_fp16_rmem[mma_id_d], K_tile[mma_id_d], S_fp16[mma_id_kv]);
+        }
+
+        __syncthreads();
+        const T* V_fp16_ptr = V_fp16_in + kv_iter * FP16_ROWS * HEAD_DIM;
+        ta_gmem_to_smem<FP16_ROWS, HEAD_DIM, TB_SIZE, T>(
+            KV_fp16_smem, V_fp16_ptr, tid, HEAD_DIM);
+        asm volatile("cp.async.commit_group;");
+
+        if constexpr (CAUSAL) {
+            if (needs_causal_mask) {
+                for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+                    const int k_col_0 = k_block_start + mma_id_kv * MMA_N + k_col_base;
+                    const int k_col_1 = k_col_0 + 1;
+                    if (k_col_0 > q_row_upper_global) S_fp16[mma_id_kv][0] = -INFINITY;
+                    if (k_col_1 > q_row_upper_global) S_fp16[mma_id_kv][1] = -INFINITY;
+                    if (k_col_0 > q_row_lower_global) S_fp16[mma_id_kv][2] = -INFINITY;
+                    if (k_col_1 > q_row_lower_global) S_fp16[mma_id_kv][3] = -INFINITY;
+                }
+            }
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++)
+            for (int r = 0; r < 4; r++)
+                S_fp16[mma_id_kv][r] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+            this_rowmax[0] = max(this_rowmax[0], max(S_fp16[mma_id_kv][0], S_fp16[mma_id_kv][1]));
+            this_rowmax[1] = max(this_rowmax[1], max(S_fp16[mma_id_kv][2], S_fp16[mma_id_kv][3]));
+        }
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0][0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[0][1]);
+
+        float rescale[2] = {
+            __expf(rowmax[0][0] - this_rowmax[0]),
+            __expf(rowmax[0][1] - this_rowmax[1])
+        };
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[0][mma_id_d][0] *= rescale[0];
+            O_rmem[0][mma_id_d][1] *= rescale[0];
+            O_rmem[0][mma_id_d][2] *= rescale[1];
+            O_rmem[0][mma_id_d][3] *= rescale[1];
+        }
+        rowmax[0][0] = this_rowmax[0];
+        rowmax[0][1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        uint32_t P_rmem[FP16_PV_CHUNKS][4];
+
+        for (int mma_blk = 0; mma_blk < FP16_PV_CHUNKS; mma_blk++) {
+            const int t0 = 2 * mma_blk;
+            const int t1 = t0 + 1;
+            float *r0 = S_fp16[t0];
+            float *r1 = S_fp16[t1];
+
+            r0[0] = __expf(r0[0] - rowmax[0][0]);
+            r0[1] = __expf(r0[1] - rowmax[0][0]);
+            r0[2] = __expf(r0[2] - rowmax[0][1]);
+            r0[3] = __expf(r0[3] - rowmax[0][1]);
+
+            r1[0] = __expf(r1[0] - rowmax[0][0]);
+            r1[1] = __expf(r1[1] - rowmax[0][0]);
+            r1[2] = __expf(r1[2] - rowmax[0][1]);
+            r1[3] = __expf(r1[3] - rowmax[0][1]);
+
+            this_rowsumexp[0] += r0[0] + r0[1] + r1[0] + r1[1];
+            this_rowsumexp[1] += r0[2] + r0[3] + r1[2] + r1[3];
+
+            typename Traits::vec2* p = reinterpret_cast<typename Traits::vec2*>(P_rmem[mma_blk]);
+            p[0] = Traits::pack2(r0[0] * FP4_RANGE, r0[1] * FP4_RANGE);
+            p[1] = Traits::pack2(r0[2] * FP4_RANGE, r0[3] * FP4_RANGE);
+            p[2] = Traits::pack2(r1[0] * FP4_RANGE, r1[1] * FP4_RANGE);
+            p[3] = Traits::pack2(r1[2] * FP4_RANGE, r1[3] * FP4_RANGE);
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+        rowsum[0][0] = rowsum[0][0] * rescale[0] + this_rowsumexp[0];
+        rowsum[0][1] = rowsum[0][1] * rescale[1] + this_rowsumexp[1];
+
+        asm volatile("cp.async.wait_all;");
+        __syncthreads();
+
+        uint32_t V_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            KV_fp16_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < FP16_PV_CHUNKS; mma_id_kv++) {
+                uint32_t V_tile[2];
+                uint32_t addr = V_fp16_ld_base
+                    + mma_id_kv * MMA_K_FP16 * Q_FP16_ROW_BYTES;
+                addr ^= mma_id_d * MMA_N * (int)sizeof(T);
+                ta_ldmatrix_x2_trans(V_tile, addr);
+                Traits::mma(P_rmem[mma_id_kv], V_tile, O_rmem[0][mma_id_d]);
+            }
+
+        __syncthreads();
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            const float norm0 = rowsum[mma_id_q][0] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][0]
+                : 0.0f;
+            const float norm1 = rowsum[mma_id_q][1] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][1]
+                : 0.0f;
+
+            regs[0] *= norm0;  regs[1] *= norm0;
+            regs[2] *= norm1;  regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+        }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4, int TOPK_BUCKET>
+static void launch_thrift_attention_fp16_finalize(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int q_fp16_smem = BLOCK_Q * HEAD_DIM * (int)sizeof(T);
+    constexpr int fp16_kv_smem = BLOCK_KV_FP4 * HEAD_DIM * (int)sizeof(T);
+    constexpr int fp16_smem = (q_fp16_smem > fp16_kv_smem) ? q_fp16_smem : fp16_kv_smem;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    auto fp16_finalize_kernel = thrift_attention_fp16_finalize_kernel<
+        T, CAUSAL, BLOCK_Q, BLOCK_KV_FP4, HEAD_DIM, NUM_WARPS, WARP_Q, TOPK_BUCKET>;
+
+    cudaFuncSetAttribute(fp16_finalize_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, fp16_smem);
+
+    fp16_finalize_kernel<<<num_blocks, TB_SIZE, fp16_smem>>>(
+        Q_fp16, K_fp16, V_fp16,
+        selected_blocks, topk_count,
+        O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4>
+static void dispatch_thrift_attention_fp16_finalize(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    if (topk_count <= 1)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 1>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 2)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 2>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 4)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 4>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 8)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 8>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 16)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 16>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 32)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 32>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 64)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 64>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 128)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 128>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 256)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 256>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 512)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 512>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 2048>(
+        Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+        rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4>
+static void launch_thrift_attention(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    const unsigned long long* topk_mask,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 32;
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    constexpr int q_phase_smem =
+        BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e8m0);
+
+    constexpr int v_phase_smem =
+        HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 32) * (int)sizeof(__nv_fp8_e8m0);
+
+    constexpr int fp4_kv_smem = q_phase_smem + v_phase_smem;
+
+    auto fp4_state_kernel = thrift_attention_kernel<
+        T, CAUSAL, BLOCK_Q, BLOCK_KV_FP4, HEAD_DIM,
+        HEAD_DIM_2, SCALE_DIM, NUM_WARPS, WARP_Q>;
+
+    cudaFuncSetAttribute(fp4_state_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, fp4_kv_smem);
+
+    fp4_state_kernel<<<num_blocks, TB_SIZE, fp4_kv_smem>>>(
+        Q_fp16, K_fp16, V_fp16,
+        topk_mask, topk_word_count,
+        Q_fp4, K_fp4, V_fp4,
+        S_Q, S_K, S_V, O,
+        rowmax_state, rowsum_state,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+    dispatch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4>(
+        Q_fp16, K_fp16, V_fp16,
+        selected_blocks, topk_count,
+        O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+static void dispatch_thrift_attention(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    const unsigned long long* topk_mask,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e8m0* S_Q,
+    const __nv_fp8_e8m0* S_K,
+    const __nv_fp8_e8m0* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    return launch_thrift_attention<T, CAUSAL, HEAD_DIM, 64, 64>(
+        Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count,
+        topk_mask, topk_word_count, Q_fp4, K_fp4, V_fp4,
+        S_Q, S_K, S_V, O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL>
+static void thrift_attention_mxfp4_typed(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim)
+{
+    auto Q_fp16 = reinterpret_cast<const T*>(Q_fp16_raw);
+    auto K_fp16 = reinterpret_cast<const T*>(K_fp16_raw);
+    auto V_fp16 = reinterpret_cast<const T*>(V_fp16_raw);
+    auto selected_blocks = reinterpret_cast<const int32_t*>(selected_blocks_raw);
+    auto topk_mask = reinterpret_cast<const unsigned long long*>(topk_mask_raw);
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+
+    auto S_Q = reinterpret_cast<const __nv_fp8_e8m0*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e8m0*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e8m0*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+    auto rowmax_state = reinterpret_cast<float*>(rowmax_state_raw);
+    auto rowsum_state = reinterpret_cast<float*>(rowsum_state_raw);
+
+    if (head_dim == 64)
+        dispatch_thrift_attention<T, CAUSAL, 64>(
+            Q_fp16, K_fp16, V_fp16,
+            selected_blocks, topk_count,
+            topk_mask, topk_word_count,
+            Q, K, V, S_Q, S_K, S_V, O,
+            rowmax_state, rowsum_state,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    else
+        dispatch_thrift_attention<T, CAUSAL, 128>(
+            Q_fp16, K_fp16, V_fp16,
+            selected_blocks, topk_count,
+            topk_mask, topk_word_count,
+            Q, K, V, S_Q, S_K, S_V, O,
+            rowmax_state, rowsum_state,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+void thrift_attention_causal_mxfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_mxfp4_typed<__nv_bfloat16, true>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        thrift_attention_mxfp4_typed<half, true>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}
+
+void thrift_attention_noncausal_mxfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_mxfp4_typed<__nv_bfloat16, false>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        thrift_attention_mxfp4_typed<half, false>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/nvfp4/fp4_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/nvfp4/fp4_attention.cu
@@ -1,0 +1,564 @@
+// SM120 NVFP4 attention baseline
+
+#include <cstdint>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV, int HEAD_DIM,
+         int HEAD_DIM_2, int SCALE_DIM,
+         int NUM_WARPS, int WARP_Q>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void fp4_attention_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+    const int v_kv = ta_cdiv(kv_capacity, 128) * 128;
+
+    Q += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM_2;
+    K += kv_bid * kv_capacity * HEAD_DIM_2;
+    V += kv_bid * HEAD_DIM * (v_kv / 2);
+
+    S_Q += (q_bid * q_len + q_block_id * BLOCK_Q) * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv * SCALE_DIM;
+    O += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+    const uint32_t Q_smem = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem = Q_sf_smem + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e4m3);
+    const uint32_t V_sf_smem = V_smem + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfQ_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    float rowmax[WARP_Q/MMA_M][2];
+    float rowsum[WARP_Q/MMA_M][2] = {};
+    float O_rmem[WARP_Q/MMA_M][HEAD_DIM/MMA_N][4] = {};
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q/MMA_M; mma_id_q++) {
+        rowmax[mma_id_q][0] = -FLT_MAX;
+        rowmax[mma_id_q][1] = -FLT_MAX;
+    }
+
+    // ---- load Q data global -> shared (swizzled) -> registers ----
+    ta_gmem_to_smem<BLOCK_Q, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(Q_smem, Q, tid, HEAD_DIM_2);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    // Pre-compute swizzled base address for Q ldmatrix.
+    // Row offsets that are multiples of 8 rows can be added (swizzle repeats every 8 rows).
+    // Column tile offsets use XOR: swizzle(base + col_delta) == swizzle(base) ^ col_delta.
+    uint32_t Q_ld_base;
+    {
+        const int row_off = warp_id * WARP_Q + (lane_id % 16);
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = ta_swizzle<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            uint32_t addr = Q_ld_base;
+            addr += mma_id_q * MMA_M * HEAD_DIM_2;  // row: MMA_M=16, 16%8==0
+            addr ^= mma_id_d * (MMA_K / 2);          // col via XOR
+            ta_ldmatrix_x4(Q_rmem[mma_id_q][mma_id_d], addr);
+        }
+
+    // ---- load Q scales global -> shared -> registers ----
+    ta_load_scales<BLOCK_Q, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(Q_sf_smem, S_Q, SCALE_DIM, tid);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + sf_row_q;
+            const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+            asm volatile("ld.shared.u32 %0, [%1];"
+                : "=r"(sfQ_rmem[mma_id_q][mma_id_d])
+                : "r"(Q_sf_smem + offset));
+        }
+    }
+
+    // ---- KV loop ----
+    __syncthreads();
+    const uint32_t K_smem = __cvta_generic_to_shared(smem);
+    const uint32_t K_sf_smem = K_smem + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV);
+    const int max_kv_pos = q_block_id * BLOCK_Q + BLOCK_Q - 1;
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV + 1, total_kv_iters)
+        : total_kv_iters;
+
+    // Pre-compute base address for K ldmatrix.
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = ta_swizzle<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // Precompute per-thread query row offsets within the block.
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);       // rows 0-7 of MMA tile
+    const int q_row_lower = q_row_upper + 8;                         // rows 8-15 of MMA tile
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base = (lane_id % 4) * 2;                        // base key col within MMA_N tile
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[WARP_Q / MMA_M][BLOCK_KV / MMA_K];
+
+        const int k_block_start = kv_iter * BLOCK_KV;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV - 1) > q_block_start);
+
+        // Load K first; issue V in a second async group so QK can overlap
+        // with the V transfer.
+        ta_gmem_to_smem<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem, K, tid, HEAD_DIM_2);;
+        ta_load_scales<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(K_sf_smem, S_K, SCALE_DIM, tid);
+        asm volatile("cp.async.commit_group;");
+        ta_gmem_to_smem<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem, V, tid, v_kv / 2);
+        ta_load_scales<HEAD_DIM, BLOCK_KV / 16, TB_SIZE, __nv_fp8_e4m3>(V_sf_smem, S_V, v_kv / 16, tid);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 1;");
+        __syncthreads();
+
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            // ldmatrix_x4: lanes 0-15 cover mma_id_d=0, lanes 16-31 cover mma_id_d=1
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ta_ldmatrix_x4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ta_ldmatrix_x2(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        const int sf_row_k = (lane_id / 4);
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                    : "r"(K_sf_smem + offset));
+            }
+        }
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                    ta_mma_m16n8k64_nvfp4(
+                        Q_rmem[mma_id_q][mma_id_d],
+                        K_rmem[mma_id_kv][mma_id_d],
+                        sfQ_rmem[mma_id_q][mma_id_d],
+                        sfK_rmem[mma_id_kv][mma_id_d],
+                        S_rmem[mma_id_q][mma_id_kv]);
+
+        // ---- Apply causal mask on blocks overlapping the query tile ----
+        if constexpr (CAUSAL) {
+            if (needs_causal_mask) {
+                for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+                    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                        const int k_phys_0 = mma_id_kv * MMA_N + k_col_base;
+                        const int k_phys_1 = k_phys_0 + 1;
+                        const int k_col_0 = k_block_start + ta_kv_logical_from_physical(k_phys_0);
+                        const int k_col_1 = k_block_start + ta_kv_logical_from_physical(k_phys_1);
+
+                        // regs[0]: (q_row_upper, k_col_0), regs[1]: (q_row_upper, k_col_1)
+                        // regs[2]: (q_row_lower, k_col_0), regs[3]: (q_row_lower, k_col_1)
+                        if (k_col_0 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][0] = -INFINITY;
+                        if (k_col_1 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][1] = -INFINITY;
+                        if (k_col_0 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][2] = -INFINITY;
+                        if (k_col_1 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][3] = -INFINITY;
+                    }
+                }
+            }
+        }
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+            // apply softmax scale
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int reg_id = 0; reg_id < 4; reg_id++)
+                    S_rmem[mma_id_q][mma_id_kv][reg_id] *= softmax_scale;
+
+            // rowmax over this KV block
+            float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                float *regs = S_rmem[mma_id_q][mma_id_kv];
+                this_rowmax[0] = max(this_rowmax[0], max(regs[0], regs[1]));
+                this_rowmax[1] = max(this_rowmax[1], max(regs[2], regs[3]));
+            }
+            this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+            this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+            // new rowmax
+            this_rowmax[0] = max(this_rowmax[0], rowmax[mma_id_q][0]);
+            this_rowmax[1] = max(this_rowmax[1], rowmax[mma_id_q][1]);
+
+            // rescale previous O for new rowmax
+            float rescale[2];
+            rescale[0] = __expf(rowmax[mma_id_q][0] - this_rowmax[0]);
+            rescale[1] = __expf(rowmax[mma_id_q][1] - this_rowmax[1]);
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                O_rmem[mma_id_q][mma_id_d][0] *= rescale[0];
+                O_rmem[mma_id_q][mma_id_d][1] *= rescale[0];
+                O_rmem[mma_id_q][mma_id_d][2] *= rescale[1];
+                O_rmem[mma_id_q][mma_id_d][3] *= rescale[1];
+            }
+
+            // save new rowmax
+            rowmax[mma_id_q][0] = this_rowmax[0];
+            rowmax[mma_id_q][1] = this_rowmax[1];
+
+            // softmax numerator and rowsumexp
+            float this_rowsumexp[2] = {};
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                float *regs = S_rmem[mma_id_q][mma_id_kv];
+                regs[0] = __expf(regs[0] - rowmax[mma_id_q][0]);
+                regs[1] = __expf(regs[1] - rowmax[mma_id_q][0]);
+                regs[2] = __expf(regs[2] - rowmax[mma_id_q][1]);
+                regs[3] = __expf(regs[3] - rowmax[mma_id_q][1]);
+
+                this_rowsumexp[0] += regs[0] + regs[1];
+                this_rowsumexp[1] += regs[2] + regs[3];
+            }
+
+            // butterfly reduction within 4 threads
+            this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+            this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+            // accumulate to running rowsum
+            rowsum[mma_id_q][0] = rowsum[mma_id_q][0] * rescale[0] + this_rowsumexp[0];
+            rowsum[mma_id_q][1] = rowsum[mma_id_q][1] * rescale[1] + this_rowsumexp[1];
+
+            constexpr float FP4_RANGE = 448.0f * 6.0f;
+            constexpr float FP4_MAX = 6.0f;
+            float sf_P_upper[BLOCK_KV / MMA_N / 2];
+            float sf_P_lower[BLOCK_KV / MMA_N / 2];
+
+            for (int blk = 0; blk < BLOCK_KV / MMA_N /2 ; blk++) {
+                const int t0 = 2 * blk;
+                const int t1 = t0 + 1;
+                const float gmax_upper = rowmax[mma_id_q][0];
+                const float gmax_lower = rowmax[mma_id_q][1];
+                const bool valid_upper = gmax_upper > -FLT_MAX * 0.5f;
+                const bool valid_lower = gmax_lower > -FLT_MAX * 0.5f;
+                const float inv_upper = valid_upper ? (FP4_MAX * __expf(rowmax[mma_id_q][0] - gmax_upper)) : 0.0f;
+                const float inv_lower = valid_lower ? (FP4_MAX * __expf(rowmax[mma_id_q][1] - gmax_lower)) : 0.0f;
+                sf_P_upper[blk] = valid_upper ? (FP4_RANGE / FP4_MAX * __expf(gmax_upper - rowmax[mma_id_q][0])) : 1.0f;
+                sf_P_lower[blk] = valid_lower ? (FP4_RANGE / FP4_MAX * __expf(gmax_lower - rowmax[mma_id_q][1])) : 1.0f;
+
+                S_rmem[mma_id_q][t0][0] *= inv_upper;
+                S_rmem[mma_id_q][t0][1] *= inv_upper;
+                S_rmem[mma_id_q][t1][0] *= inv_upper;
+                S_rmem[mma_id_q][t1][1] *= inv_upper;
+                S_rmem[mma_id_q][t0][2] *= inv_lower;
+                S_rmem[mma_id_q][t0][3] *= inv_lower;
+                S_rmem[mma_id_q][t1][2] *= inv_lower;
+                S_rmem[mma_id_q][t1][3] *= inv_lower;
+            }
+
+            for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+                int blk = 4 * g;
+                float *r0 = S_rmem[mma_id_q][blk];
+                float *r1 = S_rmem[mma_id_q][blk + 1];
+                float *r2 = S_rmem[mma_id_q][blk + 2];
+                float *r3 = S_rmem[mma_id_q][blk + 3];
+
+                S_fp4_rmem[mma_id_q][0][2 * g] = ta_cvt_8xf32_to_e2m1_packed(
+                    r0[1], r0[0], r1[1], r1[0],
+                    r2[1], r2[0], r3[1], r3[0]);
+                S_fp4_rmem[mma_id_q][0][2 * g + 1] = ta_cvt_8xf32_to_e2m1_packed(
+                    r0[3], r0[2], r1[3], r1[2],
+                    r2[3], r2[2], r3[3], r3[2]);
+            }
+
+            for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+                int base = mma_sc_id * 4;
+                uint32_t sfP_upper_packed = ta_cvt_4xf32_to_e4m3_packed(
+                    sf_P_upper[base + 1], sf_P_upper[base + 0],
+                    sf_P_upper[base + 3], sf_P_upper[base + 2]);
+
+                uint32_t sfP_lower_packed = ta_cvt_4xf32_to_e4m3_packed(
+                    sf_P_lower[base + 1], sf_P_lower[base + 0],
+                    sf_P_lower[base + 3], sf_P_lower[base + 2]);
+
+                S_fp4_s_rmem[mma_id_q][mma_sc_id] =
+                    (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+            }
+        }
+
+        // V layout in smem: [HEAD_DIM, BLOCK_KV/2], stride = BLOCK_KV/2 bytes.
+        // ldmatrix_x4: lanes 0-15 address tile mma_id_d, lanes 16-31 address tile mma_id_d+1.
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = ta_swizzle<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ta_ldmatrix_x4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        constexpr int V_SF_STRIDE = BLOCK_KV / 16;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                    : "r"(V_sf_smem + offset));
+            }
+
+        // MMA O += P @ V
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                    ta_mma_m16n8k64_nvfp4(
+                        S_fp4_rmem[mma_id_q][mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        S_fp4_s_rmem[mma_id_q][mma_id_kv],
+                        sfV_rmem[mma_id_kv][mma_id_d],
+                        O_rmem[mma_id_q][mma_id_d]);
+
+        K += BLOCK_KV * HEAD_DIM_2;
+        S_K += BLOCK_KV * SCALE_DIM;
+
+        V  += BLOCK_KV / 2;
+        S_V += BLOCK_KV / 16;
+    }
+
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            float norm0 = FP4_RANGE_INV / rowsum[mma_id_q][0];
+            float norm1 = FP4_RANGE_INV / rowsum[mma_id_q][1];
+
+            regs[0] *= norm0;
+            regs[1] *= norm0;
+            regs[2] *= norm1;
+            regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+        }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+static void launch_fp4_attention(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q, const __nv_fp8_e4m3* S_K, const __nv_fp8_e4m3* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_Q = 64;
+    constexpr int BLOCK_KV = 64;
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e4m3);
+    constexpr int v_phase_smem = HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 16) * sizeof(__nv_fp8_e4m3);
+    constexpr int k_phase_smem = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e4m3);
+    constexpr int smem_size = q_phase_smem + v_phase_smem > k_phase_smem
+                            ? q_phase_smem + v_phase_smem : k_phase_smem;
+
+    auto kernel = fp4_attention_kernel<T, CAUSAL, BLOCK_Q, BLOCK_KV, HEAD_DIM,
+                                       HEAD_DIM_2, SCALE_DIM,
+                                       NUM_WARPS, WARP_Q>;
+
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    kernel<<<num_blocks, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL>
+static void dispatch_fp4_attention(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+    if (head_dim == 64) {
+        launch_fp4_attention<T, CAUSAL, 64>(
+            Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+            kv_capacity, num_q_heads, num_kv_heads);
+    } else {
+        launch_fp4_attention<T, CAUSAL, 128>(
+            Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+            kv_capacity, num_q_heads, num_kv_heads);
+    }
+}
+
+template<typename T, bool CAUSAL>
+static void fp4_attention_nvfp4_typed(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+    auto S_Q = reinterpret_cast<const __nv_fp8_e4m3*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e4m3*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e4m3*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    dispatch_fp4_attention<T, CAUSAL>(
+        Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len,
+        kv_capacity, num_q_heads, num_kv_heads, head_dim);
+}
+
+void fp4_attention_causal_nvfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_nvfp4_typed<__nv_bfloat16, true>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_nvfp4_typed<half, true>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}
+
+void fp4_attention_noncausal_nvfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_nvfp4_typed<__nv_bfloat16, false>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_nvfp4_typed<half, false>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/nvfp4/quantization.cu
+++ b/thrift-attention/csrc/cuda/sm120/nvfp4/quantization.cu
@@ -1,0 +1,655 @@
+#include <cstdint>
+#include <cstdio>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+constexpr int ELEMENTS_PER_THREAD = 16;
+
+template<typename T, int SEQ_PER_BLOCK, int THREADS_PER_HEAD>
+__global__
+void nvfp4_quantise_kernel(const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale, int bs, int seq_len, int head_dim)
+{
+    using Traits = PrecisionTraits<T>;
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid/num_seq_blocks;
+
+    const int seq_block_id = bid % num_seq_blocks;
+    const int seq_thread_id = tid / THREADS_PER_HEAD;
+    const int head_id = tid % THREADS_PER_HEAD;
+
+    X += (batch_id * seq_len *head_dim) + (seq_block_id * SEQ_PER_BLOCK + seq_thread_id) * head_dim + head_id * ELEMENTS_PER_THREAD;
+
+    const int seq_id = seq_block_id * SEQ_PER_BLOCK + seq_thread_id;
+
+    uint32_t X_reg[2][4];
+
+    if (seq_id < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+        }
+    }
+
+    typename Traits::vec2* X_h2 = reinterpret_cast<typename Traits::vec2*>(X_reg);
+
+    typename Traits::vec2 local_max = Traits::abs2(X_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(X_h2[i]));
+    }
+
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    // compute scale factor: quantise to fp8, then recover for exact representable value
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8) = __nv_fp8_e4m3(sf);
+    sf = float(reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8));
+
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        X_f2[i] = Traits::to_float2(X_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    // convert to fp4 e2m1: 16 elements = 2 x uint32_t (8 nibbles each)
+    // swap .y/.x at call site so .x (even elem) lands in low nibble
+    uint32_t fp4_packed[2];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+
+    // store fp4 output: 16 fp4 values = 8 bytes per thread
+    // output layout: [bs, seq_len, head_dim/2] (each byte = 2 fp4 values)
+    if (seq_id < seq_len) {
+        __nv_fp4x2_e2m1* out = X_fp4 + batch_id * seq_len * (head_dim / 2)
+                              + seq_id * (head_dim / 2)
+                              + head_id * (ELEMENTS_PER_THREAD / 2);
+        reinterpret_cast<uint64_t*>(out)[0] = reinterpret_cast<uint64_t*>(fp4_packed)[0];
+
+        // store scale factor: 1 fp8 per 16 elements
+        // output layout: [bs, seq_len, head_dim/16]
+        X_scale[batch_id * seq_len * (head_dim / 16) + seq_id * (head_dim / 16) + head_id] =
+            reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8);
+    }
+}
+
+// ---- launch wrapper ----
+
+template<typename T, int HEAD_DIM>
+static void nvfp4_quantise_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * THREADS_PER_HEAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+
+    nvfp4_quantise_kernel<T, SEQ_PER_BLOCK, THREADS_PER_HEAD>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, HEAD_DIM);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "nvfp4_quantise_kernel launch failed: %s\n", cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_nvfp4_quantise(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim) {
+
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e4m3*>(X_scale_raw);
+
+    if (head_dim == 64)
+        nvfp4_quantise_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len);
+    else if (head_dim == 128)
+        nvfp4_quantise_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len);
+    else
+        fprintf(stderr, "nvfp4_quantise: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void nvfp4_quantise(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_nvfp4_quantise<__nv_bfloat16>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    } else {
+        dispatch_nvfp4_quantise<half>(X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    }
+}
+
+template<typename T, int SEQ_PER_BLOCK, int THREADS_PER_HEAD>
+__global__
+void nvfp4_quantise_permute_seq_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len, int head_dim, bool inverse)
+{
+    using Traits = PrecisionTraits<T>;
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+    const int seq_thread_id = tid / THREADS_PER_HEAD;
+    const int head_id = tid % THREADS_PER_HEAD;
+
+    const int phys_seq_id = seq_block_id * SEQ_PER_BLOCK + seq_thread_id;
+    const int logical_local = ta_sage_perm_seq(seq_thread_id, inverse);
+    const int logical_seq_id = seq_block_id * SEQ_PER_BLOCK + logical_local;
+
+    const T* X_ptr = X + batch_id * seq_len * head_dim
+                    + logical_seq_id * head_dim
+                    + head_id * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[2][4];
+    if (logical_seq_id < seq_len && phys_seq_id < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+        }
+    }
+
+    typename Traits::vec2* X_h2 = reinterpret_cast<typename Traits::vec2*>(X_reg);
+
+    typename Traits::vec2 local_max = Traits::abs2(X_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(X_h2[i]));
+    }
+
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8) = __nv_fp8_e4m3(sf);
+    sf = float(reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8));
+
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        X_f2[i] = Traits::to_float2(X_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[2];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+
+    if (phys_seq_id < seq_len) {
+        __nv_fp4x2_e2m1* out = X_fp4 + batch_id * seq_len * (head_dim / 2)
+                              + phys_seq_id * (head_dim / 2)
+                              + head_id * (ELEMENTS_PER_THREAD / 2);
+        reinterpret_cast<uint64_t*>(out)[0] = reinterpret_cast<uint64_t*>(fp4_packed)[0];
+
+        X_scale[batch_id * seq_len * (head_dim / 16) + phys_seq_id * (head_dim / 16) + head_id] =
+            reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8);
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void nvfp4_quantise_permute_seq_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len, bool inverse) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * THREADS_PER_HEAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+
+    nvfp4_quantise_permute_seq_kernel<T, SEQ_PER_BLOCK, THREADS_PER_HEAD>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, HEAD_DIM, inverse);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "nvfp4_quantise_permute_seq_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_nvfp4_quantise_permute_seq(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse) {
+
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e4m3*>(X_scale_raw);
+
+    if (head_dim == 64)
+        nvfp4_quantise_permute_seq_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else if (head_dim == 128)
+        nvfp4_quantise_permute_seq_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else
+        fprintf(stderr, "nvfp4_quantise_permute_seq: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void nvfp4_quantise_permute_seq(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_nvfp4_quantise_permute_seq<__nv_bfloat16>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    } else {
+        dispatch_nvfp4_quantise_permute_seq<half>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    }
+}
+
+// ============================================================================
+// Transpose + quantise kernel
+// Reads  [bs, seq_len, HEAD_DIM]  (row-major, contiguous)
+// Writes [bs, HEAD_DIM, padded_seq/2]  (fp4x2) and [bs, HEAD_DIM, padded_seq/16]  (fp8 scale)
+// i.e. transposes the last two dims while quantising to NV-FP4.
+// ============================================================================
+
+template<typename T, int HEAD_DIM, int SEQ_PER_BLOCK>
+__global__
+void nvfp4_quantise_transpose_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len, int padded_seq)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int THREADS_PER_SEQ  = SEQ_PER_BLOCK / ELEMENTS_PER_THREAD;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+
+    // --- Phase 1: Load input tile [SEQ_PER_BLOCK, HEAD_DIM] into shared mem ---
+    // Thread mapping (same as non-transpose kernel):
+    //   load_seq_local  = which row within the block   [0, SEQ_PER_BLOCK)
+    //   load_head_chunk = which 16-element chunk of d   [0, THREADS_PER_HEAD)
+    const int load_seq_local  = tid / THREADS_PER_HEAD;
+    const int load_head_chunk = tid % THREADS_PER_HEAD;
+    const int load_seq_global = seq_block_id * SEQ_PER_BLOCK + load_seq_local;
+
+    const T* X_ptr = X + batch_id * seq_len * HEAD_DIM
+                    + load_seq_global * HEAD_DIM
+                    + load_head_chunk * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[2][4];
+    if (load_seq_global < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+        }
+    }
+
+    // smem layout: [SEQ_PER_BLOCK][HEAD_DIM]
+    __shared__ T smem[SEQ_PER_BLOCK * HEAD_DIM];
+
+    T* smem_row = smem + load_seq_local * HEAD_DIM + load_head_chunk * ELEMENTS_PER_THREAD;
+    *reinterpret_cast<uint4*>(smem_row)     = *reinterpret_cast<uint4*>(X_reg[0]);
+    *reinterpret_cast<uint4*>(smem_row + 8) = *reinterpret_cast<uint4*>(X_reg[1]);
+
+    __syncthreads();
+
+    // --- Phase 2: Read transposed — 16 elements along seq for one head_dim pos ---
+    // Thread mapping after transpose:
+    //   dim_id    = which head_dim position   [0, HEAD_DIM)
+    //   seq_chunk = which 16-element group     [0, THREADS_PER_SEQ)
+    const int dim_id    = tid / THREADS_PER_SEQ;
+    const int seq_chunk = tid % THREADS_PER_SEQ;
+
+    typename Traits::vec2 vals_h2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        int s0 = seq_chunk * ELEMENTS_PER_THREAD + 2 * i;
+        int s1 = s0 + 1;
+        vals_h2[i] = Traits::make_vec2(smem[s0 * HEAD_DIM + dim_id],
+                                       smem[s1 * HEAD_DIM + dim_id]);
+    }
+
+    // --- Quantise (identical to non-transpose kernel) ---
+    typename Traits::vec2 local_max = Traits::abs2(vals_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(vals_h2[i]));
+    }
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8) = __nv_fp8_e4m3(sf);
+    sf = float(reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8));
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        X_f2[i] = Traits::to_float2(vals_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[2];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+
+    // --- Store in transposed layout ---
+    // fp4 output: [bs, HEAD_DIM, padded_seq / 2]
+    const int seq_offset = seq_block_id * SEQ_PER_BLOCK + seq_chunk * ELEMENTS_PER_THREAD;
+
+    __nv_fp4x2_e2m1* out = X_fp4 + batch_id * HEAD_DIM * (padded_seq / 2)
+                          + dim_id * (padded_seq / 2)
+                          + seq_offset / 2;
+    reinterpret_cast<uint64_t*>(out)[0] = reinterpret_cast<uint64_t*>(fp4_packed)[0];
+
+    // scale output: [bs, HEAD_DIM, padded_seq / 16]
+    X_scale[batch_id * HEAD_DIM * (padded_seq / 16)
+            + dim_id * (padded_seq / 16)
+            + seq_block_id * (SEQ_PER_BLOCK / 16) + seq_chunk] =
+        reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8);
+}
+
+// ---- launch wrapper (transpose) ----
+
+template<typename T, int HEAD_DIM>
+static void nvfp4_quantise_transpose_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * HEAD_DIM / ELEMENTS_PER_THREAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int padded_seq = ta_cdiv(seq_len, SEQ_PER_BLOCK) * SEQ_PER_BLOCK;
+
+    nvfp4_quantise_transpose_kernel<T, HEAD_DIM, SEQ_PER_BLOCK>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, padded_seq);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "nvfp4_quantise_transpose_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_nvfp4_quantise_transpose(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim) {
+
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e4m3*>(X_scale_raw);
+
+    if (head_dim == 64)
+        nvfp4_quantise_transpose_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len);
+    else if (head_dim == 128)
+        nvfp4_quantise_transpose_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len);
+    else
+        fprintf(stderr, "nvfp4_quantise_transpose: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void nvfp4_quantise_transpose(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_nvfp4_quantise_transpose<__nv_bfloat16>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    } else {
+        dispatch_nvfp4_quantise_transpose<half>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim);
+    }
+}
+
+template<typename T, int HEAD_DIM, int SEQ_PER_BLOCK>
+__global__
+void nvfp4_quantise_transpose_permute_seq_kernel(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len, int padded_seq, bool inverse)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int THREADS_PER_HEAD = HEAD_DIM / ELEMENTS_PER_THREAD;
+    constexpr int THREADS_PER_SEQ  = SEQ_PER_BLOCK / ELEMENTS_PER_THREAD;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int num_seq_blocks = ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int batch_id = bid / num_seq_blocks;
+    const int seq_block_id = bid % num_seq_blocks;
+
+    const int load_phys_local = tid / THREADS_PER_HEAD;
+    const int load_head_chunk = tid % THREADS_PER_HEAD;
+    const int load_logical_local = ta_sage_perm_seq(load_phys_local, inverse);
+    const int load_logical_global = seq_block_id * SEQ_PER_BLOCK + load_logical_local;
+    const int load_phys_global = seq_block_id * SEQ_PER_BLOCK + load_phys_local;
+
+    const T* X_ptr = X + batch_id * seq_len * HEAD_DIM
+                    + load_logical_global * HEAD_DIM
+                    + load_head_chunk * ELEMENTS_PER_THREAD;
+
+    uint32_t X_reg[2][4];
+    if (load_logical_global < seq_len && load_phys_global < seq_len) {
+        asm volatile(
+            "ld.global.v4.b32 {%0, %1, %2, %3}, [%8];\n\t"
+            "ld.global.v4.b32 {%4, %5, %6, %7}, [%8+16];\n\t"
+            : "=r"(X_reg[0][0]), "=r"(X_reg[0][1]), "=r"(X_reg[0][2]), "=r"(X_reg[0][3]),
+              "=r"(X_reg[1][0]), "=r"(X_reg[1][1]), "=r"(X_reg[1][2]), "=r"(X_reg[1][3])
+            : "l"(X_ptr)
+        );
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 4; i++) {
+            X_reg[0][i] = 0;
+            X_reg[1][i] = 0;
+        }
+    }
+
+    __shared__ T smem[SEQ_PER_BLOCK * HEAD_DIM];
+    T* smem_row = smem + load_phys_local * HEAD_DIM + load_head_chunk * ELEMENTS_PER_THREAD;
+    *reinterpret_cast<uint4*>(smem_row)     = *reinterpret_cast<uint4*>(X_reg[0]);
+    *reinterpret_cast<uint4*>(smem_row + 8) = *reinterpret_cast<uint4*>(X_reg[1]);
+
+    __syncthreads();
+
+    const int dim_id    = tid / THREADS_PER_SEQ;
+    const int seq_chunk = tid % THREADS_PER_SEQ;
+
+    typename Traits::vec2 vals_h2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        int s0 = seq_chunk * ELEMENTS_PER_THREAD + 2 * i;
+        int s1 = s0 + 1;
+        vals_h2[i] = Traits::make_vec2(smem[s0 * HEAD_DIM + dim_id],
+                                       smem[s1 * HEAD_DIM + dim_id]);
+    }
+
+    typename Traits::vec2 local_max = Traits::abs2(vals_h2[0]);
+    #pragma unroll
+    for (int i = 1; i < 8; i++) {
+        local_max = Traits::max2(local_max, Traits::abs2(vals_h2[i]));
+    }
+    float vec_max = max(Traits::to_float(Traits::low(local_max)),
+                        Traits::to_float(Traits::high(local_max)));
+
+    float sf = vec_max / 6.0f;
+    uint8_t sf_fp8;
+    reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8) = __nv_fp8_e4m3(sf);
+    sf = float(reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8));
+    float sf_inv = (sf == 0.0f) ? 0.0f : 1.0f / sf;
+
+    float2 X_f2[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        X_f2[i] = Traits::to_float2(vals_h2[i]);
+        X_f2[i].x *= sf_inv;
+        X_f2[i].y *= sf_inv;
+    }
+
+    uint32_t fp4_packed[2];
+    fp4_packed[0] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[0].y, X_f2[0].x, X_f2[1].y, X_f2[1].x,
+        X_f2[2].y, X_f2[2].x, X_f2[3].y, X_f2[3].x);
+    fp4_packed[1] = ta_cvt_8xf32_to_e2m1_packed(
+        X_f2[4].y, X_f2[4].x, X_f2[5].y, X_f2[5].x,
+        X_f2[6].y, X_f2[6].x, X_f2[7].y, X_f2[7].x);
+
+    const int seq_offset = seq_block_id * SEQ_PER_BLOCK + seq_chunk * ELEMENTS_PER_THREAD;
+
+    __nv_fp4x2_e2m1* out = X_fp4 + batch_id * HEAD_DIM * (padded_seq / 2)
+                          + dim_id * (padded_seq / 2)
+                          + seq_offset / 2;
+    reinterpret_cast<uint64_t*>(out)[0] = reinterpret_cast<uint64_t*>(fp4_packed)[0];
+
+    X_scale[batch_id * HEAD_DIM * (padded_seq / 16)
+            + dim_id * (padded_seq / 16)
+            + seq_block_id * (SEQ_PER_BLOCK / 16) + seq_chunk] =
+        reinterpret_cast<__nv_fp8_e4m3&>(sf_fp8);
+}
+
+template<typename T, int HEAD_DIM>
+static void nvfp4_quantise_transpose_permute_seq_launch(
+    const T* X, __nv_fp4x2_e2m1* X_fp4, __nv_fp8_e4m3* X_scale,
+    int bs, int seq_len, bool inverse) {
+
+    constexpr int SEQ_PER_BLOCK = 128;
+    constexpr int TB_SIZE = SEQ_PER_BLOCK * HEAD_DIM / ELEMENTS_PER_THREAD;
+
+    const int num_blocks = bs * ta_cdiv(seq_len, SEQ_PER_BLOCK);
+    const int padded_seq = ta_cdiv(seq_len, SEQ_PER_BLOCK) * SEQ_PER_BLOCK;
+
+    nvfp4_quantise_transpose_permute_seq_kernel<T, HEAD_DIM, SEQ_PER_BLOCK>
+        <<<num_blocks, TB_SIZE>>>(X, X_fp4, X_scale, bs, seq_len, padded_seq, inverse);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "nvfp4_quantise_transpose_permute_seq_kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T>
+static void dispatch_nvfp4_quantise_transpose_permute_seq(
+    const void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse) {
+
+    auto X = reinterpret_cast<const T*>(X_raw);
+    auto X_fp4 = reinterpret_cast<__nv_fp4x2_e2m1*>(X_fp4_raw);
+    auto X_scale = reinterpret_cast<__nv_fp8_e4m3*>(X_scale_raw);
+
+    if (head_dim == 64)
+        nvfp4_quantise_transpose_permute_seq_launch<T, 64>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else if (head_dim == 128)
+        nvfp4_quantise_transpose_permute_seq_launch<T, 128>(X, X_fp4, X_scale, bs, seq_len, inverse);
+    else
+        fprintf(stderr, "nvfp4_quantise_transpose_permute_seq: unsupported head_dim=%d (must be 64 or 128)\n", head_dim);
+}
+
+void nvfp4_quantise_transpose_permute_seq(
+    void* X_raw,
+    void* X_fp4_raw,
+    void* X_scale_raw,
+    int bs,
+    int seq_len,
+    int head_dim,
+    bool inverse,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_nvfp4_quantise_transpose_permute_seq<__nv_bfloat16>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    } else {
+        dispatch_nvfp4_quantise_transpose_permute_seq<half>(
+            X_raw, X_fp4_raw, X_scale_raw, bs, seq_len, head_dim, inverse);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/nvfp4/single_query_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/nvfp4/single_query_attention.cu
@@ -1,0 +1,1800 @@
+// SM120 mixed-precision single-query attention.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+__device__ inline
+void ldmatrix_x4_sqmix(uint32_t reg[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+         : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_sqmix(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_trans_sqmix(uint32_t reg[2], uint32_t addr) {
+    asm volatile(
+        "ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
+        : "=r"(reg[0]), "=r"(reg[1])
+        : "r"(addr));
+}
+
+__device__ __forceinline__
+void mma_m16n8k16_f16_sqmix(
+    const uint32_t (&A)[4],
+    const uint32_t (&B)[2],
+    float (&D)[4]) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
+}
+
+// keep your existing mma_m16n8k64_nvfp4_sqmix(...) and conversion helpers
+
+template <int STRIDE>
+__device__
+uint32_t swizzle_sqmix(uint32_t index) {
+    if constexpr (STRIDE == 16)
+        return index;
+    uint32_t row_idx = (index / STRIDE) % 8;
+    uint32_t bits_to_xor = row_idx / max(64 / STRIDE, 1);
+    return index ^ (bits_to_xor << 4);
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_sqmix(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int num_iters = (HEIGHT * WIDTH) / (num_elements * TB_SIZE);
+
+    for (int iter = 0; iter < num_iters; iter++) {
+        const int index = (iter * TB_SIZE + tid) * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+
+        uint32_t dst_addr = swizzle_sqmix<WIDTH * (int)sizeof(T)>(
+            dst + (row * WIDTH + col) * sizeof(T));
+        const T *src_addr = src + (row * src_stride + col);
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void load_scales_sqmix(uint32_t dst, const T *src, int src_stride, int tid) {
+    constexpr int cp_size = WIDTH * sizeof(T);
+    static_assert(cp_size < 16);
+
+    auto load_row = [&](int row) {
+        const uint32_t dst_addr = dst + row * WIDTH * sizeof(T);
+        const T *src_addr = src + row * src_stride;
+        asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+            :: "r"(dst_addr), "l"(src_addr), "n"(cp_size));
+    };
+
+    for (int iter = 0; iter < HEIGHT / TB_SIZE; iter++)
+        load_row(iter * TB_SIZE + tid);
+
+    if constexpr (HEIGHT % TB_SIZE != 0) {
+        const int row = HEIGHT / TB_SIZE * TB_SIZE + tid;
+        if (row < HEIGHT)
+            load_row(row);
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_linear_sqmix(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int total_vectors = (HEIGHT * WIDTH) / num_elements;
+
+    for (int vec = tid; vec < total_vectors; vec += TB_SIZE) {
+        const int index = vec * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+        const uint32_t dst_addr = dst + (row * WIDTH + col) * (int)sizeof(T);
+        const T *src_addr = src + row * src_stride + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+constexpr int WARP_SIZE_sqmix = 32;
+
+static int single_query_target_split_ctas_sqmix(int total_kv_blocks) {
+    if (const char* env = std::getenv("SAGE_MIXED_SPLIT_CTAS")) {
+        const int v = std::atoi(env);
+        if (v > 0) return v;
+    }
+    return (total_kv_blocks <= 512) ? 384
+         : (total_kv_blocks <= 1024) ? 384
+         : 896;
+}
+
+__host__ __device__ inline
+int cdiv_sqmix(int a, int b) { return (a + b - 1) / b; }
+
+__device__ __forceinline__
+bool block_in_topk_sqmix(const int32_t* topk_row, int topk_count, int block_id)
+{
+    bool hit = false;
+    for (int i = 0; i < topk_count; i++)
+        hit |= (topk_row[i] == block_id);
+    return hit;
+}
+
+__device__ __forceinline__
+bool range_has_topk_sqmix(const int32_t* topk_row, int topk_count, int block_begin, int block_end)
+{
+    bool hit = false;
+    for (int i = 0; i < topk_count; i++) {
+        const int b = topk_row[i];
+        hit |= (b >= block_begin) && (b < block_end);
+    }
+    return hit;
+}
+
+__device__ inline
+uint32_t cvt_8xf32_to_e2m1_packed_sqmix(float f0, float f1, float f2, float f3,
+                                     float f4, float f5, float f6, float f7) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 a0, a1, a2, a3;\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a0, %1, %2;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a1, %3, %4;\n\t"
+        "mov.b16 lo, {a0, a1};\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a2, %5, %6;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a3, %7, %8;\n\t"
+        "mov.b16 hi, {a2, a3};\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3),
+          "f"(f4), "f"(f5), "f"(f6), "f"(f7)
+    );
+    return packed;
+}
+
+__device__ inline
+uint32_t cvt_4xf32_to_e4m3_packed_sqmix(float f0, float f1, float f2, float f3) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, %1, %2;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, %3, %4;\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3)
+    );
+    return packed;
+}
+
+__device__ inline
+void mma_m16n8k64_nvfp4_sqmix(uint32_t A[4], uint32_t B[2], uint32_t sf_A, uint32_t sf_B, float D[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4"
+        ".block_scale.scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]),
+          "r"(sf_A), "h"(byte_id), "h"(thread_id),
+          "r"(sf_B), "h"(byte_id), "h"(thread_id));
+}
+
+
+template<typename T, int HEAD_DIM, int BLOCK_Q = 16>
+__device__ __forceinline__
+void load_q_fp16_to_regs_single_query_sqmix(
+    uint32_t (&Q_rmem)[HEAD_DIM / 16][4],
+    uint32_t Q_smem,
+    const T* Q_ptr,
+    int lane_id,
+    int q_len)
+{
+    constexpr int MMA_K = 16;
+    constexpr int ROW_BYTES = HEAD_DIM * (int)sizeof(T);
+    constexpr int TOTAL_BYTES = BLOCK_Q * ROW_BYTES;
+    constexpr int LOAD_UNIT = 16;  // cp.async.cg copies 16 bytes
+    constexpr int TOTAL_CHUNKS = TOTAL_BYTES / LOAD_UNIT;
+
+    static_assert(HEAD_DIM % MMA_K == 0);
+    static_assert(ROW_BYTES % LOAD_UNIT == 0);
+
+    // Zero the entire BLOCK_Q × HEAD_DIM staging area, then load valid rows.
+    // 32 lanes cooperate; each lane handles multiple 16-byte chunks.
+    for (int chunk = lane_id; chunk < TOTAL_CHUNKS; chunk += WARP_SIZE_sqmix) {
+        const int byte_off = chunk * LOAD_UNIT;
+        const int row = byte_off / ROW_BYTES;
+        const int col = byte_off % ROW_BYTES;
+        uint32_t dst = swizzle_sqmix<ROW_BYTES>(Q_smem + row * ROW_BYTES + col);
+
+        if (row < q_len) {
+            const char* src = reinterpret_cast<const char*>(Q_ptr + row * HEAD_DIM) + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst), "l"(src));
+        } else {
+            // Zero-fill rows beyond q_len so the MMA sees zeros
+            asm volatile("st.shared.v4.b32 [%0], {%1, %2, %3, %4};"
+                :: "r"(dst), "r"(0), "r"(0), "r"(0), "r"(0));
+        }
+    }
+
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    // ldmatrix layout for A operand of mma.m16n8k16.row.col
+    const uint32_t Q_ld_base = swizzle_sqmix<ROW_BYTES>(
+        Q_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+    #pragma unroll
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * MMA_K * (int)sizeof(T);
+        ldmatrix_x4_sqmix(Q_rmem[mma_id_d], addr);
+    }
+}
+
+
+template<typename T, int BLOCK_KV, int BLOCK_KV_STEP, int HEAD_DIM,
+         bool USE_LOWER_ROWS = true, int O_REGS = 4>
+__device__ __forceinline__
+void attention_inner_loop_fp16(
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][O_REGS],
+    uint32_t Q_rmem[HEAD_DIM / 16][4],
+    uint32_t K_smem,
+    uint32_t V_smem,
+    const T*& K_ptr,
+    const T*& V_ptr,
+    const int lane_id,
+    const float softmax_scale)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int MMA_K = 16;
+    constexpr int MMA_N = 8;
+    constexpr float FP4_RANGE = 448.0f * 6.0f;  // keep final normalization compatible
+
+    static_assert(BLOCK_KV % BLOCK_KV_STEP == 0);
+    static_assert(BLOCK_KV_STEP % MMA_K == 0);
+    static_assert(HEAD_DIM % MMA_K == 0);
+    static_assert(HEAD_DIM % MMA_N == 0);
+
+    const uint32_t K_ld_base = swizzle_sqmix<HEAD_DIM * (int)sizeof(T)>(
+        K_smem + ((lane_id % 8) * HEAD_DIM + (lane_id / 8) * 8) * (int)sizeof(T));
+
+    const uint32_t V_ld_base = swizzle_sqmix<HEAD_DIM * (int)sizeof(T)>(
+        V_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+    for (int kv_sub = 0; kv_sub < BLOCK_KV; kv_sub += BLOCK_KV_STEP) {
+        gmem_to_smem_sqmix<BLOCK_KV_STEP, HEAD_DIM, WARP_SIZE_sqmix, T>(
+            K_smem, K_ptr, lane_id, HEAD_DIM);
+        gmem_to_smem_sqmix<BLOCK_KV_STEP, HEAD_DIM, WARP_SIZE_sqmix, T>(
+            V_smem, V_ptr, lane_id, HEAD_DIM);
+
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        uint32_t K_rmem[BLOCK_KV_STEP / MMA_N][HEAD_DIM / MMA_K][2];
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                uint32_t addr = K_ld_base;
+                addr += mma_id_kv * MMA_N * HEAD_DIM * (int)sizeof(T);
+                addr ^= mma_id_d * MMA_K * (int)sizeof(T);
+                ldmatrix_x2_sqmix(K_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        float S_rmem[BLOCK_KV_STEP / MMA_N][4] = {};
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                Traits::mma(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+            }
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            for (int reg_id = 0; reg_id < 4; reg_id++) {
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+            }
+        }
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_N; mma_id_kv++) {
+            float* r = S_rmem[mma_id_kv];
+            this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+            if constexpr (USE_LOWER_ROWS)
+                this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+        if constexpr (USE_LOWER_ROWS) {
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+            this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        if constexpr (USE_LOWER_ROWS)
+            this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale0 = __expf(rowmax[0] - this_rowmax[0]);
+        float rescale1 = 1.0f;
+        if constexpr (USE_LOWER_ROWS)
+            rescale1 = __expf(rowmax[1] - this_rowmax[1]);
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale0;
+            O_rmem[mma_id_d][1] *= rescale0;
+            if constexpr (USE_LOWER_ROWS && O_REGS == 4) {
+                O_rmem[mma_id_d][2] *= rescale1;
+                O_rmem[mma_id_d][3] *= rescale1;
+            }
+        }
+
+        rowmax[0] = this_rowmax[0];
+        if constexpr (USE_LOWER_ROWS)
+            rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        uint32_t P_rmem[BLOCK_KV_STEP / MMA_K][4];
+
+        for (int mma_blk = 0; mma_blk < BLOCK_KV_STEP / MMA_K; mma_blk++) {
+            const int t0 = 2 * mma_blk + 0;
+            const int t1 = 2 * mma_blk + 1;
+
+            float* r0 = S_rmem[t0];
+            float* r1 = S_rmem[t1];
+
+            r0[0] = __expf(r0[0] - rowmax[0]);
+            r0[1] = __expf(r0[1] - rowmax[0]);
+
+            r1[0] = __expf(r1[0] - rowmax[0]);
+            r1[1] = __expf(r1[1] - rowmax[0]);
+
+            this_rowsumexp[0] += r0[0] + r0[1] + r1[0] + r1[1];
+            if constexpr (USE_LOWER_ROWS) {
+                r0[2] = __expf(r0[2] - rowmax[1]);
+                r0[3] = __expf(r0[3] - rowmax[1]);
+                r1[2] = __expf(r1[2] - rowmax[1]);
+                r1[3] = __expf(r1[3] - rowmax[1]);
+                this_rowsumexp[1] += r0[2] + r0[3] + r1[2] + r1[3];
+            } else {
+                r0[2] = 0.0f; r0[3] = 0.0f;
+                r1[2] = 0.0f; r1[3] = 0.0f;
+            }
+
+            typename Traits::vec2* p = reinterpret_cast<typename Traits::vec2*>(P_rmem[mma_blk]);
+            p[0] = Traits::pack2(r0[0] * FP4_RANGE, r0[1] * FP4_RANGE);
+            p[1] = Traits::pack2(r0[2] * FP4_RANGE, r0[3] * FP4_RANGE);
+            p[2] = Traits::pack2(r1[0] * FP4_RANGE, r1[1] * FP4_RANGE);
+            p[3] = Traits::pack2(r1[2] * FP4_RANGE, r1[3] * FP4_RANGE);
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+
+        rowsum[0] = rowsum[0] * rescale0 + this_rowsumexp[0];
+        if constexpr (USE_LOWER_ROWS) {
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+            this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+            rowsum[1] = rowsum[1] * rescale1 + this_rowsumexp[1];
+        }
+
+        uint32_t V_rmem[BLOCK_KV_STEP / MMA_K][HEAD_DIM / MMA_N][2];
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                uint32_t addr = V_ld_base;
+                addr += mma_id_kv * MMA_K * HEAD_DIM * (int)sizeof(T);
+                addr ^= mma_id_d * MMA_N * (int)sizeof(T);
+                ldmatrix_x2_trans_sqmix(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_STEP / MMA_K; mma_id_kv++) {
+                if constexpr (O_REGS == 4) {
+                    Traits::mma(
+                        P_rmem[mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        O_rmem[mma_id_d]);
+                } else {
+                    float d[4] = {O_rmem[mma_id_d][0], O_rmem[mma_id_d][1], 0.0f, 0.0f};
+                    Traits::mma(
+                        P_rmem[mma_id_kv],
+                        V_rmem[mma_id_kv][mma_id_d],
+                        d);
+                    O_rmem[mma_id_d][0] = d[0];
+                    O_rmem[mma_id_d][1] = d[1];
+                }
+            }
+        }
+
+        K_ptr += BLOCK_KV_STEP * HEAD_DIM;
+        V_ptr += BLOCK_KV_STEP * HEAD_DIM;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Separated load / compute helpers for FP4 attention.
+// Used by the split kernel for double-buffering; the combined
+// attention_inner_loop_fp4 below calls them sequentially.
+// ---------------------------------------------------------------------------
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__device__ __forceinline__
+void load_kv_fp4_async_sqmix(
+    uint32_t K_smem, uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    const __nv_fp4x2_e2m1* K_ptr,
+    const __nv_fp4x2_e2m1* V_ptr,
+    const __nv_fp8_e4m3* SK_ptr,
+    const __nv_fp8_e4m3* SV_ptr,
+    int lane_id, int v_kv)
+{
+    gmem_to_smem_sqmix<BLOCK_KV, HEAD_DIM_2, WARP_SIZE_sqmix, __nv_fp4x2_e2m1>(K_smem,    K_ptr,  lane_id, HEAD_DIM_2);
+    load_scales_sqmix <BLOCK_KV, SCALE_DIM,  WARP_SIZE_sqmix, __nv_fp8_e4m3>  (K_sf_smem, SK_ptr, SCALE_DIM, lane_id);
+    gmem_to_smem_sqmix<HEAD_DIM, BLOCK_KV/2, WARP_SIZE_sqmix, __nv_fp4x2_e2m1>(V_smem,    V_ptr,  lane_id, v_kv / 2);
+    load_scales_sqmix <HEAD_DIM, BLOCK_KV/16,WARP_SIZE_sqmix, __nv_fp8_e4m3>  (V_sf_smem, SV_ptr, v_kv / 16, lane_id);
+    asm volatile("cp.async.commit_group;");
+}
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM,
+         bool USE_LOWER_ROWS = true, int O_REGS = 4>
+__device__ __forceinline__
+void compute_kv_fp4_sqmix(
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][O_REGS],
+    uint32_t Q_rmem[HEAD_DIM / 64][4],
+    uint32_t sfQ_rmem[HEAD_DIM / 64],
+    uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    uint32_t K_ld_base,
+    const int lane_id,
+    const float softmax_scale)
+{
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    // ---- K → registers ----
+    uint32_t K_rmem [BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+
+    if constexpr (HEAD_DIM / MMA_K >= 2) {
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+            ldmatrix_x4_sqmix(K_rmem[mma_id_kv][0], addr);
+        }
+    } else {
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                uint32_t addr = K_ld_base;
+                addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                addr ^= mma_id_d * (MMA_K / 2);
+                ldmatrix_x2_sqmix(K_rmem[mma_id_kv][mma_id_d], addr);
+            }
+    }
+
+    // ---- K scales → registers ----
+    const int sf_row_k = lane_id / 4;
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+            const int row = mma_id_kv * MMA_N + sf_row_k;
+            const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+            asm volatile("ld.shared.u32 %0, [%1];"
+                : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                : "r"(K_sf_smem + offset));
+        }
+
+    // ---- QK^T MMA → S_rmem (float) ----
+    float S_rmem[BLOCK_KV / MMA_N][4] = {};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+            mma_m16n8k64_nvfp4_sqmix(
+                Q_rmem[mma_id_d],
+                K_rmem[mma_id_kv][mma_id_d],
+                sfQ_rmem[mma_id_d],
+                sfK_rmem[mma_id_kv][mma_id_d],
+                S_rmem[mma_id_kv]);
+
+    // ---- Online softmax ----
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+        for (int reg_id = 0; reg_id < 4; reg_id++)
+            S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+    float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        float *r = S_rmem[mma_id_kv];
+        this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+        if constexpr (USE_LOWER_ROWS)
+            this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+    }
+    this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+    this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+    if constexpr (USE_LOWER_ROWS) {
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+    }
+
+    this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+    if constexpr (USE_LOWER_ROWS)
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+    float rescale0 = __expf(rowmax[0] - this_rowmax[0]);
+    float rescale1 = 1.0f;
+    if constexpr (USE_LOWER_ROWS)
+        rescale1 = __expf(rowmax[1] - this_rowmax[1]);
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        O_rmem[mma_id_d][0] *= rescale0;  O_rmem[mma_id_d][1] *= rescale0;
+        if constexpr (USE_LOWER_ROWS && O_REGS == 4) {
+            O_rmem[mma_id_d][2] *= rescale1;  O_rmem[mma_id_d][3] *= rescale1;
+        }
+    }
+    rowmax[0] = this_rowmax[0];
+    if constexpr (USE_LOWER_ROWS)
+        rowmax[1] = this_rowmax[1];
+
+    float this_rowsumexp[2] = {};
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        float *r = S_rmem[mma_id_kv];
+        r[0] = __expf(r[0] - rowmax[0]);  r[1] = __expf(r[1] - rowmax[0]);
+        this_rowsumexp[0] += r[0] + r[1];
+        if constexpr (USE_LOWER_ROWS) {
+            r[2] = __expf(r[2] - rowmax[1]);  r[3] = __expf(r[3] - rowmax[1]);
+            this_rowsumexp[1] += r[2] + r[3];
+        } else {
+            r[2] = 0.0f;  r[3] = 0.0f;
+        }
+    }
+    this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+    this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+    rowsum[0] = rowsum[0] * rescale0 + this_rowsumexp[0];
+    if constexpr (USE_LOWER_ROWS) {
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+        rowsum[1] = rowsum[1] * rescale1 + this_rowsumexp[1];
+    }
+
+    // ---- Quantise S → FP4 for P@V ----
+    constexpr float FP4_RANGE = 448.0f * 6.0f;
+    constexpr float FP4_MAX   = 6.0f;
+
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+        S_rmem[mma_id_kv][0] *= FP4_RANGE;
+        S_rmem[mma_id_kv][1] *= FP4_RANGE;
+        if constexpr (USE_LOWER_ROWS) {
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        } else {
+            S_rmem[mma_id_kv][2] = 0.0f;
+            S_rmem[mma_id_kv][3] = 0.0f;
+        }
+    }
+
+    float sf_P_upper[BLOCK_KV / MMA_N / 2];
+    float sf_P_lower[BLOCK_KV / MMA_N / 2];
+    for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+        int t0 = 2 * blk, t1 = t0 + 1;
+        float amax_upper = max(max(S_rmem[t0][0], S_rmem[t0][1]),
+                               max(S_rmem[t1][0], S_rmem[t1][1]));
+        amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+        amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+        sf_P_upper[blk] = amax_upper / FP4_MAX;
+        if constexpr (USE_LOWER_ROWS) {
+            float amax_lower = max(max(S_rmem[t0][2], S_rmem[t0][3]),
+                                   max(S_rmem[t1][2], S_rmem[t1][3]));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+        } else {
+            sf_P_lower[blk] = 1.0f;
+        }
+    }
+
+    for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+        float inv_upper = 1.0f / sf_P_upper[blk];
+        int t0 = 2 * blk, t1 = t0 + 1;
+        S_rmem[t0][0] *= inv_upper;  S_rmem[t0][1] *= inv_upper;
+        S_rmem[t1][0] *= inv_upper;  S_rmem[t1][1] *= inv_upper;
+        if constexpr (USE_LOWER_ROWS) {
+            float inv_lower = 1.0f / sf_P_lower[blk];
+            S_rmem[t0][2] *= inv_lower;  S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;  S_rmem[t1][3] *= inv_lower;
+        }
+    }
+
+    // Shuffle S into MMA-compatible layout
+    uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+    const int qid = lane_id & 3;
+    for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+        for (int r = 0; r < 4; r++) {
+            float send, recv;
+            send = (qid & 1) ? S_rmem[g*4+0][r] : S_rmem[g*4+1][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+            if (qid & 1) S_rmem[g*4+0][r] = recv; else S_rmem[g*4+1][r] = recv;
+
+            send = (qid & 1) ? S_rmem[g*4+2][r] : S_rmem[g*4+3][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+            if (qid & 1) S_rmem[g*4+2][r] = recv; else S_rmem[g*4+3][r] = recv;
+
+            send = (qid & 2) ? S_rmem[g*4+0][r] : S_rmem[g*4+2][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+            if (qid & 2) S_rmem[g*4+0][r] = recv; else S_rmem[g*4+2][r] = recv;
+
+            send = (qid & 2) ? S_rmem[g*4+1][r] : S_rmem[g*4+3][r];
+            recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+            if (qid & 2) S_rmem[g*4+1][r] = recv; else S_rmem[g*4+3][r] = recv;
+        }
+
+        float *r0 = S_rmem[g*4], *r1 = S_rmem[g*4+1],
+              *r2 = S_rmem[g*4+2], *r3 = S_rmem[g*4+3];
+        S_fp4_rmem[0][2*g]   = cvt_8xf32_to_e2m1_packed_sqmix(r0[1],r0[0],r1[1],r1[0], r2[1],r2[0],r3[1],r3[0]);
+        S_fp4_rmem[0][2*g+1] = cvt_8xf32_to_e2m1_packed_sqmix(r0[3],r0[2],r1[3],r1[2], r2[3],r2[2],r3[3],r3[2]);
+    }
+
+    uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+    for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+        int base = mma_sc_id * 4;
+        uint32_t sfP_upper_packed = cvt_4xf32_to_e4m3_packed_sqmix(
+            sf_P_upper[base+1], sf_P_upper[base+0], sf_P_upper[base+3], sf_P_upper[base+2]);
+        uint32_t sfP_lower_packed = cvt_4xf32_to_e4m3_packed_sqmix(
+            sf_P_lower[base+1], sf_P_lower[base+0], sf_P_lower[base+3], sf_P_lower[base+2]);
+        S_fp4_s_rmem[mma_sc_id] = (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+    }
+
+    // ---- V → registers ----
+    uint32_t V_rmem [BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+            const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+            const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+            uint32_t addr = swizzle_sqmix<BLOCK_KV / 2>(
+                V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+            ldmatrix_x4_sqmix(V_rmem[mma_id_kv][mma_id_d], addr);
+        }
+
+    constexpr int V_SF_STRIDE = BLOCK_KV / 16;
+    const int sf_col_v = lane_id / 4;
+    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int hd_col = mma_id_d * MMA_N + sf_col_v;
+            const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+            asm volatile("ld.shared.u32 %0, [%1];"
+                : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                : "r"(V_sf_smem + offset));
+        }
+
+    // ---- O += P @ V ----
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            if constexpr (O_REGS == 4) {
+                mma_m16n8k64_nvfp4_sqmix(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+            } else {
+                float d[4] = {O_rmem[mma_id_d][0], O_rmem[mma_id_d][1], 0.0f, 0.0f};
+                mma_m16n8k64_nvfp4_sqmix(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    d);
+                O_rmem[mma_id_d][0] = d[0];
+                O_rmem[mma_id_d][1] = d[1];
+            }
+        }
+}
+
+template<int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__device__ __forceinline__
+void attention_inner_loop_fp4(
+    // Persistent accumulator state (read-modify-write across iterations)
+    float rowmax[2],
+    float rowsum[2],
+    float O_rmem[HEAD_DIM / 8][4],  // HEAD_DIM / MMA_N, MMA_N=8
+
+    // Q register tiles (loaded once before the loop)
+    uint32_t Q_rmem[HEAD_DIM / 64][4],   // HEAD_DIM / MMA_K
+    uint32_t sfQ_rmem[HEAD_DIM / 64],
+
+    // KV smem base addresses (warp-private regions)
+    uint32_t K_smem, uint32_t K_sf_smem,
+    uint32_t V_smem, uint32_t V_sf_smem,
+    uint32_t K_ld_base,
+
+    // KV global-memory pointers (advanced at end of each iteration)
+    const __nv_fp4x2_e2m1*& K_ptr,
+    const __nv_fp4x2_e2m1*& V_ptr,
+    const __nv_fp8_e4m3*&   SK_ptr,
+    const __nv_fp8_e4m3*&   SV_ptr,
+
+    // Per-call constants
+    const int lane_id,
+    const float softmax_scale,
+    const int v_kv)
+{
+    load_kv_fp4_async_sqmix<BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+        K_smem, K_sf_smem, V_smem, V_sf_smem,
+        K_ptr, V_ptr, SK_ptr, SV_ptr, lane_id, v_kv);
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    compute_kv_fp4_sqmix<BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+        K_sf_smem, V_smem, V_sf_smem, K_ld_base,
+        lane_id, softmax_scale);
+
+    K_ptr  += BLOCK_KV * HEAD_DIM_2;
+    SK_ptr += BLOCK_KV * SCALE_DIM;
+    V_ptr  += BLOCK_KV / 2;
+    SV_ptr += BLOCK_KV / 16;
+}
+
+template<
+    typename T,
+    int BLOCK_KV_FP16,
+    int BLOCK_KV_FP4,
+    int HEAD_DIM,
+    int HEAD_DIM_2,
+    int SCALE_DIM,
+    int NUM_WARPS,
+    int KV_SMEM_PER_WARP>
+__launch_bounds__(NUM_WARPS * WARP_SIZE_sqmix, 1)
+__global__
+void thrift_attention_single_query_cta_kernel(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmix;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    // Stride uses capacity (allocation), loop bounds use kv_len (logical).
+    const int v_kv = cdiv_sqmix(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / WARP_SIZE_sqmix;
+    const int lane_id = tid % WARP_SIZE_sqmix;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    Q_fp16 += bid * q_len       * HEAD_DIM;
+    K_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+    V_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+
+    const int32_t* topk_row = top_k + bid * topk_count;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: cooperatively load Q_fp4 + scales into smem ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem so unused rows (q_len..15) are zero
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncthreads();
+
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmix<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto* src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto* src_addr = S_Q + row * SCALE_DIM;
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+        }
+    }
+
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmix<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+        ldmatrix_x4_sqmix(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        const uint32_t offset =
+            (sf_row_q * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+        asm volatile("ld.shared.u32 %0, [%1];"
+            : "=r"(sfQ_rmem[mma_id_d])
+            : "r"(Q_sf_smem + offset));
+    }
+
+    __syncthreads();
+
+    // ---- Phase 2: warp-private KV processing ----
+    const uint32_t warp_kv_base = __cvta_generic_to_shared(smem) + warp_id * KV_SMEM_PER_WARP;
+
+    // FP4 layout in warp-private smem
+    const uint32_t K_smem_fp4    = warp_kv_base;
+    const uint32_t K_sf_smem     = K_smem_fp4 + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem_fp4    = K_sf_smem + BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+    const uint32_t V_sf_smem     = V_smem_fp4 + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    // FP16 layout in warp-private smem
+    const uint32_t K_smem_fp16   = warp_kv_base;
+    const uint32_t V_smem_fp16   = K_smem_fp16 + BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T);
+
+    const int total_kv_blocks = cdiv_sqmix(kv_len, BLOCK_KV_FP4);
+    const int blocks_per_warp = cdiv_sqmix(total_kv_blocks, NUM_WARPS);
+    const int kv_block_start = warp_id * blocks_per_warp;
+    const int kv_block_end   = (kv_block_start + blocks_per_warp < total_kv_blocks)
+                             ? (kv_block_start + blocks_per_warp)
+                             : total_kv_blocks;
+    const int num_kv_iters   = (kv_block_start < total_kv_blocks)
+                             ? (kv_block_end - kv_block_start)
+                             : 0;
+
+    const bool warp_has_fp16 = range_has_topk_sqmix(topk_row, topk_count, kv_block_start, kv_block_end);
+
+    uint32_t K_ld_base_fp4;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base_fp4 = swizzle_sqmix<HEAD_DIM_2>(K_smem_fp4 + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // Phase 2a: process all FP4 blocks first (no FP16 registers live)
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        const int global_block_id = kv_block_start + kv_iter;
+        if (warp_has_fp16 && block_in_topk_sqmix(topk_row, topk_count, global_block_id))
+            continue;
+
+        const __nv_fp4x2_e2m1* K_ptr_iter = K + global_block_id * BLOCK_KV_FP4 * HEAD_DIM_2;
+        const __nv_fp4x2_e2m1* V_ptr_iter = V + global_block_id * BLOCK_KV_FP4 / 2;
+        const __nv_fp8_e4m3*   SK_ptr_iter = S_K + global_block_id * BLOCK_KV_FP4 * SCALE_DIM;
+        const __nv_fp8_e4m3*   SV_ptr_iter = S_V + global_block_id * BLOCK_KV_FP4 / 16;
+
+        attention_inner_loop_fp4<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+            rowmax, rowsum, O_rmem,
+            Q_rmem, sfQ_rmem,
+            K_smem_fp4, K_sf_smem,
+            V_smem_fp4, V_sf_smem,
+            K_ld_base_fp4,
+            K_ptr_iter, V_ptr_iter,
+            SK_ptr_iter, SV_ptr_iter,
+            lane_id, softmax_scale, v_kv);
+    }
+
+    // Phase 2b: process FP16 (top-k) blocks — Q FP16 loaded once
+    if (warp_has_fp16) {
+        uint32_t Q_fp16_rmem[HEAD_DIM / 16][4];
+        load_q_fp16_to_regs_single_query_sqmix<T, HEAD_DIM, BLOCK_Q>(
+            Q_fp16_rmem, K_smem_fp16, Q_fp16, lane_id, q_len);
+
+        for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+            const int global_block_id = kv_block_start + kv_iter;
+            if (!block_in_topk_sqmix(topk_row, topk_count, global_block_id))
+                continue;
+
+            const T* K_fp16_ptr_iter = K_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+            const T* V_fp16_ptr_iter = V_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+
+            attention_inner_loop_fp16<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM>(
+                rowmax, rowsum, O_rmem,
+                Q_fp16_rmem,
+                K_smem_fp16, V_smem_fp16,
+                K_fp16_ptr_iter, V_fp16_ptr_iter,
+                lane_id, softmax_scale);
+        }
+    }
+
+    // ---- Phase 3: CTA reduction ----
+    __syncthreads();
+
+    float* reduce_base = reinterpret_cast<float*>(smem);
+    float* rowmax_smem = reduce_base;
+    float* rowsum_smem = rowmax_smem + NUM_WARPS * BLOCK_Q;
+    float* O_part_smem = rowsum_smem + NUM_WARPS * BLOCK_Q;
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        rowmax_smem[warp_id * BLOCK_Q + row]     = rowmax[0];
+        rowmax_smem[warp_id * BLOCK_Q + row + 8] = rowmax[1];
+        rowsum_smem[warp_id * BLOCK_Q + row]     = rowsum[0];
+        rowsum_smem[warp_id * BLOCK_Q + row + 8] = rowsum[1];
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float* regs = O_rmem[mma_id_d];
+
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col]           = regs[0];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col + 1]       = regs[1];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col]     = regs[2];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col + 1] = regs[3];
+    }
+
+    __syncthreads();
+
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+
+    if (tid < BLOCK_Q) {
+        const int row = tid;
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = max(global_max, rowmax_smem[w * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        float rsc[NUM_WARPS];
+        for (int w = 0; w < NUM_WARPS; w++) {
+            rsc[w] = __expf(rowmax_smem[w * BLOCK_Q + row] - global_max);
+            sum_acc += rowsum_smem[w * BLOCK_Q + row] * rsc[w];
+        }
+
+        float norm = FP4_RANGE_INV / sum_acc;
+        for (int w = 0; w < NUM_WARPS; w++)
+            rowmax_smem[w * BLOCK_Q + row] = rsc[w];
+        rowsum_smem[row] = norm;
+    }
+
+    __syncthreads();
+
+    constexpr int TOTAL_PAIRS = BLOCK_Q * (HEAD_DIM / 2);
+
+    for (int pair = tid; pair < TOTAL_PAIRS; pair += TB_SIZE) {
+        const int elem = pair * 2;
+        const int row = elem / HEAD_DIM;
+        const int col = elem % HEAD_DIM;
+
+        float norm = rowsum_smem[row];
+        float acc0 = 0.0f, acc1 = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++) {
+            float rsc = rowmax_smem[w * BLOCK_Q + row];
+            const float* src = &O_part_smem[w * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col];
+            acc0 += src[0] * rsc;
+            acc1 += src[1] * rsc;
+        }
+
+        if (row < q_len) {
+            typename Traits::vec2 result = Traits::pack2(acc0 * norm, acc1 * norm);
+            *reinterpret_cast<typename Traits::vec2*>(&O[row * HEAD_DIM + col]) = result;
+        }
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void thrift_attention_single_query_cta_launch(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_KV_FP4 = 64;
+    constexpr int BLOCK_KV_FP16 = 32;
+    constexpr int BLOCK_Q = 16;
+    constexpr int NUM_WARPS = 4;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqmix;
+
+    constexpr int q_phase_smem_fp4 =
+        BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+
+    constexpr int q_phase_smem_fp16 =
+        BLOCK_Q * HEAD_DIM * (int)sizeof(T);
+
+    constexpr int q_phase_smem =
+        (q_phase_smem_fp16 > q_phase_smem_fp4) ? q_phase_smem_fp16 : q_phase_smem_fp4;
+
+    constexpr int kv_smem_per_warp_fp4 =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    constexpr int kv_smem_per_warp_fp16 =
+        BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T) * 2;
+
+    constexpr int kv_smem_per_warp =
+        (kv_smem_per_warp_fp4 > kv_smem_per_warp_fp16) ? kv_smem_per_warp_fp4 : kv_smem_per_warp_fp16;
+
+    constexpr int kv_phase_smem = NUM_WARPS * kv_smem_per_warp;
+
+    constexpr int reduce_smem =
+        (int)sizeof(float) * (NUM_WARPS * BLOCK_Q * 2 + NUM_WARPS * BLOCK_Q * HEAD_DIM);
+
+    constexpr int smem_12 = (q_phase_smem > kv_phase_smem) ? q_phase_smem : kv_phase_smem;
+    constexpr int smem_size = (smem_12 > reduce_smem) ? smem_12 : reduce_smem;
+
+    auto kernel =
+        thrift_attention_single_query_cta_kernel<
+            T,
+            BLOCK_KV_FP16,
+            BLOCK_KV_FP4,
+            HEAD_DIM,
+            HEAD_DIM_2,
+            SCALE_DIM,
+            NUM_WARPS,
+            kv_smem_per_warp>;
+
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q_fp16,
+        K_fp16,
+        V_fp16,
+        top_k,
+        topk_count,
+        Q_fp4,
+        K_fp4,
+        V_fp4,
+        S_Q,
+        S_K,
+        S_V,
+        O,
+        bs,
+        q_len,
+        kv_len,
+        kv_capacity,
+        num_q_heads,
+        num_kv_heads);
+
+}
+
+// ---------------------------------------------------------------------------
+// Split-KV mixed-precision single-query kernel.
+// Grid: (num_kv_splits, bs).  Each block is a single warp that processes a
+// contiguous range of KV blocks (FP16 for top-k, FP4 for the rest), writes
+// partial (O, rowmax, rowsum) to a global workspace, then the last block to
+// finish reduces all partials and writes the final FP16 output.
+//
+// Optimisations over the naive version:
+//   1. Bitmask for O(1) top-k lookup instead of O(topk_count) linear scan
+//   2. Double-buffered FP4 KV loads (overlaps gmem latency with MMA compute)
+//   3. float2 vectorised partial-O stores
+//   4. Two-pass smem-assisted reduction (precompute per-row rescale once)
+// ---------------------------------------------------------------------------
+template<
+    typename T,
+    int BLOCK_KV_FP16,
+    int BLOCK_KV_FP4,
+    int HEAD_DIM,
+    int HEAD_DIM_2,
+    int SCALE_DIM,
+    bool UPPER_ONLY = false>
+__launch_bounds__(WARP_SIZE_sqmix)
+__global__
+void thrift_attention_single_query_split_kernel(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    float* O_partial,
+    float* rowmax_partial,
+    float* rowsum_partial,
+    T* O_final,
+    int* split_counter,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_kv_splits,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqmix;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    // Size of one FP4 KV buffer in smem (bytes)
+    constexpr int FP4_BUF_BYTES =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqmix(kv_capacity, 128) * 128;
+
+    const int split_id = blockIdx.x;
+    const int bid = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    const int total_kv_blocks = cdiv_sqmix(kv_len, BLOCK_KV_FP4);
+    const int kv_block_start = (split_id * total_kv_blocks) / num_kv_splits;
+    const int kv_block_end = ((split_id + 1) * total_kv_blocks) / num_kv_splits;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+
+    Q_fp16 += bid * q_len       * HEAD_DIM;
+    K_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+    V_fp16 += kv_bid * kv_capacity * HEAD_DIM;
+
+    const int partial_offset = bid * num_kv_splits + split_id;
+    O_partial      += partial_offset * q_len * HEAD_DIM;
+    rowmax_partial += partial_offset * q_len;
+    rowsum_partial += partial_offset * q_len;
+
+    const int32_t* topk_row = top_k + bid * topk_count;
+
+    // ---- Optimisation 1: build local bitmask for O(1) top-k lookup ----
+    constexpr int TOPK_MASK_WORDS = 4;  // 128 bits — covers up to 128 blocks/split
+    constexpr int TOPK_MASK_BITS  = TOPK_MASK_WORDS * 32;
+    uint32_t topk_local_mask[TOPK_MASK_WORDS] = {};
+
+    const int num_kv_iters = kv_block_end - kv_block_start;
+
+    for (int i = lane_id; i < topk_count; i += WARP_SIZE_sqmix) {
+        int b = topk_row[i] - kv_block_start;
+        if (b >= 0 && b < min(num_kv_iters, TOPK_MASK_BITS))
+            topk_local_mask[b >> 5] |= (1u << (b & 31));
+    }
+    #pragma unroll
+    for (int w = 0; w < TOPK_MASK_WORDS; w++) {
+        #pragma unroll
+        for (int delta = WARP_SIZE_sqmix / 2; delta > 0; delta >>= 1)
+            topk_local_mask[w] |= __shfl_down_sync(0xffffffffu, topk_local_mask[w], delta);
+        topk_local_mask[w] = __shfl_sync(0xffffffffu, topk_local_mask[w], 0);
+    }
+
+    const bool range_has_fp16 = (num_kv_iters <= TOPK_MASK_BITS)
+        ? ((topk_local_mask[0] | topk_local_mask[1] |
+            topk_local_mask[2] | topk_local_mask[3]) != 0)
+        : range_has_topk_sqmix(topk_row, topk_count, kv_block_start, kv_block_end);
+
+    // Helper lambda: O(1) top-k test for local block index
+    auto is_topk = [&](int local_idx) -> bool {
+        if (local_idx < TOPK_MASK_BITS)
+            return (topk_local_mask[local_idx >> 5] >> (local_idx & 31)) & 1;
+        return block_in_topk_sqmix(topk_row, topk_count, kv_block_start + local_idx);
+    };
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q_fp4 + scales → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[2] = {-FLT_MAX, -FLT_MAX};
+    float rowsum[2] = {};
+    constexpr int O_REGS = UPPER_ONLY ? 2 : 4;
+    float O_rmem[HEAD_DIM / MMA_N][O_REGS] = {};
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqmix<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqmix<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+        ldmatrix_x4_sqmix(Q_rmem[mma_id_d], addr);
+    }
+    __syncwarp();
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+        const uint32_t offset =
+            (sf_row_q * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+        asm volatile("ld.shared.u32 %0, [%1];"
+            : "=r"(sfQ_rmem[mma_id_d])
+            : "r"(Q_sf_smem + offset));
+    }
+
+    // ---- Phase 2: KV loop ----
+    __syncwarp();
+
+    // ---- Optimisation 2: double-buffered FP4 smem layout ----
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    uint32_t K_smem_buf[2], K_sf_buf[2], V_smem_buf[2], V_sf_buf[2], K_ld_buf[2];
+    for (int b = 0; b < 2; b++) {
+        K_smem_buf[b] = smem_base + b * FP4_BUF_BYTES;
+        K_sf_buf[b]   = K_smem_buf[b] + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+        V_smem_buf[b] = K_sf_buf[b]   + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3);
+        V_sf_buf[b]   = V_smem_buf[b] + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_buf[b] = swizzle_sqmix<HEAD_DIM_2>(K_smem_buf[b] + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    // FP16 smem layout (overlaps buffer region — used only after FP4 is done)
+    const uint32_t K_smem_fp16 = smem_base;
+    const uint32_t V_smem_fp16 = K_smem_fp16 + BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T);
+
+    // ---- Double-buffered FP4 loop ----
+    {
+        // Find first non-topk block
+        int cur_iter = -1;
+        if (range_has_fp16) {
+            for (int i = 0; i < num_kv_iters; i++) {
+                if (!is_topk(i)) { cur_iter = i; break; }
+            }
+        } else {
+            if (num_kv_iters > 0) cur_iter = 0;
+        }
+
+        if (cur_iter >= 0) {
+            int cur_buf = 0;
+            int gid = kv_block_start + cur_iter;
+
+            // Preload first FP4 block
+            load_kv_fp4_async_sqmix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+                K_smem_buf[0], K_sf_buf[0], V_smem_buf[0], V_sf_buf[0],
+                K + gid * BLOCK_KV_FP4 * HEAD_DIM_2,
+                V + gid * BLOCK_KV_FP4 / 2,
+                S_K + gid * BLOCK_KV_FP4 * SCALE_DIM,
+                S_V + gid * BLOCK_KV_FP4 / 16,
+                lane_id, v_kv);
+
+            while (cur_iter >= 0) {
+                // Find next non-topk block
+                int next_iter = -1;
+                for (int j = cur_iter + 1; j < num_kv_iters; j++) {
+                    if (!range_has_fp16 || !is_topk(j)) {
+                        next_iter = j;
+                        break;
+                    }
+                }
+
+                // Preload next block into alternate buffer
+                if (next_iter >= 0) {
+                    int next_gid = kv_block_start + next_iter;
+                    load_kv_fp4_async_sqmix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>(
+                        K_smem_buf[1 - cur_buf], K_sf_buf[1 - cur_buf],
+                        V_smem_buf[1 - cur_buf], V_sf_buf[1 - cur_buf],
+                        K + next_gid * BLOCK_KV_FP4 * HEAD_DIM_2,
+                        V + next_gid * BLOCK_KV_FP4 / 2,
+                        S_K + next_gid * BLOCK_KV_FP4 * SCALE_DIM,
+                        S_V + next_gid * BLOCK_KV_FP4 / 16,
+                        lane_id, v_kv);
+                }
+
+                // Wait for current buffer's load to complete
+                if (next_iter >= 0) {
+                    asm volatile("cp.async.wait_group %0;" :: "n"(1));
+                } else {
+                    asm volatile("cp.async.wait_all;");
+                }
+                __syncwarp();
+
+                // Compute attention on current buffer.  GQA single-query usually
+                // has q_len=4, so instantiate a variant that skips lower-half
+                // scalar softmax/packing work for rows 8..15.
+                if constexpr (UPPER_ONLY) {
+                    compute_kv_fp4_sqmix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, false, 2>(
+                        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+                        K_sf_buf[cur_buf], V_smem_buf[cur_buf], V_sf_buf[cur_buf],
+                        K_ld_buf[cur_buf],
+                        lane_id, softmax_scale);
+                } else {
+                    compute_kv_fp4_sqmix<BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, true, 4>(
+                        rowmax, rowsum, O_rmem, Q_rmem, sfQ_rmem,
+                        K_sf_buf[cur_buf], V_smem_buf[cur_buf], V_sf_buf[cur_buf],
+                        K_ld_buf[cur_buf],
+                        lane_id, softmax_scale);
+                }
+
+                cur_buf = 1 - cur_buf;
+                cur_iter = next_iter;
+            }
+        }
+    }
+
+    // FP16 (top-k) blocks — Q FP16 loaded once
+    if (range_has_fp16) {
+        uint32_t Q_fp16_rmem[HEAD_DIM / 16][4];
+        load_q_fp16_to_regs_single_query_sqmix<T, HEAD_DIM, BLOCK_Q>(
+            Q_fp16_rmem, K_smem_fp16, Q_fp16, lane_id, q_len);
+
+        for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+            if (!is_topk(kv_iter))
+                continue;
+
+            const int global_block_id = kv_block_start + kv_iter;
+            const T* K_fp16_ptr_iter = K_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+            const T* V_fp16_ptr_iter = V_fp16 + global_block_id * BLOCK_KV_FP4 * HEAD_DIM;
+
+            if constexpr (UPPER_ONLY) {
+                attention_inner_loop_fp16<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM, false, 2>(
+                    rowmax, rowsum, O_rmem,
+                    Q_fp16_rmem,
+                    K_smem_fp16, V_smem_fp16,
+                    K_fp16_ptr_iter, V_fp16_ptr_iter,
+                    lane_id, softmax_scale);
+            } else {
+                attention_inner_loop_fp16<T, BLOCK_KV_FP4, BLOCK_KV_FP16, HEAD_DIM, true, 4>(
+                    rowmax, rowsum, O_rmem,
+                    Q_fp16_rmem,
+                    K_smem_fp16, V_smem_fp16,
+                    K_fp16_ptr_iter, V_fp16_ptr_iter,
+                lane_id, softmax_scale);
+            }
+        }
+    }
+
+    // ---- Phase 3: Write partials to global memory ----
+    // Optimisation 3: float2 vectorised stores
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        if (row < q_len) {
+            *reinterpret_cast<float2*>(&O_partial[row * HEAD_DIM + col]) =
+                make_float2(regs[0], regs[1]);
+        }
+        if constexpr (!UPPER_ONLY) {
+        if (row + 8 < q_len) {
+            *reinterpret_cast<float2*>(&O_partial[(row + 8) * HEAD_DIM + col]) =
+                make_float2(regs[2], regs[3]);
+        }
+        }
+    }
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        if (row < q_len) {
+            rowmax_partial[row] = rowmax[0];
+            rowsum_partial[row] = rowsum[0];
+        }
+        if constexpr (!UPPER_ONLY) {
+        if (row + 8 < q_len) {
+            rowmax_partial[row + 8] = rowmax[1];
+            rowsum_partial[row + 8] = rowsum[1];
+        }
+        }
+    }
+
+    // ---- Fused reduction: last split to finish reduces all partials ----
+    __threadfence();
+
+    int completed = 0;
+    if (lane_id == 0)
+        completed = atomicAdd(&split_counter[bid], 1);
+    completed = __shfl_sync(0xFFFFFFFF, completed, 0);
+
+    if (completed != num_kv_splits - 1)
+        return;
+
+    // ---- Optimisation 4: two-pass smem-assisted reduction ----
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+    const float* batch_O = O_partial - split_id * q_len * HEAD_DIM;
+    const float* batch_rowmax = rowmax_partial - split_id * q_len;
+    const float* batch_rowsum = rowsum_partial - split_id * q_len;
+
+    // Pass 1: 16 threads compute per-row rescale factors + norms → smem
+    // Layout: rsc_smem[s * q_len + row], then norm_smem[row]
+    float* rsc_smem  = reinterpret_cast<float*>(smem);
+    float* norm_smem = rsc_smem + num_kv_splits * q_len;
+
+    if (lane_id < q_len) {
+        const int row = lane_id;
+        float global_max = -FLT_MAX;
+        for (int s = 0; s < num_kv_splits; s++)
+            global_max = max(global_max, batch_rowmax[s * q_len + row]);
+
+        float sum_acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = __expf(batch_rowmax[s * q_len + row] - global_max);
+            rsc_smem[s * q_len + row] = rsc;
+            sum_acc += batch_rowsum[s * q_len + row] * rsc;
+        }
+        norm_smem[row] = FP4_RANGE_INV / sum_acc;
+    }
+    __syncwarp();
+
+    // Pass 2: reduce only the valid q_len rows.  Qwen-style grouped single-query
+    // passes q_len=4, so reducing the full m16 tile mostly moves dead data.
+    const int valid_elems = q_len * HEAD_DIM;
+    for (int flat_idx = lane_id; flat_idx < valid_elems; flat_idx += TB_SIZE) {
+        const int row = flat_idx / HEAD_DIM;
+        const int col = flat_idx % HEAD_DIM;
+
+        float acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = rsc_smem[s * q_len + row];
+            acc += batch_O[s * q_len * HEAD_DIM + row * HEAD_DIM + col] * rsc;
+        }
+
+        float norm = norm_smem[row];
+        O_final[bid * q_len * HEAD_DIM + row * HEAD_DIM + col] =
+            Traits::from_float(acc * norm);
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void thrift_attention_single_query_split_launch(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* top_k,
+    int topk_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    float* workspace,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_KV_FP4 = 64;
+    constexpr int BLOCK_KV_FP16 = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqmix;
+
+    const int total_kv_blocks = cdiv_sqmix(kv_len, BLOCK_KV_FP4);
+    const int target_split_ctas = single_query_target_split_ctas_sqmix(total_kv_blocks);
+    int num_kv_splits = max(1, min(total_kv_blocks, cdiv_sqmix(target_split_ctas, bs)));
+    num_kv_splits = min(num_kv_splits, total_kv_blocks);
+
+    float* O_partial      = workspace;
+    float* rowmax_partial = O_partial + bs * num_kv_splits * q_len * HEAD_DIM;
+    float* rowsum_partial = rowmax_partial + bs * num_kv_splits * q_len;
+    int* split_counter    = reinterpret_cast<int*>(rowsum_partial + bs * num_kv_splits * q_len);
+
+    cudaMemsetAsync(split_counter, 0, bs * sizeof(int));
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+
+    // Single FP4 buffer size (K + K_scales + V_transposed + V_scales)
+    constexpr int kv_smem_fp4_single =
+        BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV_FP4 * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV_FP4 / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    // Double-buffered FP4
+    constexpr int kv_smem_fp4 = kv_smem_fp4_single * 2;
+
+    constexpr int kv_smem_fp16 = BLOCK_KV_FP16 * HEAD_DIM * (int)sizeof(T) * 2;
+
+    constexpr int kv_smem = (kv_smem_fp4 > kv_smem_fp16) ? kv_smem_fp4 : kv_smem_fp16;
+    constexpr int smem_size = (q_phase_smem > kv_smem) ? q_phase_smem : kv_smem;
+
+    dim3 grid(num_kv_splits, bs);
+    if (q_len <= 8) {
+        auto kernel = thrift_attention_single_query_split_kernel<
+            T, BLOCK_KV_FP16, BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, true>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        kernel<<<grid, TB_SIZE, smem_size>>>(
+            Q_fp16, K_fp16, V_fp16,
+            top_k, topk_count,
+            Q_fp4, K_fp4, V_fp4,
+            S_Q, S_K, S_V,
+            O_partial, rowmax_partial, rowsum_partial,
+            O, split_counter,
+            bs, q_len, kv_len, kv_capacity, num_kv_splits,
+            num_q_heads, num_kv_heads);
+    } else {
+        auto kernel = thrift_attention_single_query_split_kernel<
+            T, BLOCK_KV_FP16, BLOCK_KV_FP4, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, false>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        kernel<<<grid, TB_SIZE, smem_size>>>(
+            Q_fp16, K_fp16, V_fp16,
+            top_k, topk_count,
+            Q_fp4, K_fp4, V_fp4,
+            S_Q, S_K, S_V,
+            O_partial, rowmax_partial, rowsum_partial,
+            O, split_counter,
+            bs, q_len, kv_len, kv_capacity, num_kv_splits,
+            num_q_heads, num_kv_heads);
+    }
+
+}
+
+template<typename T>
+static void thrift_attention_single_query_nvfp4_typed(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const int32_t* top_k,
+    int topk_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim)
+{
+    auto Q_fp16 = reinterpret_cast<const T*>(Q_fp16_raw);
+    auto K_fp16 = reinterpret_cast<const T*>(K_fp16_raw);
+    auto V_fp16 = reinterpret_cast<const T*>(V_fp16_raw);
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+
+    auto S_Q = reinterpret_cast<const __nv_fp8_e4m3*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e4m3*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e4m3*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    constexpr int BLOCK_KV_FP4 = 64;
+    const int total_kv_blocks = cdiv_sqmix(kv_len, BLOCK_KV_FP4);
+
+    if (total_kv_blocks < 128) {
+        // CTA-cooperative: up to kv_len=8192
+        if (head_dim == 64) {
+            thrift_attention_single_query_cta_launch<T, 64>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        } else {
+            thrift_attention_single_query_cta_launch<T, 128>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        }
+    } else {
+        // Split-KV: kv_len > 4096
+        auto workspace = reinterpret_cast<float*>(workspace_raw);
+        if (head_dim == 64) {
+            thrift_attention_single_query_split_launch<T, 64>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O, workspace,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        } else {
+            thrift_attention_single_query_split_launch<T, 128>(
+                Q_fp16, K_fp16, V_fp16,
+                top_k, topk_count,
+                Q, K, V, S_Q, S_K, S_V, O, workspace,
+                bs, q_len, kv_len, kv_capacity,
+                num_q_heads, num_kv_heads);
+        }
+    }
+}
+
+void thrift_attention_single_query_nvfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const int32_t* top_k,
+    int topk_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_single_query_nvfp4_typed<__nv_bfloat16>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, top_k, topk_count,
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            workspace_raw, bs, q_len, kv_len, kv_capacity, num_q_heads,
+            num_kv_heads, head_dim);
+    } else {
+        thrift_attention_single_query_nvfp4_typed<half>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, top_k, topk_count,
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw,
+            workspace_raw, bs, q_len, kv_len, kv_capacity, num_q_heads,
+            num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/nvfp4/single_query_fp4_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/nvfp4/single_query_fp4_attention.cu
@@ -1,0 +1,1796 @@
+// SM120 NVFP4 single-query attention baseline.
+
+#include <cstdint>
+#include <cstdio>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+__device__ inline
+void ldmatrix_x4_sqfp4(uint32_t reg[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+         : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+         : "r"(addr));
+}
+
+__device__ inline
+void ldmatrix_x2_sqfp4(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+// Swizzle shared memory addresses to avoid bank conflicts during ldmatrix.
+// XORs bits 4-6 of the byte address based on (row_index % 8), so that
+// consecutive rows land on different bank groups.
+// STRIDE = row width in bytes.
+template <int STRIDE>
+__device__
+uint32_t swizzle_sqfp4(uint32_t index) {
+    if constexpr (STRIDE == 16)
+        return index;
+    uint32_t row_idx = (index / STRIDE) % 8;
+    uint32_t bits_to_xor = row_idx / max(64 / STRIDE, 1);
+    return index ^ (bits_to_xor << 4);
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void gmem_to_smem_sqfp4(uint32_t dst, const T *src, int tid, int src_stride)
+{
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int num_iters = (HEIGHT * WIDTH) / (num_elements * TB_SIZE);
+
+    for (int iter = 0; iter < num_iters; iter++) {
+        const int index = (iter * TB_SIZE + tid) * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+
+        uint32_t dst_addr = swizzle_sqfp4<WIDTH * (int)sizeof(T)>(
+            dst + (row * WIDTH + col) * sizeof(T));
+        const T *src_addr = src + (row * src_stride + col);
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__
+void load_scales_sqfp4(uint32_t dst, const T *src, int src_stride, int tid) {
+  constexpr int cp_size = WIDTH * sizeof(T);
+  static_assert(cp_size < 16);
+
+  auto load_row = [&](int row) {
+    const uint32_t dst_addr = dst + row * WIDTH * sizeof(T);
+    const T *src_addr = src + row * src_stride;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], %2;" :: "r"(dst_addr), "l"(src_addr), "n"(cp_size));
+  };
+
+  for (int iter = 0; iter < HEIGHT / TB_SIZE; iter++)
+    load_row(iter * TB_SIZE + tid);
+
+  if constexpr (HEIGHT % TB_SIZE != 0) {
+    const int row = HEIGHT / TB_SIZE * TB_SIZE + tid;
+    if (row < HEIGHT)
+      load_row(row);
+  }
+}
+
+__device__ inline
+uint32_t cvt_8xf32_to_e2m1_packed_sqfp4(float f0, float f1, float f2, float f3,
+                                     float f4, float f5, float f6, float f7) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 a0, a1, a2, a3;\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a0, %1, %2;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a1, %3, %4;\n\t"
+        "mov.b16 lo, {a0, a1};\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a2, %5, %6;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a3, %7, %8;\n\t"
+        "mov.b16 hi, {a2, a3};\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3),
+          "f"(f4), "f"(f5), "f"(f6), "f"(f7)
+    );
+    return packed;
+}
+
+__device__ inline
+uint32_t cvt_4xf32_to_e4m3_packed_sqfp4(float f0, float f1, float f2, float f3) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, %1, %2;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, %3, %4;\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3)
+    );
+    return packed;
+}
+
+__device__ inline
+void mma_m16n8k64_nvfp4_sqfp4(uint32_t A[4], uint32_t B[2], uint32_t sf_A, uint32_t sf_B, float D[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4"
+        ".block_scale.scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+          "r"(B[0]), "r"(B[1]),
+          "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]),
+          "r"(sf_A), "h"(byte_id), "h"(thread_id),
+          "r"(sf_B), "h"(byte_id), "h"(thread_id));
+}
+
+constexpr int WARP_SIZE_sqfp4 = 32;
+
+__host__ __device__ inline
+int cdiv_sqfp4(int a, int b) { return (a + b - 1) / b; }
+
+__host__ __device__ inline
+int sage_perm32_sqfp4(int x) {
+    return (x / 8) * 2 + ((x % 8) / 2) * 8 + (x % 2);
+}
+
+__host__ __device__ inline
+int sage_perm_seq_sqfp4(int x) {
+    const int base = (x / 32) * 32;
+    return base + sage_perm32_sqfp4(x & 31);
+}
+
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__launch_bounds__(WARP_SIZE_sqfp4)
+__global__
+void fp4_attention_single_query_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    float* O_partial,       // [bs, num_kv_splits, 16, HEAD_DIM]
+    float* rowmax_partial,  // [bs, num_kv_splits, 16]
+    float* rowsum_partial,  // [bs, num_kv_splits, 16]
+    T* O_final,             // [bs, q_len, HEAD_DIM]
+    int* split_counter,     // [bs] — zeroed before launch
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_kv_splits,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    // Size of one FP4 KV buffer in smem (bytes)
+    constexpr int FP4_BUF_BYTES =
+        BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+      + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3)
+      + HEAD_DIM * (BLOCK_KV / 2)  * (int)sizeof(__nv_fp4x2_e2m1)
+      + HEAD_DIM * (BLOCK_KV / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    // V/S_V are transposed; per-row stride uses capacity, not logical kv_len.
+    const int v_kv = cdiv_sqfp4(kv_capacity, 128) * 128;
+
+    const int split_id = blockIdx.x;
+    const int bid = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    // Compute KV range for this split
+    const int total_kv_blocks = cdiv_sqfp4(kv_len, BLOCK_KV);
+    const int kv_block_start = (split_id * total_kv_blocks) / num_kv_splits;
+    const int kv_block_end = ((split_id + 1) * total_kv_blocks) / num_kv_splits;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2 + kv_block_start * BLOCK_KV * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2) + kv_block_start * BLOCK_KV / 2;
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM  + kv_block_start * BLOCK_KV * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM  + kv_block_start * BLOCK_KV / 16;
+
+    const int partial_offset = bid * num_kv_splits + split_id;
+    O_partial      += partial_offset * BLOCK_Q * HEAD_DIM;
+    rowmax_partial += partial_offset * BLOCK_Q;
+    rowsum_partial += partial_offset * BLOCK_Q;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q data + scales into smem → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+        asm volatile("ld.shared.u32 %0, [%1];"
+            : "=r"(sfQ_rmem[mma_id_d])
+            : "r"(Q_sf_smem + offset));
+    }
+
+    // ---- Phase 2: Double-buffered KV loop ----
+    __syncwarp();
+
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    // Two smem buffers for double-buffering
+    uint32_t K_smem_buf[2], K_sf_buf[2], V_smem_buf[2], V_sf_buf[2], K_ld_buf[2];
+    for (int b = 0; b < 2; b++) {
+        K_smem_buf[b] = smem_base + b * FP4_BUF_BYTES;
+        K_sf_buf[b]   = K_smem_buf[b] + BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+        V_smem_buf[b] = K_sf_buf[b]   + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3);
+        V_sf_buf[b]   = V_smem_buf[b] + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_buf[b] = swizzle_sqfp4<HEAD_DIM_2>(K_smem_buf[b] + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    const int num_kv_iters = kv_block_end - kv_block_start;
+
+    // Helper: start async load of KV block at offset iter into buffer buf
+    auto start_kv_load = [&](int buf, int iter) {
+        const auto* Kp  = K   + iter * BLOCK_KV * HEAD_DIM_2;
+        const auto* Vp  = V   + iter * BLOCK_KV / 2;
+        const auto* SKp = S_K + iter * BLOCK_KV * SCALE_DIM;
+        const auto* SVp = S_V + iter * BLOCK_KV / 16;
+        gmem_to_smem_sqfp4<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem_buf[buf], Kp, tid, HEAD_DIM_2);
+        load_scales_sqfp4<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(K_sf_buf[buf], SKp, SCALE_DIM, tid);
+        gmem_to_smem_sqfp4<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem_buf[buf], Vp, tid, v_kv / 2);
+        load_scales_sqfp4<HEAD_DIM, BLOCK_KV / 16, TB_SIZE, __nv_fp8_e4m3>(V_sf_buf[buf], SVp, v_kv / 16, tid);
+        asm volatile("cp.async.commit_group;");
+    };
+
+    // Preload first block
+    if (num_kv_iters > 0)
+        start_kv_load(0, 0);
+
+    int cur_buf = 0;
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        // Preload next block into alternate buffer
+        if (kv_iter + 1 < num_kv_iters)
+            start_kv_load(1 - cur_buf, kv_iter + 1);
+
+        // Wait for current buffer
+        if (kv_iter + 1 < num_kv_iters) {
+            asm volatile("cp.async.wait_group %0;" :: "n"(1));
+        } else {
+            asm volatile("cp.async.wait_all;");
+        }
+        __syncwarp();
+
+        // Aliases for current buffer
+        const uint32_t cur_K_sf  = K_sf_buf[cur_buf];
+        const uint32_t cur_V     = V_smem_buf[cur_buf];
+        const uint32_t cur_V_sf  = V_sf_buf[cur_buf];
+        const uint32_t cur_K_ld  = K_ld_buf[cur_buf];
+
+        // K → registers
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = cur_K_ld + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = cur_K_ld;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        // K scales → registers
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                    : "r"(cur_K_sf + offset));
+            }
+
+        // QK^T MMA
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        // ---- online softmax (no causal mask) ----
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 448.0f * 6.0f;
+        constexpr float FP4_MAX = 6.0f;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= FP4_RANGE;
+            S_rmem[mma_id_kv][1] *= FP4_RANGE;
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        }
+
+        float sf_P_upper[BLOCK_KV / MMA_N / 2];
+        float sf_P_lower[BLOCK_KV / MMA_N / 2];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            int t0 = 2 * blk;
+            int t1 = t0 + 1;
+
+            float amax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+        }
+
+        // Reorder lanes so the following MMA consumes contiguous probability fragments.
+        const int qid = lane_id & 3;
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 4;
+            uint32_t sfP_upper_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0],
+                sf_P_upper[base + 3], sf_P_upper[base + 2]);
+
+            uint32_t sfP_lower_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0],
+                sf_P_lower[base + 3], sf_P_lower[base + 2]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        // V → registers
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqfp4<BLOCK_KV / 2>(
+                    cur_V + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        // V scales → registers
+        constexpr int V_SF_STRIDE = BLOCK_KV / 16;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                    : "r"(cur_V_sf + offset));
+            }
+
+        // O += P @ V
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        cur_buf = 1 - cur_buf;
+    }
+
+    // ---- Phase 3: Write partials — float2 vectorised stores ----
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        *reinterpret_cast<float2*>(&O_partial[(row + 0) * HEAD_DIM + col]) =
+            make_float2(regs[0], regs[1]);
+        *reinterpret_cast<float2*>(&O_partial[(row + 8) * HEAD_DIM + col]) =
+            make_float2(regs[2], regs[3]);
+    }
+
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;
+        rowmax_partial[row + 0] = rowmax[0];
+        rowmax_partial[row + 8] = rowmax[1];
+        rowsum_partial[row + 0] = rowsum[0];
+        rowsum_partial[row + 8] = rowsum[1];
+    }
+
+    // ---- Fused reduction: last block to finish reduces all partials ----
+    __threadfence();
+
+    int completed = 0;
+    if (lane_id == 0)
+        completed = atomicAdd(&split_counter[bid], 1);
+    completed = __shfl_sync(0xFFFFFFFF, completed, 0);
+
+    if (completed != num_kv_splits - 1)
+        return;
+
+    // ---- Two-pass smem-assisted reduction ----
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+    constexpr int ELEMS_PER_THREAD = (BLOCK_Q * HEAD_DIM) / TB_SIZE;
+
+    const float* batch_O = O_partial - split_id * BLOCK_Q * HEAD_DIM;
+    const float* batch_rowmax = rowmax_partial - split_id * BLOCK_Q;
+    const float* batch_rowsum = rowsum_partial - split_id * BLOCK_Q;
+
+    // Pass 1: 16 threads compute per-row rescale factors + norms → smem
+    float* rsc_smem  = reinterpret_cast<float*>(smem);
+    float* norm_smem = rsc_smem + num_kv_splits * BLOCK_Q;
+
+    if (lane_id < BLOCK_Q) {
+        const int row = lane_id;
+        float global_max = -FLT_MAX;
+        for (int s = 0; s < num_kv_splits; s++)
+            global_max = max(global_max, batch_rowmax[s * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = __expf(batch_rowmax[s * BLOCK_Q + row] - global_max);
+            rsc_smem[s * BLOCK_Q + row] = rsc;
+            sum_acc += batch_rowsum[s * BLOCK_Q + row] * rsc;
+        }
+        norm_smem[row] = FP4_RANGE_INV / sum_acc;
+    }
+    __syncwarp();
+
+    // Pass 2: all 32 threads reduce O elements using precomputed factors
+    for (int elem = 0; elem < ELEMS_PER_THREAD; elem++) {
+        const int flat_idx = lane_id + elem * TB_SIZE;
+        const int row = flat_idx / HEAD_DIM;
+        const int col = flat_idx % HEAD_DIM;
+
+        float acc = 0.0f;
+        for (int s = 0; s < num_kv_splits; s++) {
+            float rsc = rsc_smem[s * BLOCK_Q + row];
+            acc += batch_O[s * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col] * rsc;
+        }
+
+        if (row < q_len) {
+            float norm = norm_smem[row];
+            O_final[bid * q_len * HEAD_DIM + row * HEAD_DIM + col] =
+                Traits::from_float(acc * norm);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode kernel: no-split fast path. One block per batch element, processes
+// all KV blocks, writes FP16 output directly. No workspace, no atomics.
+// Handles unpadded Q (q_len rows, typically 1 for single-query).
+// Grid: (bs,)
+// ---------------------------------------------------------------------------
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM>
+__launch_bounds__(WARP_SIZE_sqfp4)
+__global__
+void fp4_attention_single_query_nosplit_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = WARP_SIZE_sqfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqfp4(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int lane_id = tid;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: load Q data + scales into smem → registers ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q data + Q scale smem, then load only q_len valid rows
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncwarp();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncwarp();
+
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+        asm volatile("ld.shared.u32 %0, [%1];"
+            : "=r"(sfQ_rmem[mma_id_d])
+            : "r"(Q_sf_smem + offset));
+    }
+
+    // ---- Phase 2: KV loop (all blocks) ----
+    __syncwarp();
+
+    const uint32_t K_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t K_sf_smem = K_smem    + BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem    = K_sf_smem + BLOCK_KV * SCALE_DIM  * sizeof(__nv_fp8_e4m3);
+    const uint32_t V_sf_smem = V_smem    + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = swizzle_sqfp4<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    const int total_kv_blocks = cdiv_sqfp4(kv_len, BLOCK_KV);
+
+    for (int kv_iter = 0; kv_iter < total_kv_blocks; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        gmem_to_smem_sqfp4<BLOCK_KV, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem, K, tid, HEAD_DIM_2);
+        load_scales_sqfp4<BLOCK_KV, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(K_sf_smem, S_K, SCALE_DIM, tid);
+        gmem_to_smem_sqfp4<HEAD_DIM, BLOCK_KV / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem, V, tid, v_kv / 2);
+        load_scales_sqfp4<HEAD_DIM, BLOCK_KV / 16, TB_SIZE, __nv_fp8_e4m3>(V_sf_smem, S_V, v_kv / 16, tid);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                    : "r"(K_sf_smem + offset));
+            }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 448.0f * 6.0f;
+        constexpr float inv_sP1 = FP4_RANGE;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= inv_sP1;
+            S_rmem[mma_id_kv][1] *= inv_sP1;
+            S_rmem[mma_id_kv][2] *= inv_sP1;
+            S_rmem[mma_id_kv][3] *= inv_sP1;
+        }
+
+        constexpr float FP4_MAX = 6.0f;
+        float sf_P_upper[BLOCK_KV / MMA_N / 2];
+        float sf_P_lower[BLOCK_KV / MMA_N / 2];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            int t0 = 2 * blk;
+            int t1 = t0 + 1;
+
+            float amax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+        }
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+            int t0 = 2 * blk;
+            int t1 = t0 + 1;
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 4;
+            uint32_t sfP_upper_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0],
+                sf_P_upper[base + 3], sf_P_upper[base + 2]);
+
+            uint32_t sfP_lower_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0],
+                sf_P_lower[base + 3], sf_P_lower[base + 2]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqfp4<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        constexpr int V_SF_STRIDE = BLOCK_KV / 16;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                    : "r"(V_sf_smem + offset));
+            }
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        K   += BLOCK_KV * HEAD_DIM_2;
+        S_K += BLOCK_KV * SCALE_DIM;
+        V   += BLOCK_KV / 2;
+        S_V += BLOCK_KV / 16;
+    }
+
+    // ---- Phase 3: normalize and write FP16 output directly ----
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+
+        float *regs = O_rmem[mma_id_d];
+
+        float norm0 = FP4_RANGE_INV / rowsum[0];
+        float norm1 = FP4_RANGE_INV / rowsum[1];
+
+        regs[0] *= norm0;
+        regs[1] *= norm0;
+        regs[2] *= norm1;
+        regs[3] *= norm1;
+
+        if (row < q_len)
+            reinterpret_cast<typename Traits::vec2*>(O + row * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+        if (row + 8 < q_len)
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode kernel: CTA-cooperative version. NUM_WARPS warps per block, each
+// warp processes a disjoint chunk of KV blocks independently using its own
+// smem region, then all warps reduce (O, rowmax, rowsum) via shared memory.
+// No workspace allocation needed — reduction is entirely intra-CTA.
+// Grid: (bs,)
+// ---------------------------------------------------------------------------
+template<typename T, int BLOCK_KV, int HEAD_DIM, int HEAD_DIM_2, int SCALE_DIM, int NUM_WARPS>
+__launch_bounds__(NUM_WARPS * WARP_SIZE_sqfp4, 1)
+__global__
+void fp4_attention_single_query_cta_kernel(
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqfp4;
+    constexpr int BLOCK_Q = 16;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+    const int v_kv = cdiv_sqfp4(kv_capacity, 128) * 128;
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / WARP_SIZE_sqfp4;
+    const int lane_id = tid % WARP_SIZE_sqfp4;
+    const int batch_id = bid / num_q_heads;
+    const int q_head = bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q   += bid * q_len       * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM    * (v_kv / 2);
+    S_Q += bid * q_len       * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv        * SCALE_DIM;
+    O   += bid * q_len       * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Phase 1: cooperatively load Q data + scales into smem ----
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t Q_rmem[HEAD_DIM / MMA_K][4];
+    uint32_t sfQ_rmem[HEAD_DIM / MMA_K];
+
+    float rowmax[2];
+    float rowsum[2] = {};
+    float O_rmem[HEAD_DIM / MMA_N][4] = {};
+    rowmax[0] = -FLT_MAX;
+    rowmax[1] = -FLT_MAX;
+
+    // Zero Q smem, then load valid rows (all threads cooperate)
+    {
+        constexpr int TOTAL_WORDS = (BLOCK_Q * HEAD_DIM_2 + BLOCK_Q * SCALE_DIM) / 4;
+        uint32_t* base = reinterpret_cast<uint32_t*>(smem);
+        for (int i = tid; i < TOTAL_WORDS; i += TB_SIZE)
+            base[i] = 0;
+    }
+    __syncthreads();
+    {
+        constexpr int LOAD_SIZE = 16;
+        const int total_loads = q_len * HEAD_DIM_2 / LOAD_SIZE;
+        for (int load_id = tid; load_id < total_loads; load_id += TB_SIZE) {
+            const int byte_offset = load_id * LOAD_SIZE;
+            const int row = byte_offset / HEAD_DIM_2;
+            const int col = byte_offset % HEAD_DIM_2;
+            uint32_t dst_addr = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row * HEAD_DIM_2 + col);
+            const auto *src_addr = Q + row * HEAD_DIM_2 + col;
+            asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+                :: "r"(dst_addr), "l"(src_addr));
+        }
+    }
+    {
+        constexpr int SF_ROW_BYTES = SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+        for (int row = tid; row < q_len; row += TB_SIZE) {
+            const uint32_t dst_addr = Q_sf_smem + row * SF_ROW_BYTES;
+            const auto *src_addr = S_Q + row * SCALE_DIM;
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(SF_ROW_BYTES));
+        }
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    // Each warp reads Q into registers (same smem, only lane_id matters)
+    uint32_t Q_ld_base;
+    {
+        const int row_off = lane_id % 16;
+        const int col_off = (lane_id / 16) * 16;
+        Q_ld_base = swizzle_sqfp4<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        uint32_t addr = Q_ld_base;
+        addr ^= mma_id_d * (MMA_K / 2);
+        ldmatrix_x4_sqfp4(Q_rmem[mma_id_d], addr);
+    }
+
+    int sf_row_q = 0;
+    if (lane_id % 4 == 0) sf_row_q = (lane_id / 4);
+    else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+        const uint32_t offset = (sf_row_q * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+        asm volatile("ld.shared.u32 %0, [%1];"
+            : "=r"(sfQ_rmem[mma_id_d])
+            : "r"(Q_sf_smem + offset));
+    }
+
+    // ---- Phase 2: each warp processes its KV chunk independently ----
+    __syncthreads();
+
+    // Per-warp KV smem: [warp0: K|Ksf|V|Vsf] [warp1: ...] ...
+    constexpr int KV_SMEM_PER_WARP = BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + BLOCK_KV * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3)
+                                    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + HEAD_DIM * (BLOCK_KV / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    const uint32_t warp_kv_base = __cvta_generic_to_shared(smem) + warp_id * KV_SMEM_PER_WARP;
+    const uint32_t K_smem    = warp_kv_base;
+    const uint32_t K_sf_smem = K_smem    + BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem    = K_sf_smem + BLOCK_KV * SCALE_DIM  * (int)sizeof(__nv_fp8_e4m3);
+    const uint32_t V_sf_smem = V_smem    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    // Divide KV blocks evenly across warps
+    const int total_kv_blocks = cdiv_sqfp4(kv_len, BLOCK_KV);
+    const int blocks_per_warp = cdiv_sqfp4(total_kv_blocks, NUM_WARPS);
+    const int kv_block_start = warp_id * blocks_per_warp;
+    const int kv_block_end = min(kv_block_start + blocks_per_warp, total_kv_blocks);
+    const int num_kv_iters = (kv_block_start < total_kv_blocks)
+                           ? (kv_block_end - kv_block_start) : 0;
+
+    // Per-warp pointers offset to this warp's starting KV block
+    const __nv_fp4x2_e2m1* K_ptr = K + kv_block_start * BLOCK_KV * HEAD_DIM_2;
+    const __nv_fp4x2_e2m1* V_ptr = V + kv_block_start * BLOCK_KV / 2;
+    const __nv_fp8_e4m3* SK_ptr = S_K + kv_block_start * BLOCK_KV * SCALE_DIM;
+    const __nv_fp8_e4m3* SV_ptr = S_V + kv_block_start * BLOCK_KV / 16;
+
+    uint32_t K_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+    uint32_t V_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+    uint32_t sfK_rmem[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K];
+    uint32_t sfV_rmem[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N];
+
+    uint32_t K_ld_base;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base = swizzle_sqfp4<HEAD_DIM_2>(K_smem + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        float S_rmem[BLOCK_KV / MMA_N][4] = {};
+        uint32_t S_fp4_rmem[BLOCK_KV / MMA_K][4];
+        uint32_t S_fp4_s_rmem[BLOCK_KV / MMA_K];
+
+        // Each warp loads its own KV block into its own smem region
+        gmem_to_smem_sqfp4<BLOCK_KV, HEAD_DIM_2, WARP_SIZE_sqfp4, __nv_fp4x2_e2m1>(K_smem, K_ptr, lane_id, HEAD_DIM_2);
+        load_scales_sqfp4<BLOCK_KV, SCALE_DIM, WARP_SIZE_sqfp4, __nv_fp8_e4m3>(K_sf_smem, SK_ptr, SCALE_DIM, lane_id);
+        gmem_to_smem_sqfp4<HEAD_DIM, BLOCK_KV / 2, WARP_SIZE_sqfp4, __nv_fp4x2_e2m1>(V_smem, V_ptr, lane_id, v_kv / 2);
+        load_scales_sqfp4<HEAD_DIM, BLOCK_KV / 16, WARP_SIZE_sqfp4, __nv_fp8_e4m3>(V_sf_smem, SV_ptr, v_kv / 16, lane_id);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncwarp();
+
+        // K → registers
+        if constexpr (HEAD_DIM / MMA_K >= 2) {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+                uint32_t addr = K_ld_base + mma_id_kv * MMA_N * HEAD_DIM_2;
+                ldmatrix_x4_sqfp4(K_rmem[mma_id_kv][0], addr);
+            }
+        } else {
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                    uint32_t addr = K_ld_base;
+                    addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                    addr ^= mma_id_d * (MMA_K / 2);
+                    ldmatrix_x2_sqfp4(K_rmem[mma_id_kv][mma_id_d], addr);
+                }
+        }
+
+        // K scales → registers
+        const int sf_row_k = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++) {
+                const int row = mma_id_kv * MMA_N + sf_row_k;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                    : "r"(K_sf_smem + offset));
+            }
+
+        // QK^T MMA
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K; mma_id_d++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    Q_rmem[mma_id_d],
+                    K_rmem[mma_id_kv][mma_id_d],
+                    sfQ_rmem[mma_id_d],
+                    sfK_rmem[mma_id_kv][mma_id_d],
+                    S_rmem[mma_id_kv]);
+
+        // ---- online softmax ----
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++)
+            for (int reg_id = 0; reg_id < 4; reg_id++)
+                S_rmem[mma_id_kv][reg_id] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        float p_group_max_upper[BLOCK_KV / MMA_N / 2];
+        float p_group_max_lower[BLOCK_KV / MMA_N / 2];
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            const int t0 = 2 * blk;
+            const int t1 = t0 + 1;
+            float gmax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            float gmax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 1));
+            gmax_upper = max(gmax_upper, __shfl_xor_sync(0xFFFFFFFF, gmax_upper, 2));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 1));
+            gmax_lower = max(gmax_lower, __shfl_xor_sync(0xFFFFFFFF, gmax_lower, 2));
+            p_group_max_upper[blk] = gmax_upper;
+            p_group_max_lower[blk] = gmax_lower;
+            this_rowmax[0] = max(this_rowmax[0], gmax_upper);
+            this_rowmax[1] = max(this_rowmax[1], gmax_lower);
+        }
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[1]);
+
+        float rescale[2];
+        rescale[0] = __expf(rowmax[0] - this_rowmax[0]);
+        rescale[1] = __expf(rowmax[1] - this_rowmax[1]);
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[mma_id_d][0] *= rescale[0];
+            O_rmem[mma_id_d][1] *= rescale[0];
+            O_rmem[mma_id_d][2] *= rescale[1];
+            O_rmem[mma_id_d][3] *= rescale[1];
+        }
+
+        rowmax[0] = this_rowmax[0];
+        rowmax[1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            float *regs = S_rmem[mma_id_kv];
+            regs[0] = __expf(regs[0] - rowmax[0]);
+            regs[1] = __expf(regs[1] - rowmax[0]);
+            regs[2] = __expf(regs[2] - rowmax[1]);
+            regs[3] = __expf(regs[3] - rowmax[1]);
+
+            this_rowsumexp[0] += regs[0] + regs[1];
+            this_rowsumexp[1] += regs[2] + regs[3];
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+
+        rowsum[0] = rowsum[0] * rescale[0] + this_rowsumexp[0];
+        rowsum[1] = rowsum[1] * rescale[1] + this_rowsumexp[1];
+
+        constexpr float FP4_RANGE = 448.0f * 6.0f;
+        constexpr float FP4_MAX = 6.0f;
+
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_N; mma_id_kv++) {
+            S_rmem[mma_id_kv][0] *= FP4_RANGE;
+            S_rmem[mma_id_kv][1] *= FP4_RANGE;
+            S_rmem[mma_id_kv][2] *= FP4_RANGE;
+            S_rmem[mma_id_kv][3] *= FP4_RANGE;
+        }
+
+        float sf_P_upper[BLOCK_KV / MMA_N / 2];
+        float sf_P_lower[BLOCK_KV / MMA_N / 2];
+
+        for (int blk = 0; blk < BLOCK_KV / MMA_N / 2; blk++) {
+            int t0 = 2 * blk;
+            int t1 = t0 + 1;
+
+            float amax_upper = max(
+                max(S_rmem[t0][0], S_rmem[t0][1]),
+                max(S_rmem[t1][0], S_rmem[t1][1])
+            );
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 1));
+            amax_upper = max(amax_upper, __shfl_xor_sync(0xFFFFFFFF, amax_upper, 2));
+
+            float amax_lower = max(
+                max(S_rmem[t0][2], S_rmem[t0][3]),
+                max(S_rmem[t1][2], S_rmem[t1][3])
+            );
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 1));
+            amax_lower = max(amax_lower, __shfl_xor_sync(0xFFFFFFFF, amax_lower, 2));
+
+            sf_P_upper[blk] = amax_upper / FP4_MAX;
+            sf_P_lower[blk] = amax_lower / FP4_MAX;
+
+            float inv_upper = 1.0f / sf_P_upper[blk];
+            float inv_lower = 1.0f / sf_P_lower[blk];
+
+            S_rmem[t0][0] *= inv_upper;
+            S_rmem[t0][1] *= inv_upper;
+            S_rmem[t1][0] *= inv_upper;
+            S_rmem[t1][1] *= inv_upper;
+            S_rmem[t0][2] *= inv_lower;
+            S_rmem[t0][3] *= inv_lower;
+            S_rmem[t1][2] *= inv_lower;
+            S_rmem[t1][3] *= inv_lower;
+        }
+
+        const int qid = lane_id & 3;
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            for (int r = 0; r < 4; r++) {
+                float send = (qid & 1) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 1][r];
+                float recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 1][r] = recv;
+
+                send = (qid & 1) ? S_rmem[g*4 + 2][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 1);
+                if (qid & 1) S_rmem[g*4 + 2][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 0][r] : S_rmem[g*4 + 2][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 0][r] = recv;
+                else         S_rmem[g*4 + 2][r] = recv;
+
+                send = (qid & 2) ? S_rmem[g*4 + 1][r] : S_rmem[g*4 + 3][r];
+                recv = __shfl_xor_sync(0xFFFFFFFF, send, 2);
+                if (qid & 2) S_rmem[g*4 + 1][r] = recv;
+                else         S_rmem[g*4 + 3][r] = recv;
+            }
+        }
+
+        for (int g = 0; g < BLOCK_KV / MMA_N / 4; g++) {
+            float *r0 = S_rmem[g*4];
+            float *r1 = S_rmem[g*4 + 1];
+            float *r2 = S_rmem[g*4 + 2];
+            float *r3 = S_rmem[g*4 + 3];
+
+            S_fp4_rmem[0][2 * g] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[1], r0[0], r1[1], r1[0],
+                r2[1], r2[0], r3[1], r3[0]);
+
+            S_fp4_rmem[0][2 * g + 1] = cvt_8xf32_to_e2m1_packed_sqfp4(
+                r0[3], r0[2], r1[3], r1[2],
+                r2[3], r2[2], r3[3], r3[2]);
+        }
+
+        for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV / MMA_K; mma_sc_id++) {
+            int base = mma_sc_id * 4;
+            uint32_t sfP_upper_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_upper[base + 1], sf_P_upper[base + 0],
+                sf_P_upper[base + 3], sf_P_upper[base + 2]);
+
+            uint32_t sfP_lower_packed = cvt_4xf32_to_e4m3_packed_sqfp4(
+                sf_P_lower[base + 1], sf_P_lower[base + 0],
+                sf_P_lower[base + 3], sf_P_lower[base + 2]);
+
+            S_fp4_s_rmem[mma_sc_id] =
+                (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+        }
+
+        // V → registers
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++) {
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                uint32_t addr = swizzle_sqfp4<BLOCK_KV / 2>(
+                    V_smem + n_idx * (BLOCK_KV / 2) + k_byte_offset);
+
+                ldmatrix_x4_sqfp4(V_rmem[mma_id_kv][mma_id_d], addr);
+            }
+        }
+
+        // V scales → registers
+        constexpr int V_SF_STRIDE = BLOCK_KV / 16;
+        const int sf_col_v = lane_id / 4;
+        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                    : "r"(V_sf_smem + offset));
+            }
+
+        // O += P @ V
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV / MMA_K; mma_id_kv++)
+                mma_m16n8k64_nvfp4_sqfp4(
+                    S_fp4_rmem[mma_id_kv],
+                    V_rmem[mma_id_kv][mma_id_d],
+                    S_fp4_s_rmem[mma_id_kv],
+                    sfV_rmem[mma_id_kv][mma_id_d],
+                    O_rmem[mma_id_d]);
+
+        K_ptr  += BLOCK_KV * HEAD_DIM_2;
+        SK_ptr += BLOCK_KV * SCALE_DIM;
+        V_ptr  += BLOCK_KV / 2;
+        SV_ptr += BLOCK_KV / 16;
+    }
+
+    // ---- Phase 3: CTA-level reduction via shared memory ----
+    __syncthreads();
+
+    // Reduction smem layout:
+    //   rowmax [NUM_WARPS][BLOCK_Q]           — float
+    //   rowsum [NUM_WARPS][BLOCK_Q]           — float
+    //   O_part [NUM_WARPS][BLOCK_Q][HEAD_DIM] — float
+    float* reduce_base = reinterpret_cast<float*>(smem);
+    float* rowmax_smem = reduce_base;
+    float* rowsum_smem = rowmax_smem + NUM_WARPS * BLOCK_Q;
+    float* O_part_smem = rowsum_smem + NUM_WARPS * BLOCK_Q;
+
+    // Each warp writes its per-row rowmax/rowsum
+    if (lane_id % 4 == 0) {
+        const int row = lane_id / 4;  // 0..7
+        rowmax_smem[warp_id * BLOCK_Q + row]     = rowmax[0];
+        rowmax_smem[warp_id * BLOCK_Q + row + 8] = rowmax[1];
+        rowsum_smem[warp_id * BLOCK_Q + row]     = rowsum[0];
+        rowsum_smem[warp_id * BLOCK_Q + row + 8] = rowsum[1];
+    }
+
+    // Each warp writes its partial O
+    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+        const int row = lane_id / 4;
+        const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+        float *regs = O_rmem[mma_id_d];
+
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col]           = regs[0];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col + 1]       = regs[1];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col]     = regs[2];
+        O_part_smem[warp_id * BLOCK_Q * HEAD_DIM + (row + 8) * HEAD_DIM + col + 1] = regs[3];
+    }
+
+    __syncthreads();
+
+    // Precompute per-row rescale weights and normalization factor.
+    // One thread per row: computes global_max, per-warp rescale, and final norm.
+    // Reuses rowmax_smem for weights, rowsum_smem[0..BLOCK_Q-1] for norm.
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+
+    if (tid < BLOCK_Q) {
+        const int row = tid;
+        float global_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+            global_max = max(global_max, rowmax_smem[w * BLOCK_Q + row]);
+
+        float sum_acc = 0.0f;
+        float rsc[NUM_WARPS];
+        for (int w = 0; w < NUM_WARPS; w++) {
+            rsc[w] = __expf(rowmax_smem[w * BLOCK_Q + row] - global_max);
+            sum_acc += rowsum_smem[w * BLOCK_Q + row] * rsc[w];
+        }
+
+        float norm = FP4_RANGE_INV / sum_acc;
+        for (int w = 0; w < NUM_WARPS; w++)
+            rowmax_smem[w * BLOCK_Q + row] = rsc[w];
+        rowsum_smem[row] = norm;
+    }
+
+    __syncthreads();
+
+    // All threads: weighted sum of warp partials + vectorised FP16 output
+    constexpr int TOTAL_PAIRS = BLOCK_Q * (HEAD_DIM / 2);
+
+    for (int pair = tid; pair < TOTAL_PAIRS; pair += TB_SIZE) {
+        const int elem = pair * 2;
+        const int row = elem / HEAD_DIM;
+        const int col = elem % HEAD_DIM;
+
+        float norm = rowsum_smem[row];
+        float acc0 = 0.0f, acc1 = 0.0f;
+        for (int w = 0; w < NUM_WARPS; w++) {
+            float rsc = rowmax_smem[w * BLOCK_Q + row];
+            const float* src = &O_part_smem[w * BLOCK_Q * HEAD_DIM + row * HEAD_DIM + col];
+            acc0 += src[0] * rsc;
+            acc1 += src[1] * rsc;
+        }
+
+        if (row < q_len) {
+            typename Traits::vec2 result = Traits::pack2(acc0 * norm, acc1 * norm);
+            *reinterpret_cast<typename Traits::vec2*>(&O[row * HEAD_DIM + col]) = result;
+        }
+    }
+}
+
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_nosplit_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q, const __nv_fp8_e4m3* S_K, const __nv_fp8_e4m3* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqfp4;
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e4m3);
+    constexpr int kv_phase_smem = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e4m3)
+                                + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 16) * sizeof(__nv_fp8_e4m3);
+    constexpr int smem_size = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+
+    auto kernel = fp4_attention_single_query_nosplit_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+}
+
+// CTA-cooperative launch: multiple warps per block, shared-memory reduction
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_cta_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q, const __nv_fp8_e4m3* S_K, const __nv_fp8_e4m3* S_V,
+    T* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int NUM_WARPS = 4;
+    constexpr int TB_SIZE = NUM_WARPS * WARP_SIZE_sqfp4;
+
+    // Smem: max of Q phase, KV phase (per-warp regions), reduction phase
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+    constexpr int kv_smem_per_warp = BLOCK_KV * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + BLOCK_KV * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3)
+                                    + HEAD_DIM * (BLOCK_KV / 2) * (int)sizeof(__nv_fp4x2_e2m1)
+                                    + HEAD_DIM * (BLOCK_KV / 16) * (int)sizeof(__nv_fp8_e4m3);
+    constexpr int kv_phase_smem = NUM_WARPS * kv_smem_per_warp;
+    constexpr int reduce_smem = (int)sizeof(float) * (NUM_WARPS * BLOCK_Q * 2
+                              + NUM_WARPS * BLOCK_Q * HEAD_DIM);
+    constexpr int smem_12 = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+    constexpr int smem_size = smem_12 > reduce_smem ? smem_12 : reduce_smem;
+
+    auto kernel = fp4_attention_single_query_cta_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM, NUM_WARPS>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    kernel<<<bs, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V, O,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+}
+
+// Split-KV launch: multiple blocks per batch element, requires workspace
+template<typename T, int HEAD_DIM>
+static void fp4_attention_single_query_split_launch(
+    const __nv_fp4x2_e2m1* Q, const __nv_fp4x2_e2m1* K, const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q, const __nv_fp8_e4m3* S_K, const __nv_fp8_e4m3* S_V,
+    T* O, float* workspace, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads) {
+
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int BLOCK_KV = 64;
+    constexpr int BLOCK_Q = 16;
+    constexpr int TB_SIZE = WARP_SIZE_sqfp4;
+
+    const int total_kv_blocks = cdiv_sqfp4(kv_len, BLOCK_KV);
+    int num_kv_splits = max(1, min(total_kv_blocks, cdiv_sqfp4(256, bs)));
+    num_kv_splits = min(num_kv_splits, total_kv_blocks);
+
+    float* O_partial      = workspace;
+    float* rowmax_partial = O_partial + bs * num_kv_splits * BLOCK_Q * HEAD_DIM;
+    float* rowsum_partial = rowmax_partial + bs * num_kv_splits * BLOCK_Q;
+    int* split_counter    = reinterpret_cast<int*>(rowsum_partial + bs * num_kv_splits * BLOCK_Q);
+
+    cudaMemsetAsync(split_counter, 0, bs * sizeof(int));
+
+    constexpr int q_phase_smem = BLOCK_Q * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                               + BLOCK_Q * SCALE_DIM * sizeof(__nv_fp8_e4m3);
+    constexpr int kv_phase_smem_single = BLOCK_KV * HEAD_DIM_2 * sizeof(__nv_fp4x2_e2m1)
+                                + BLOCK_KV * SCALE_DIM * sizeof(__nv_fp8_e4m3)
+                                + HEAD_DIM * (BLOCK_KV / 2) * sizeof(__nv_fp4x2_e2m1)
+                                + HEAD_DIM * (BLOCK_KV / 16) * sizeof(__nv_fp8_e4m3);
+    constexpr int kv_phase_smem = kv_phase_smem_single * 2;  // double-buffer
+    constexpr int smem_size = q_phase_smem > kv_phase_smem ? q_phase_smem : kv_phase_smem;
+
+    auto kernel = fp4_attention_single_query_kernel<T, BLOCK_KV, HEAD_DIM, HEAD_DIM_2, SCALE_DIM>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    dim3 grid(num_kv_splits, bs);
+    kernel<<<grid, TB_SIZE, smem_size>>>(
+        Q, K, V, S_Q, S_K, S_V,
+        O_partial, rowmax_partial, rowsum_partial,
+        O, split_counter,
+        bs, q_len, kv_len, kv_capacity, num_kv_splits, num_q_heads, num_kv_heads);
+}
+
+template<typename T>
+static void fp4_attention_single_query_nvfp4_typed(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim) {
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+    auto S_Q = reinterpret_cast<const __nv_fp8_e4m3*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e4m3*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e4m3*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+
+    constexpr int BLOCK_KV = 64;
+    const int total_kv_blocks = cdiv_sqfp4(kv_len, BLOCK_KV);
+
+    if (total_kv_blocks <= 4) {
+        if (head_dim == 64)
+            fp4_attention_single_query_nosplit_launch<T, 64>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+        else
+            fp4_attention_single_query_nosplit_launch<T, 128>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    } else {
+        if (head_dim == 64)
+            fp4_attention_single_query_cta_launch<T, 64>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+        else
+            fp4_attention_single_query_cta_launch<T, 128>(Q, K, V, S_Q, S_K, S_V, O, bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    }
+}
+
+void fp4_attention_single_query_nvfp4(
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* workspace_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16) {
+    if (is_bf16) {
+        fp4_attention_single_query_nvfp4_typed<__nv_bfloat16>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw, workspace_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        fp4_attention_single_query_nvfp4_typed<half>(
+            Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw, S_V_raw, O_raw, workspace_raw,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/nvfp4/thrift_attention.cu
+++ b/thrift-attention/csrc/cuda/sm120/nvfp4/thrift_attention.cu
@@ -1,0 +1,1075 @@
+#include <cstdint>
+#include <float.h>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+// ===========================================================================
+// Mixed-precision attention kernel.
+// FP4 is used for non-selected KV blocks; FP16 is used for selected KV blocks.
+// Grid: (batch * heads * query_blocks), one CTA per query tile.
+// ===========================================================================
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV_FP4, int HEAD_DIM,
+         int HEAD_DIM_2, int SCALE_DIM,
+         int NUM_WARPS, int WARP_Q>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void thrift_attention_kernel(
+    const T* Q_fp16_in,
+    const T* K_fp16_in,
+    const T* V_fp16_in,
+    const unsigned long long* topk_mask_in,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q,
+    const __nv_fp4x2_e2m1* K,
+    const __nv_fp4x2_e2m1* V,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K_FP4 = 64;
+    constexpr int MMA_N = 8;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+    const int v_kv = ta_cdiv(kv_capacity, 128) * 128;
+
+    Q   += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM_2;
+    K   += kv_bid * kv_capacity * HEAD_DIM_2;
+    V   += kv_bid * HEAD_DIM * (v_kv / 2);
+    S_Q += (q_bid * q_len + q_block_id * BLOCK_Q) * SCALE_DIM;
+    S_K += kv_bid * kv_capacity * SCALE_DIM;
+    S_V += kv_bid * v_kv * SCALE_DIM;
+    O   += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    rowmax_state += q_bid * q_len + q_block_id * BLOCK_Q;
+    rowsum_state += q_bid * q_len + q_block_id * BLOCK_Q;
+
+    Q_fp16_in += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    K_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    V_fp16_in += kv_bid * kv_len * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+
+    // ---- Persistent register state ----
+    uint32_t Q_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K_FP4][4];
+    uint32_t sfQ_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_K_FP4];
+
+    float rowmax[WARP_Q / MMA_M][2];
+    float rowsum[WARP_Q / MMA_M][2] = {};
+    float O_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        rowmax[mma_id_q][0] = -FLT_MAX;
+        rowmax[mma_id_q][1] = -FLT_MAX;
+    }
+
+    // ==================== PHASE 1: Load Q FP4 + scales -> registers ====================
+    const uint32_t Q_smem    = __cvta_generic_to_shared(smem);
+    const uint32_t Q_sf_smem = Q_smem + BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+
+    ta_gmem_to_smem<BLOCK_Q, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(Q_smem, Q, tid, HEAD_DIM_2);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    {
+        const int row_off = warp_id * WARP_Q + (lane_id % 16);
+        const int col_off = (lane_id / 16) * 16;
+        uint32_t Q_ld_base = ta_swizzle<HEAD_DIM_2>(Q_smem + row_off * HEAD_DIM_2 + col_off);
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                uint32_t addr = Q_ld_base;
+                addr += mma_id_q * MMA_M * HEAD_DIM_2;
+                addr ^= mma_id_d * (MMA_K_FP4 / 2);
+                ta_ldmatrix_x4(Q_rmem[mma_id_q][mma_id_d], addr);
+            }
+    }
+
+    ta_load_scales<BLOCK_Q, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(Q_sf_smem, S_Q, SCALE_DIM, tid);
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    {
+        int sf_row_q = 0;
+        if (lane_id % 4 == 0)      sf_row_q = (lane_id / 4);
+        else if (lane_id % 4 == 1) sf_row_q = (lane_id / 4) + 8;
+
+        for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                const int row = warp_id * WARP_Q + mma_id_q * MMA_M + sf_row_q;
+                const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                asm volatile("ld.shared.u32 %0, [%1];"
+                    : "=r"(sfQ_rmem[mma_id_q][mma_id_d])
+                    : "r"(Q_sf_smem + offset));
+            }
+    }
+
+    // ==================== PHASE 1b: Build per-query-block top-k mask ====================
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int max_kv_pos = q_block_start + BLOCK_Q - 1;
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV_FP4);
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV_FP4 + 1, total_kv_iters)
+        : total_kv_iters;
+
+
+    constexpr int TOPK_UNIT_TOKENS = 64;
+    constexpr int TOPK_UNITS_PER_ITER = BLOCK_KV_FP4 / TOPK_UNIT_TOKENS;
+    static_assert(BLOCK_KV_FP4 == 64 || BLOCK_KV_FP4 == 128,
+                  "attention top-k bitset assumes 64-token top-k units");
+    const int total_topk_units = ta_cdiv(kv_len, TOPK_UNIT_TOKENS);
+
+    constexpr int MAX_KV_BLOCK_WORDS = 32;  // 2048 * 64 tokens
+    const int num_kv_words = min(min(ta_cdiv(total_topk_units, 64), topk_word_count), MAX_KV_BLOCK_WORDS);
+    __shared__ unsigned long long topk_mask[MAX_KV_BLOCK_WORDS];
+    if (tid < MAX_KV_BLOCK_WORDS) {
+        const int64_t mask_row =
+            (static_cast<int64_t>(q_bid) * num_q_blocks + q_block_id) * topk_word_count;
+        topk_mask[tid] = (tid < num_kv_words)
+            ? topk_mask_in[mask_row + tid]
+            : 0ULL;
+    }
+    __syncthreads();
+
+    // ==================== PHASE 2: FP4 non-selected KV pass ====================
+
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+
+    // FP4 smem addresses
+    const uint32_t K_smem_fp4    = smem_base;
+    const uint32_t K_sf_smem     = K_smem_fp4 + BLOCK_KV_FP4 * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1);
+    const uint32_t V_smem_fp4    = K_sf_smem + BLOCK_KV_FP4 * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+    const uint32_t V_sf_smem_fp4 = V_smem_fp4 + HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1);
+
+    uint32_t K_ld_base_fp4;
+    {
+        const int row_off = lane_id % 8;
+        const int col_off = (lane_id / 8) * 16;
+        K_ld_base_fp4 = ta_swizzle<HEAD_DIM_2>(K_smem_fp4 + row_off * HEAD_DIM_2 + col_off);
+    }
+
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);
+    const int q_row_lower = q_row_upper + 8;
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base  = (lane_id % 4) * 2;
+
+    for (int kv_iter = 0; kv_iter < num_kv_iters; kv_iter++) {
+        bool is_topk = false;
+        #pragma unroll
+        for (int u = 0; u < TOPK_UNITS_PER_ITER; u++) {
+            const int topk_unit = kv_iter * TOPK_UNITS_PER_ITER + u;
+            const int topk_word = topk_unit >> 6;
+            is_topk |= (topk_word < MAX_KV_BLOCK_WORDS) &&
+                       ((topk_mask[topk_word] >> (topk_unit & 63)) & 1ULL);
+        }
+        const int k_block_start = kv_iter * BLOCK_KV_FP4;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV_FP4 - 1) > q_block_start);
+
+        if (is_topk) {
+            continue;
+        } else {
+            // ---- FP4 path: process 64 KV rows ----
+            const __nv_fp4x2_e2m1* K_ptr = K + kv_iter * BLOCK_KV_FP4 * HEAD_DIM_2;
+            const __nv_fp8_e4m3*   SK_ptr = S_K + kv_iter * BLOCK_KV_FP4 * SCALE_DIM;
+            const __nv_fp4x2_e2m1* V_ptr = V + kv_iter * BLOCK_KV_FP4 / 2;
+            const __nv_fp8_e4m3*   SV_ptr = S_V + kv_iter * BLOCK_KV_FP4 / 16;
+
+            // K load (group 1)
+            ta_gmem_to_smem<BLOCK_KV_FP4, HEAD_DIM_2, TB_SIZE, __nv_fp4x2_e2m1>(K_smem_fp4, K_ptr, tid, HEAD_DIM_2);
+            ta_load_scales<BLOCK_KV_FP4, SCALE_DIM, TB_SIZE, __nv_fp8_e4m3>(K_sf_smem, SK_ptr, SCALE_DIM, tid);
+            asm volatile("cp.async.commit_group;");
+            // V load (group 2) — overlaps with QK^T compute
+            ta_gmem_to_smem<HEAD_DIM, BLOCK_KV_FP4 / 2, TB_SIZE, __nv_fp4x2_e2m1>(V_smem_fp4, V_ptr, tid, v_kv / 2);
+            ta_load_scales<HEAD_DIM, BLOCK_KV_FP4 / 16, TB_SIZE, __nv_fp8_e4m3>(V_sf_smem_fp4, SV_ptr, v_kv / 16, tid);
+            asm volatile("cp.async.commit_group;");
+            // Wait for K only (V still in flight)
+            asm volatile("cp.async.wait_group 1;");
+            __syncthreads();
+
+            uint32_t K_rmem[BLOCK_KV_FP4 / MMA_N][HEAD_DIM / MMA_K_FP4][2];
+            uint32_t sfK_rmem[BLOCK_KV_FP4 / MMA_N][HEAD_DIM / MMA_K_FP4];
+
+            if constexpr (HEAD_DIM / MMA_K_FP4 >= 2) {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    uint32_t addr = K_ld_base_fp4 + mma_id_kv * MMA_N * HEAD_DIM_2;
+                    ta_ldmatrix_x4(K_rmem[mma_id_kv][0], addr);
+                }
+            } else {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                        uint32_t addr = K_ld_base_fp4;
+                        addr += mma_id_kv * MMA_N * HEAD_DIM_2;
+                        addr ^= mma_id_d * (MMA_K_FP4 / 2);
+                        ta_ldmatrix_x2(K_rmem[mma_id_kv][mma_id_d], addr);
+                    }
+            }
+
+            const int sf_row_k = lane_id / 4;
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++) {
+                    const int row = mma_id_kv * MMA_N + sf_row_k;
+                    const uint32_t offset = (row * SCALE_DIM + mma_id_d * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                    asm volatile("ld.shared.u32 %0, [%1];"
+                        : "=r"(sfK_rmem[mma_id_kv][mma_id_d])
+                        : "r"(K_sf_smem + offset));
+                }
+
+            float S_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_N][4] = {};
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP4; mma_id_d++)
+                        ta_mma_m16n8k64_nvfp4(
+                            Q_rmem[mma_id_q][mma_id_d],
+                            K_rmem[mma_id_kv][mma_id_d],
+                            sfQ_rmem[mma_id_q][mma_id_d],
+                            sfK_rmem[mma_id_kv][mma_id_d],
+                            S_rmem[mma_id_q][mma_id_kv]);
+
+            if constexpr (CAUSAL) {
+                if (needs_causal_mask) {
+                    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                        for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                            const int k_phys_0 = mma_id_kv * MMA_N + k_col_base;
+                            const int k_phys_1 = k_phys_0 + 1;
+                            const int k_col_0 = k_block_start + ta_kv_logical_from_physical(k_phys_0);
+                            const int k_col_1 = k_block_start + ta_kv_logical_from_physical(k_phys_1);
+                            if (k_col_0 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][0] = -INFINITY;
+                            if (k_col_1 > q_row_upper_global) S_rmem[mma_id_q][mma_id_kv][1] = -INFINITY;
+                            if (k_col_0 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][2] = -INFINITY;
+                            if (k_col_1 > q_row_lower_global) S_rmem[mma_id_q][mma_id_kv][3] = -INFINITY;
+                        }
+                }
+            }
+
+            uint32_t S_fp4_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_K_FP4][4];
+            uint32_t S_fp4_s_rmem[WARP_Q / MMA_M][BLOCK_KV_FP4 / MMA_K_FP4];
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++)
+                    for (int reg_id = 0; reg_id < 4; reg_id++)
+                        S_rmem[mma_id_q][mma_id_kv][reg_id] *= softmax_scale;
+
+                float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    float *r = S_rmem[mma_id_q][mma_id_kv];
+                    this_rowmax[0] = max(this_rowmax[0], max(r[0], r[1]));
+                    this_rowmax[1] = max(this_rowmax[1], max(r[2], r[3]));
+                }
+                this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+                this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+                this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+                this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+                this_rowmax[0] = max(this_rowmax[0], rowmax[mma_id_q][0]);
+                this_rowmax[1] = max(this_rowmax[1], rowmax[mma_id_q][1]);
+
+                float rescale[2] = {
+                    __expf(rowmax[mma_id_q][0] - this_rowmax[0]),
+                    __expf(rowmax[mma_id_q][1] - this_rowmax[1])
+                };
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                    O_rmem[mma_id_q][mma_id_d][0] *= rescale[0];
+                    O_rmem[mma_id_q][mma_id_d][1] *= rescale[0];
+                    O_rmem[mma_id_q][mma_id_d][2] *= rescale[1];
+                    O_rmem[mma_id_q][mma_id_d][3] *= rescale[1];
+                }
+                rowmax[mma_id_q][0] = this_rowmax[0];
+                rowmax[mma_id_q][1] = this_rowmax[1];
+
+                float this_rowsumexp[2] = {};
+                for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_N; mma_id_kv++) {
+                    float *r = S_rmem[mma_id_q][mma_id_kv];
+                    r[0] = __expf(r[0] - rowmax[mma_id_q][0]);
+                    r[1] = __expf(r[1] - rowmax[mma_id_q][0]);
+                    r[2] = __expf(r[2] - rowmax[mma_id_q][1]);
+                    r[3] = __expf(r[3] - rowmax[mma_id_q][1]);
+                    this_rowsumexp[0] += r[0] + r[1];
+                    this_rowsumexp[1] += r[2] + r[3];
+                }
+                this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+                this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+                this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+                this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+                rowsum[mma_id_q][0] = rowsum[mma_id_q][0] * rescale[0] + this_rowsumexp[0];
+                rowsum[mma_id_q][1] = rowsum[mma_id_q][1] * rescale[1] + this_rowsumexp[1];
+
+                constexpr float FP4_RANGE = 448.0f * 6.0f;
+                constexpr float FP4_MAX   = 6.0f;
+
+                float sf_P_upper[BLOCK_KV_FP4 / MMA_N / 2];
+                float sf_P_lower[BLOCK_KV_FP4 / MMA_N / 2];
+                for (int blk = 0; blk < BLOCK_KV_FP4 / MMA_N / 2; blk++) {
+                    const int t0 = 2 * blk, t1 = t0 + 1;
+                    const float gmax_upper = rowmax[mma_id_q][0];
+                    const float gmax_lower = rowmax[mma_id_q][1];
+                    const bool valid_upper = gmax_upper > -FLT_MAX * 0.5f;
+                    const bool valid_lower = gmax_lower > -FLT_MAX * 0.5f;
+                    const float inv_upper = valid_upper ? (FP4_MAX * __expf(rowmax[mma_id_q][0] - gmax_upper)) : 0.0f;
+                    const float inv_lower = valid_lower ? (FP4_MAX * __expf(rowmax[mma_id_q][1] - gmax_lower)) : 0.0f;
+                    sf_P_upper[blk] = valid_upper ? (FP4_RANGE / FP4_MAX * __expf(gmax_upper - rowmax[mma_id_q][0])) : 1.0f;
+                    sf_P_lower[blk] = valid_lower ? (FP4_RANGE / FP4_MAX * __expf(gmax_lower - rowmax[mma_id_q][1])) : 1.0f;
+                    S_rmem[mma_id_q][t0][0] *= inv_upper;  S_rmem[mma_id_q][t0][1] *= inv_upper;
+                    S_rmem[mma_id_q][t1][0] *= inv_upper;  S_rmem[mma_id_q][t1][1] *= inv_upper;
+                    S_rmem[mma_id_q][t0][2] *= inv_lower;  S_rmem[mma_id_q][t0][3] *= inv_lower;
+                    S_rmem[mma_id_q][t1][2] *= inv_lower;  S_rmem[mma_id_q][t1][3] *= inv_lower;
+                }
+
+                for (int g = 0; g < BLOCK_KV_FP4 / MMA_N / 4; g++) {
+                    float *r0 = S_rmem[mma_id_q][g*4], *r1 = S_rmem[mma_id_q][g*4+1],
+                          *r2 = S_rmem[mma_id_q][g*4+2], *r3 = S_rmem[mma_id_q][g*4+3];
+                    S_fp4_rmem[mma_id_q][0][2*g]   = ta_cvt_8xf32_to_e2m1_packed(
+                        r0[1],r0[0],r1[1],r1[0], r2[1],r2[0],r3[1],r3[0]);
+                    S_fp4_rmem[mma_id_q][0][2*g+1] = ta_cvt_8xf32_to_e2m1_packed(
+                        r0[3],r0[2],r1[3],r1[2], r2[3],r2[2],r3[3],r3[2]);
+                }
+
+                for (int mma_sc_id = 0; mma_sc_id < BLOCK_KV_FP4 / MMA_K_FP4; mma_sc_id++) {
+                    int base = mma_sc_id * 4;
+                    uint32_t sfP_upper_packed = ta_cvt_4xf32_to_e4m3_packed(
+                        sf_P_upper[base+1], sf_P_upper[base+0],
+                        sf_P_upper[base+3], sf_P_upper[base+2]);
+                    uint32_t sfP_lower_packed = ta_cvt_4xf32_to_e4m3_packed(
+                        sf_P_lower[base+1], sf_P_lower[base+0],
+                        sf_P_lower[base+3], sf_P_lower[base+2]);
+                    S_fp4_s_rmem[mma_id_q][mma_sc_id] =
+                        (lane_id % 4 == 0) ? sfP_upper_packed : sfP_lower_packed;
+                }
+            }
+
+            // Wait for V load to complete
+            asm volatile("cp.async.wait_group 0;");
+            __syncthreads();
+
+            uint32_t V_rmem[BLOCK_KV_FP4 / MMA_K_FP4][HEAD_DIM / MMA_N][2];
+            uint32_t sfV_rmem[BLOCK_KV_FP4 / MMA_K_FP4][HEAD_DIM / MMA_N];
+
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d += 2) {
+                    const int n_idx = mma_id_d * MMA_N + (lane_id / 16) * MMA_N + (lane_id % 8);
+                    const int k_byte_offset = mma_id_kv * 32 + ((lane_id % 16) / 8) * 16;
+                    uint32_t addr = ta_swizzle<BLOCK_KV_FP4 / 2>(
+                        V_smem_fp4 + n_idx * (BLOCK_KV_FP4 / 2) + k_byte_offset);
+                    ta_ldmatrix_x4(V_rmem[mma_id_kv][mma_id_d], addr);
+                }
+
+            constexpr int V_SF_STRIDE = BLOCK_KV_FP4 / 16;
+            const int sf_col_v = lane_id / 4;
+            for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+                    const int hd_col = mma_id_d * MMA_N + sf_col_v;
+                    const uint32_t offset = (hd_col * V_SF_STRIDE + mma_id_kv * 4) * (uint32_t)sizeof(__nv_fp8_e4m3);
+                    asm volatile("ld.shared.u32 %0, [%1];"
+                        : "=r"(sfV_rmem[mma_id_kv][mma_id_d])
+                        : "r"(V_sf_smem_fp4 + offset));
+                }
+
+            for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+                for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+                    for (int mma_id_kv = 0; mma_id_kv < BLOCK_KV_FP4 / MMA_K_FP4; mma_id_kv++)
+                        ta_mma_m16n8k64_nvfp4(
+                            S_fp4_rmem[mma_id_q][mma_id_kv],
+                            V_rmem[mma_id_kv][mma_id_d],
+                            S_fp4_s_rmem[mma_id_q][mma_id_kv],
+                            sfV_rmem[mma_id_kv][mma_id_d],
+                            O_rmem[mma_id_q][mma_id_d]);
+
+            __syncthreads();
+        }
+    }
+
+    // ==================== PHASE 3: Save FP4 partial state + output ====================
+    constexpr float FP4_RANGE_INV = 1.0f / (448.0f * 6.0f);
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        if ((lane_id & 3) == 0) {
+            const int row_upper = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int row_lower = row_upper + 8;
+            rowmax_state[row_upper] = rowmax[mma_id_q][0];
+            rowmax_state[row_lower] = rowmax[mma_id_q][1];
+            rowsum_state[row_upper] = rowsum[mma_id_q][0];
+            rowsum_state[row_lower] = rowsum[mma_id_q][1];
+        }
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            const float norm0 = rowsum[mma_id_q][0] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][0]
+                : 0.0f;
+            const float norm1 = rowsum[mma_id_q][1] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][1]
+                : 0.0f;
+
+            regs[0] *= norm0;  regs[1] *= norm0;
+            regs[2] *= norm1;  regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+    }
+}
+
+template<typename T, bool CAUSAL, int BLOCK_Q, int BLOCK_KV_FP4, int HEAD_DIM,
+         int NUM_WARPS, int WARP_Q, int TOPK_BUCKET>
+__launch_bounds__(NUM_WARPS * TA_WARP_SIZE)
+__global__
+void thrift_attention_fp16_finalize_kernel(
+    const T* Q_fp16_in,
+    const T* K_fp16_in,
+    const T* V_fp16_in,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    const float* rowmax_state,
+    const float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    using Traits = PrecisionTraits<T>;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int MMA_M = 16;
+    constexpr int MMA_K_FP16 = 16;
+    constexpr int MMA_N = 8;
+    constexpr float FP4_RANGE = 448.0f * 6.0f;
+    constexpr float FP4_RANGE_INV = 1.0f / FP4_RANGE;
+
+    const float softmax_scale = rsqrtf(static_cast<float>(HEAD_DIM));
+
+    const int bid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int warp_id = tid / TA_WARP_SIZE;
+    const int lane_id = tid % TA_WARP_SIZE;
+
+    const int num_q_blocks = ta_cdiv(q_len, BLOCK_Q);
+    const int q_bid = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int batch_id = q_bid / num_q_heads;
+    const int q_head = q_bid - batch_id * num_q_heads;
+    const int kv_head = q_head / (num_q_heads / num_kv_heads);
+    const int kv_bid = batch_id * num_kv_heads + kv_head;
+
+    Q_fp16_in += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    K_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    V_fp16_in += kv_bid * kv_len * HEAD_DIM;
+    O += (q_bid * q_len + q_block_id * BLOCK_Q) * HEAD_DIM;
+    rowmax_state += q_bid * q_len + q_block_id * BLOCK_Q;
+    rowsum_state += q_bid * q_len + q_block_id * BLOCK_Q;
+
+    const int q_block_start = q_block_id * BLOCK_Q;
+    const int max_kv_pos = q_block_start + BLOCK_Q - 1;
+    const int total_kv_iters = ta_cdiv(kv_len, BLOCK_KV_FP4);
+    const int num_kv_iters = CAUSAL
+        ? min(max_kv_pos / BLOCK_KV_FP4 + 1, total_kv_iters)
+        : total_kv_iters;
+
+    const int32_t* selected_row =
+        selected_blocks + (static_cast<int64_t>(q_bid) * num_q_blocks + q_block_id) * topk_count;
+
+    float rowmax[WARP_Q / MMA_M][2];
+    float rowsum[WARP_Q / MMA_M][2];
+    float O_rmem[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4];
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++) {
+        const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+        rowmax[mma_id_q][0] = rowmax_state[row];
+        rowmax[mma_id_q][1] = rowmax_state[row + 8];
+        rowsum[mma_id_q][0] = rowsum_state[row];
+        rowsum[mma_id_q][1] = rowsum_state[row + 8];
+
+        const float partial_scale0 = rowsum[mma_id_q][0] * FP4_RANGE;
+        const float partial_scale1 = rowsum[mma_id_q][1] * FP4_RANGE;
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            const T* upper = O + row * HEAD_DIM + col;
+            const T* lower = O + (row + 8) * HEAD_DIM + col;
+            O_rmem[mma_id_q][mma_id_d][0] = Traits::to_float(upper[0]) * partial_scale0;
+            O_rmem[mma_id_q][mma_id_d][1] = Traits::to_float(upper[1]) * partial_scale0;
+            O_rmem[mma_id_q][mma_id_d][2] = Traits::to_float(lower[0]) * partial_scale1;
+            O_rmem[mma_id_q][mma_id_d][3] = Traits::to_float(lower[1]) * partial_scale1;
+        }
+    }
+
+    extern __shared__ uint8_t smem[];
+    const uint32_t smem_base = __cvta_generic_to_shared(smem);
+    const uint32_t Q_fp16_smem = smem_base;
+    const uint32_t KV_fp16_smem = smem_base;
+
+    constexpr int Q_FP16_ROW_BYTES = HEAD_DIM * (int)sizeof(T);
+    constexpr int Q_FP16_TOTAL_BYTES = BLOCK_Q * Q_FP16_ROW_BYTES;
+    constexpr int Q_FP16_TOTAL_CHUNKS = Q_FP16_TOTAL_BYTES / 16;
+
+    for (int chunk = tid; chunk < Q_FP16_TOTAL_CHUNKS; chunk += TB_SIZE) {
+        const int byte_off = chunk * 16;
+        const int row = byte_off / Q_FP16_ROW_BYTES;
+        const int col = byte_off % Q_FP16_ROW_BYTES;
+        uint32_t dst = ta_swizzle<Q_FP16_ROW_BYTES>(Q_fp16_smem + row * Q_FP16_ROW_BYTES + col);
+        const char* src = reinterpret_cast<const char*>(Q_fp16_in + row * HEAD_DIM) + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;" :: "r"(dst), "l"(src));
+    }
+    asm volatile("cp.async.commit_group;");
+    asm volatile("cp.async.wait_all;");
+    __syncthreads();
+
+    uint32_t Q_fp16_rmem[HEAD_DIM / MMA_K_FP16][4];
+    {
+        const int q_row = warp_id * WARP_Q + (lane_id % 16);
+        const int q_col_bytes = (lane_id / 16) * 8 * (int)sizeof(T);
+        uint32_t Q_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            Q_fp16_smem + q_row * Q_FP16_ROW_BYTES + q_col_bytes);
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++) {
+            uint32_t addr = Q_fp16_ld_base;
+            addr ^= mma_id_d * MMA_K_FP16 * (int)sizeof(T);
+            ta_ldmatrix_x4(Q_fp16_rmem[mma_id_d], addr);
+        }
+    }
+    __syncthreads();
+
+    const int q_row_upper = warp_id * WARP_Q + (lane_id / 4);
+    const int q_row_lower = q_row_upper + 8;
+    const int q_row_upper_global = q_block_start + q_row_upper;
+    const int q_row_lower_global = q_block_start + q_row_lower;
+    const int k_col_base = (lane_id % 4) * 2;
+
+    const int selected_limit = min(min(topk_count, TOPK_BUCKET), num_kv_iters);
+    for (int selected_idx = 0; selected_idx < selected_limit; selected_idx++) {
+        const int kv_iter = selected_row[selected_idx];
+        if (kv_iter < 0 || kv_iter >= num_kv_iters) {
+            continue;
+        }
+
+        constexpr int FP16_ROWS = BLOCK_KV_FP4;
+        constexpr int FP16_N_TILES = FP16_ROWS / MMA_N;
+        constexpr int FP16_PV_CHUNKS = FP16_ROWS / MMA_K_FP16;
+
+        const int k_block_start = kv_iter * BLOCK_KV_FP4;
+        const bool needs_causal_mask = CAUSAL && ((k_block_start + BLOCK_KV_FP4 - 1) > q_block_start);
+
+        const T* K_fp16_ptr = K_fp16_in + kv_iter * FP16_ROWS * HEAD_DIM;
+        ta_gmem_to_smem<FP16_ROWS, HEAD_DIM, TB_SIZE, T>(
+            KV_fp16_smem, K_fp16_ptr, tid, HEAD_DIM);
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_all;");
+        __syncthreads();
+
+        uint32_t K_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            KV_fp16_smem + ((lane_id % 8) * HEAD_DIM + (lane_id / 8) * 8) * (int)sizeof(T));
+
+        float S_fp16[FP16_N_TILES][4] = {};
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+            uint32_t K_tile[HEAD_DIM / MMA_K_FP16][2];
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++) {
+                uint32_t addr = K_fp16_ld_base
+                    + mma_id_kv * MMA_N * Q_FP16_ROW_BYTES;
+                addr ^= mma_id_d * MMA_K_FP16 * (int)sizeof(T);
+                ta_ldmatrix_x2(K_tile[mma_id_d], addr);
+            }
+            for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_K_FP16; mma_id_d++)
+                Traits::mma(
+                    Q_fp16_rmem[mma_id_d], K_tile[mma_id_d], S_fp16[mma_id_kv]);
+        }
+
+        __syncthreads();
+        const T* V_fp16_ptr = V_fp16_in + kv_iter * FP16_ROWS * HEAD_DIM;
+        ta_gmem_to_smem<FP16_ROWS, HEAD_DIM, TB_SIZE, T>(
+            KV_fp16_smem, V_fp16_ptr, tid, HEAD_DIM);
+        asm volatile("cp.async.commit_group;");
+
+        if constexpr (CAUSAL) {
+            if (needs_causal_mask) {
+                for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+                    const int k_col_0 = k_block_start + mma_id_kv * MMA_N + k_col_base;
+                    const int k_col_1 = k_col_0 + 1;
+                    if (k_col_0 > q_row_upper_global) S_fp16[mma_id_kv][0] = -INFINITY;
+                    if (k_col_1 > q_row_upper_global) S_fp16[mma_id_kv][1] = -INFINITY;
+                    if (k_col_0 > q_row_lower_global) S_fp16[mma_id_kv][2] = -INFINITY;
+                    if (k_col_1 > q_row_lower_global) S_fp16[mma_id_kv][3] = -INFINITY;
+                }
+            }
+        }
+
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++)
+            for (int r = 0; r < 4; r++)
+                S_fp16[mma_id_kv][r] *= softmax_scale;
+
+        float this_rowmax[2] = {-FLT_MAX, -FLT_MAX};
+        for (int mma_id_kv = 0; mma_id_kv < FP16_N_TILES; mma_id_kv++) {
+            this_rowmax[0] = max(this_rowmax[0], max(S_fp16[mma_id_kv][0], S_fp16[mma_id_kv][1]));
+            this_rowmax[1] = max(this_rowmax[1], max(S_fp16[mma_id_kv][2], S_fp16[mma_id_kv][3]));
+        }
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 1));
+        this_rowmax[0] = max(this_rowmax[0], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[0], 2));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 1));
+        this_rowmax[1] = max(this_rowmax[1], __shfl_xor_sync(0xFFFFFFFF, this_rowmax[1], 2));
+
+        this_rowmax[0] = max(this_rowmax[0], rowmax[0][0]);
+        this_rowmax[1] = max(this_rowmax[1], rowmax[0][1]);
+
+        float rescale[2] = {
+            __expf(rowmax[0][0] - this_rowmax[0]),
+            __expf(rowmax[0][1] - this_rowmax[1])
+        };
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            O_rmem[0][mma_id_d][0] *= rescale[0];
+            O_rmem[0][mma_id_d][1] *= rescale[0];
+            O_rmem[0][mma_id_d][2] *= rescale[1];
+            O_rmem[0][mma_id_d][3] *= rescale[1];
+        }
+        rowmax[0][0] = this_rowmax[0];
+        rowmax[0][1] = this_rowmax[1];
+
+        float this_rowsumexp[2] = {};
+        uint32_t P_rmem[FP16_PV_CHUNKS][4];
+
+        for (int mma_blk = 0; mma_blk < FP16_PV_CHUNKS; mma_blk++) {
+            const int t0 = 2 * mma_blk;
+            const int t1 = t0 + 1;
+            float *r0 = S_fp16[t0];
+            float *r1 = S_fp16[t1];
+
+            r0[0] = __expf(r0[0] - rowmax[0][0]);
+            r0[1] = __expf(r0[1] - rowmax[0][0]);
+            r0[2] = __expf(r0[2] - rowmax[0][1]);
+            r0[3] = __expf(r0[3] - rowmax[0][1]);
+
+            r1[0] = __expf(r1[0] - rowmax[0][0]);
+            r1[1] = __expf(r1[1] - rowmax[0][0]);
+            r1[2] = __expf(r1[2] - rowmax[0][1]);
+            r1[3] = __expf(r1[3] - rowmax[0][1]);
+
+            this_rowsumexp[0] += r0[0] + r0[1] + r1[0] + r1[1];
+            this_rowsumexp[1] += r0[2] + r0[3] + r1[2] + r1[3];
+
+            typename Traits::vec2* p = reinterpret_cast<typename Traits::vec2*>(P_rmem[mma_blk]);
+            p[0] = Traits::pack2(r0[0] * FP4_RANGE, r0[1] * FP4_RANGE);
+            p[1] = Traits::pack2(r0[2] * FP4_RANGE, r0[3] * FP4_RANGE);
+            p[2] = Traits::pack2(r1[0] * FP4_RANGE, r1[1] * FP4_RANGE);
+            p[3] = Traits::pack2(r1[2] * FP4_RANGE, r1[3] * FP4_RANGE);
+        }
+
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 1);
+        this_rowsumexp[0] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[0], 2);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 1);
+        this_rowsumexp[1] += __shfl_xor_sync(0xFFFFFFFF, this_rowsumexp[1], 2);
+        rowsum[0][0] = rowsum[0][0] * rescale[0] + this_rowsumexp[0];
+        rowsum[0][1] = rowsum[0][1] * rescale[1] + this_rowsumexp[1];
+
+        asm volatile("cp.async.wait_all;");
+        __syncthreads();
+
+        uint32_t V_fp16_ld_base = ta_swizzle<Q_FP16_ROW_BYTES>(
+            KV_fp16_smem + ((lane_id % 16) * HEAD_DIM + (lane_id / 16) * 8) * (int)sizeof(T));
+
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++)
+            for (int mma_id_kv = 0; mma_id_kv < FP16_PV_CHUNKS; mma_id_kv++) {
+                uint32_t V_tile[2];
+                uint32_t addr = V_fp16_ld_base
+                    + mma_id_kv * MMA_K_FP16 * Q_FP16_ROW_BYTES;
+                addr ^= mma_id_d * MMA_N * (int)sizeof(T);
+                ta_ldmatrix_x2_trans(V_tile, addr);
+                Traits::mma(P_rmem[mma_id_kv], V_tile, O_rmem[0][mma_id_d]);
+            }
+
+        __syncthreads();
+    }
+
+    for (int mma_id_q = 0; mma_id_q < WARP_Q / MMA_M; mma_id_q++)
+        for (int mma_id_d = 0; mma_id_d < HEAD_DIM / MMA_N; mma_id_d++) {
+            const int row = warp_id * WARP_Q + mma_id_q * MMA_M + (lane_id / 4);
+            const int col = mma_id_d * MMA_N + (lane_id % 4) * 2;
+            float *regs = O_rmem[mma_id_q][mma_id_d];
+
+            const float norm0 = rowsum[mma_id_q][0] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][0]
+                : 0.0f;
+            const float norm1 = rowsum[mma_id_q][1] > 0.0f
+                ? FP4_RANGE_INV / rowsum[mma_id_q][1]
+                : 0.0f;
+
+            regs[0] *= norm0;  regs[1] *= norm0;
+            regs[2] *= norm1;  regs[3] *= norm1;
+
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 0) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[0], regs[1]);
+            reinterpret_cast<typename Traits::vec2*>(O + (row + 8) * HEAD_DIM + col)[0] =
+                Traits::pack2(regs[2], regs[3]);
+        }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4, int TOPK_BUCKET>
+static void launch_thrift_attention_fp16_finalize(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+    constexpr int q_fp16_smem = BLOCK_Q * HEAD_DIM * (int)sizeof(T);
+    constexpr int fp16_kv_smem = BLOCK_KV_FP4 * HEAD_DIM * (int)sizeof(T);
+    constexpr int fp16_smem = (q_fp16_smem > fp16_kv_smem) ? q_fp16_smem : fp16_kv_smem;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    auto fp16_finalize_kernel = thrift_attention_fp16_finalize_kernel<
+        T, CAUSAL, BLOCK_Q, BLOCK_KV_FP4, HEAD_DIM, NUM_WARPS, WARP_Q, TOPK_BUCKET>;
+
+    cudaFuncSetAttribute(fp16_finalize_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, fp16_smem);
+
+    fp16_finalize_kernel<<<num_blocks, TB_SIZE, fp16_smem>>>(
+        Q_fp16, K_fp16, V_fp16,
+        selected_blocks, topk_count,
+        O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4>
+static void dispatch_thrift_attention_fp16_finalize(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    if (topk_count <= 1)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 1>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 2)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 2>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 4)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 4>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 8)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 8>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 16)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 16>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 32)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 32>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 64)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 64>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 128)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 128>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 256)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 256>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    if (topk_count <= 512)
+        return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 512>(
+            Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+            rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+    return launch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4, 2048>(
+        Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count, O,
+        rowmax_state, rowsum_state, bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int BLOCK_Q, int BLOCK_KV_FP4>
+static void launch_thrift_attention(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    const unsigned long long* topk_mask,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    constexpr int HEAD_DIM_2 = HEAD_DIM / 2;
+    constexpr int SCALE_DIM = HEAD_DIM / 16;
+    constexpr int WARP_Q = 16;
+    constexpr int NUM_WARPS = BLOCK_Q / WARP_Q;
+    constexpr int TB_SIZE = NUM_WARPS * TA_WARP_SIZE;
+
+    const int num_blocks = bs * ta_cdiv(q_len, BLOCK_Q);
+
+    constexpr int q_phase_smem =
+        BLOCK_Q * HEAD_DIM_2 * (int)sizeof(__nv_fp4x2_e2m1) +
+        BLOCK_Q * SCALE_DIM * (int)sizeof(__nv_fp8_e4m3);
+
+    constexpr int v_phase_smem =
+        HEAD_DIM * (BLOCK_KV_FP4 / 2) * (int)sizeof(__nv_fp4x2_e2m1) +
+        HEAD_DIM * (BLOCK_KV_FP4 / 16) * (int)sizeof(__nv_fp8_e4m3);
+
+    constexpr int fp4_kv_smem = q_phase_smem + v_phase_smem;
+
+    auto fp4_state_kernel = thrift_attention_kernel<
+        T, CAUSAL, BLOCK_Q, BLOCK_KV_FP4, HEAD_DIM,
+        HEAD_DIM_2, SCALE_DIM, NUM_WARPS, WARP_Q>;
+
+    cudaFuncSetAttribute(fp4_state_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, fp4_kv_smem);
+
+    fp4_state_kernel<<<num_blocks, TB_SIZE, fp4_kv_smem>>>(
+        Q_fp16, K_fp16, V_fp16,
+        topk_mask, topk_word_count,
+        Q_fp4, K_fp4, V_fp4,
+        S_Q, S_K, S_V, O,
+        rowmax_state, rowsum_state,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+
+    dispatch_thrift_attention_fp16_finalize<T, CAUSAL, HEAD_DIM, BLOCK_Q, BLOCK_KV_FP4>(
+        Q_fp16, K_fp16, V_fp16,
+        selected_blocks, topk_count,
+        O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+static void dispatch_thrift_attention(
+    const T* Q_fp16,
+    const T* K_fp16,
+    const T* V_fp16,
+    const int32_t* selected_blocks,
+    int topk_count,
+    const unsigned long long* topk_mask,
+    int topk_word_count,
+    const __nv_fp4x2_e2m1* Q_fp4,
+    const __nv_fp4x2_e2m1* K_fp4,
+    const __nv_fp4x2_e2m1* V_fp4,
+    const __nv_fp8_e4m3* S_Q,
+    const __nv_fp8_e4m3* S_K,
+    const __nv_fp8_e4m3* S_V,
+    T* O,
+    float* rowmax_state,
+    float* rowsum_state,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads)
+{
+    return launch_thrift_attention<T, CAUSAL, HEAD_DIM, 64, 64>(
+        Q_fp16, K_fp16, V_fp16, selected_blocks, topk_count,
+        topk_mask, topk_word_count, Q_fp4, K_fp4, V_fp4,
+        S_Q, S_K, S_V, O, rowmax_state, rowsum_state,
+        bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+template<typename T, bool CAUSAL>
+static void thrift_attention_nvfp4_typed(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim)
+{
+    auto Q_fp16 = reinterpret_cast<const T*>(Q_fp16_raw);
+    auto K_fp16 = reinterpret_cast<const T*>(K_fp16_raw);
+    auto V_fp16 = reinterpret_cast<const T*>(V_fp16_raw);
+    auto selected_blocks = reinterpret_cast<const int32_t*>(selected_blocks_raw);
+    auto topk_mask = reinterpret_cast<const unsigned long long*>(topk_mask_raw);
+
+    auto Q = reinterpret_cast<const __nv_fp4x2_e2m1*>(Q_raw);
+    auto K = reinterpret_cast<const __nv_fp4x2_e2m1*>(K_raw);
+    auto V = reinterpret_cast<const __nv_fp4x2_e2m1*>(V_raw);
+
+    auto S_Q = reinterpret_cast<const __nv_fp8_e4m3*>(S_Q_raw);
+    auto S_K = reinterpret_cast<const __nv_fp8_e4m3*>(S_K_raw);
+    auto S_V = reinterpret_cast<const __nv_fp8_e4m3*>(S_V_raw);
+    auto O = reinterpret_cast<T*>(O_raw);
+    auto rowmax_state = reinterpret_cast<float*>(rowmax_state_raw);
+    auto rowsum_state = reinterpret_cast<float*>(rowsum_state_raw);
+
+    if (head_dim == 64)
+        dispatch_thrift_attention<T, CAUSAL, 64>(
+            Q_fp16, K_fp16, V_fp16,
+            selected_blocks, topk_count,
+            topk_mask, topk_word_count,
+            Q, K, V, S_Q, S_K, S_V, O,
+            rowmax_state, rowsum_state,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+    else
+        dispatch_thrift_attention<T, CAUSAL, 128>(
+            Q_fp16, K_fp16, V_fp16,
+            selected_blocks, topk_count,
+            topk_mask, topk_word_count,
+            Q, K, V, S_Q, S_K, S_V, O,
+            rowmax_state, rowsum_state,
+            bs, q_len, kv_len, kv_capacity, num_q_heads, num_kv_heads);
+}
+
+void thrift_attention_causal_nvfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_nvfp4_typed<__nv_bfloat16, true>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        thrift_attention_nvfp4_typed<half, true>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}
+
+void thrift_attention_noncausal_nvfp4(
+    const void* Q_fp16_raw,
+    const void* K_fp16_raw,
+    const void* V_fp16_raw,
+    const void* selected_blocks_raw,
+    int topk_count,
+    const void* topk_mask_raw,
+    int topk_word_count,
+    const void* Q_raw,
+    const void* K_raw,
+    const void* V_raw,
+    const void* S_Q_raw,
+    const void* S_K_raw,
+    const void* S_V_raw,
+    void* O_raw,
+    void* rowmax_state_raw,
+    void* rowsum_state_raw,
+    int bs,
+    int q_len,
+    int kv_len,
+    int kv_capacity,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_dim,
+    bool is_bf16)
+{
+    if (is_bf16) {
+        thrift_attention_nvfp4_typed<__nv_bfloat16, false>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    } else {
+        thrift_attention_nvfp4_typed<half, false>(
+            Q_fp16_raw, K_fp16_raw, V_fp16_raw, selected_blocks_raw, topk_count,
+            topk_mask_raw, topk_word_count, Q_raw, K_raw, V_raw, S_Q_raw, S_K_raw,
+            S_V_raw, O_raw, rowmax_state_raw, rowsum_state_raw, bs, q_len,
+            kv_len, kv_capacity, num_q_heads, num_kv_heads, head_dim);
+    }
+}

--- a/thrift-attention/csrc/cuda/sm120/shared/block_selection.cu
+++ b/thrift-attention/csrc/cuda/sm120/shared/block_selection.cu
@@ -1,0 +1,1227 @@
+#include <cstdint>
+#include <cstdio>
+#include <float.h>
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "thriftattention/sm120/cuda_common.cuh"
+
+namespace {
+
+constexpr int SQ_TOPK_CHUNK_BLOCKS = 64;
+constexpr int SQ_TOPK_LOCAL_WARPS = 8;
+constexpr int SQ_TOPK_LOCAL_THREADS = SQ_TOPK_LOCAL_WARPS * TA_WARP_SIZE;
+
+// Per-query-block selection.
+//
+// q_mean: [flat_heads, num_q_blocks, head_dim]
+// k_mean: [flat_heads, num_kv_blocks, head_dim]
+// out:    [flat_heads, num_q_blocks, topk_count]
+template<typename T, bool CAUSAL, int HEAD_DIM, int MAX_KV_BLOCKS>
+__global__ __launch_bounds__(TA_WARP_SIZE)
+void block_mean_topk_kernel(
+    const T* __restrict__ q_mean,
+    const T* __restrict__ k_mean,
+    int32_t* __restrict__ topk_out,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    using Traits = PrecisionTraits<T>;
+    constexpr int ITEMS_PER_LANE = MAX_KV_BLOCKS / TA_WARP_SIZE;
+    constexpr int ELEMS_PER_LANE = HEAD_DIM / TA_WARP_SIZE;
+
+    const int bid = blockIdx.x;
+    const int flat_head_id = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int lane_id = threadIdx.x;
+
+    const T* q_row =
+        q_mean + (static_cast<int64_t>(flat_head_id) * num_q_blocks + q_block_id) * HEAD_DIM;
+    float q_reg[ELEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ELEMS_PER_LANE; i++) {
+        q_reg[i] = Traits::to_float(q_row[lane_id + i * TA_WARP_SIZE]);
+    }
+
+    const T* k_head = k_mean + static_cast<int64_t>(flat_head_id) * num_kv_blocks * HEAD_DIM;
+    extern __shared__ uint8_t smem[];
+    float* block_scores = reinterpret_cast<float*>(smem);
+
+    for (int kv_block = 0; kv_block < num_kv_blocks; kv_block++) {
+        const T* k_row = k_head + kv_block * HEAD_DIM;
+        float dot = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < ELEMS_PER_LANE; i++) {
+            dot += q_reg[i] * Traits::to_float(k_row[lane_id + i * TA_WARP_SIZE]);
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            dot += __shfl_xor_sync(0xFFFFFFFF, dot, delta);
+        }
+
+        if (lane_id == 0) {
+            block_scores[kv_block] = dot;
+        }
+    }
+    __syncwarp();
+
+    float values[ITEMS_PER_LANE];
+    int indices[ITEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ITEMS_PER_LANE; i++) {
+        const int idx = i * TA_WARP_SIZE + lane_id;
+        indices[i] = idx;
+        values[i] = (idx < num_kv_blocks && (!CAUSAL || idx <= q_block_id))
+            ? block_scores[idx]
+            : -FLT_MAX;
+    }
+
+    int32_t* out =
+        topk_out + (static_cast<int64_t>(flat_head_id) * num_q_blocks + q_block_id) * topk_count;
+
+    for (int k = 0; k < topk_count; k++) {
+        float best = values[0];
+        int best_idx = indices[0];
+        #pragma unroll
+        for (int i = 1; i < ITEMS_PER_LANE; i++) {
+            if (values[i] > best) {
+                best = values[i];
+                best_idx = indices[i];
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, best, delta);
+            const int other_idx = __shfl_xor_sync(0xFFFFFFFF, best_idx, delta);
+            if (other > best) {
+                best = other;
+                best_idx = other_idx;
+            }
+        }
+
+        const bool found = best > -FLT_MAX * 0.5f;
+        if (lane_id == 0) out[k] = found ? best_idx : -1;
+        best_idx = __shfl_sync(0xFFFFFFFF, best_idx, 0);
+
+        #pragma unroll
+        for (int i = 0; i < ITEMS_PER_LANE; i++) {
+            if (found && indices[i] == best_idx) values[i] = -FLT_MAX;
+        }
+    }
+}
+
+// Single-token decode selection for grouped-query attention.
+//
+// q_grouped: [flat_kv_heads, groups, head_dim]
+// k_mean:    [flat_kv_heads, k_mean_capacity_blocks, head_dim]
+// out:       [flat_kv_heads, topk_count]
+//
+// Scores are max_g dot(q[flat_head, g], k_mean[flat_head, block]), matching
+// the Python grouped decode selector.
+template<typename T, int HEAD_DIM, int MAX_KV_BLOCKS>
+__global__ __launch_bounds__(TA_WARP_SIZE)
+void single_query_key_mean_topk_kernel(
+    const T* __restrict__ q_grouped,
+    const T* __restrict__ k_mean,
+    int32_t* __restrict__ topk_out,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int topk_count) {
+    using Traits = PrecisionTraits<T>;
+    constexpr int ITEMS_PER_LANE = MAX_KV_BLOCKS / TA_WARP_SIZE;
+    constexpr int ELEMS_PER_LANE = HEAD_DIM / TA_WARP_SIZE;
+
+    const int flat_head_id = blockIdx.x;
+    const int lane_id = threadIdx.x;
+
+    const T* q_head =
+        q_grouped + static_cast<int64_t>(flat_head_id) * groups * HEAD_DIM;
+    const T* k_head =
+        k_mean + static_cast<int64_t>(flat_head_id) * k_mean_capacity_blocks * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+    float* block_scores = reinterpret_cast<float*>(smem);
+
+    for (int kv_block = 0; kv_block < num_kv_blocks; kv_block++) {
+        const T* k_row = k_head + kv_block * HEAD_DIM;
+        float best = -FLT_MAX;
+
+        for (int group_id = 0; group_id < groups; group_id++) {
+            const T* q_row = q_head + group_id * HEAD_DIM;
+            float dot = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < ELEMS_PER_LANE; i++) {
+                const int elem = lane_id + i * TA_WARP_SIZE;
+                dot += Traits::to_float(q_row[elem]) * Traits::to_float(k_row[elem]);
+            }
+
+            #pragma unroll
+            for (int delta = 16; delta >= 1; delta >>= 1) {
+                dot += __shfl_xor_sync(0xFFFFFFFF, dot, delta);
+            }
+
+            if (lane_id == 0 && dot > best) {
+                best = dot;
+            }
+        }
+
+        if (lane_id == 0) {
+            block_scores[kv_block] = best;
+        }
+    }
+    __syncwarp();
+
+    float values[ITEMS_PER_LANE];
+    int indices[ITEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ITEMS_PER_LANE; i++) {
+        const int idx = i * TA_WARP_SIZE + lane_id;
+        indices[i] = idx;
+        values[i] = (idx < num_kv_blocks) ? block_scores[idx] : -FLT_MAX;
+    }
+
+    int32_t* out = topk_out + static_cast<int64_t>(flat_head_id) * topk_count;
+
+    for (int k = 0; k < topk_count; k++) {
+        float best = values[0];
+        int best_idx = indices[0];
+        #pragma unroll
+        for (int i = 1; i < ITEMS_PER_LANE; i++) {
+            if (values[i] > best) {
+                best = values[i];
+                best_idx = indices[i];
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, best, delta);
+            const int other_idx = __shfl_xor_sync(0xFFFFFFFF, best_idx, delta);
+            if (other > best) {
+                best = other;
+                best_idx = other_idx;
+            }
+        }
+
+        if (lane_id == 0) {
+            out[k] = best_idx;
+        }
+        best_idx = __shfl_sync(0xFFFFFFFF, best_idx, 0);
+
+        #pragma unroll
+        for (int i = 0; i < ITEMS_PER_LANE; i++) {
+            if (indices[i] == best_idx) values[i] = -FLT_MAX;
+        }
+    }
+}
+
+// Per-query-block QUEST min/max selection.
+//
+// q_mean: [flat_heads, num_q_blocks, head_dim]
+// k_min:  [flat_heads, num_kv_blocks, head_dim]
+// k_max:  [flat_heads, num_kv_blocks, head_dim]
+// out:    [flat_heads, num_q_blocks, topk_count]
+template<typename T, bool CAUSAL, int HEAD_DIM, int MAX_KV_BLOCKS>
+__global__ __launch_bounds__(TA_WARP_SIZE)
+void quest_block_topk_kernel(
+    const T* __restrict__ q_mean,
+    const T* __restrict__ k_min,
+    const T* __restrict__ k_max,
+    int32_t* __restrict__ topk_out,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    using Traits = PrecisionTraits<T>;
+    constexpr int ITEMS_PER_LANE = MAX_KV_BLOCKS / TA_WARP_SIZE;
+    constexpr int ELEMS_PER_LANE = HEAD_DIM / TA_WARP_SIZE;
+
+    const int bid = blockIdx.x;
+    const int flat_head_id = bid / num_q_blocks;
+    const int q_block_id = bid % num_q_blocks;
+    const int lane_id = threadIdx.x;
+
+    const T* q_row =
+        q_mean + (static_cast<int64_t>(flat_head_id) * num_q_blocks + q_block_id) * HEAD_DIM;
+    float q_reg[ELEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ELEMS_PER_LANE; i++) {
+        q_reg[i] = Traits::to_float(q_row[lane_id + i * TA_WARP_SIZE]);
+    }
+
+    const T* k_min_head = k_min + static_cast<int64_t>(flat_head_id) * num_kv_blocks * HEAD_DIM;
+    const T* k_max_head = k_max + static_cast<int64_t>(flat_head_id) * num_kv_blocks * HEAD_DIM;
+    extern __shared__ uint8_t smem[];
+    float* block_scores = reinterpret_cast<float*>(smem);
+
+    for (int kv_block = 0; kv_block < num_kv_blocks; kv_block++) {
+        const T* k_min_row = k_min_head + kv_block * HEAD_DIM;
+        const T* k_max_row = k_max_head + kv_block * HEAD_DIM;
+        float dot = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < ELEMS_PER_LANE; i++) {
+            const int elem = lane_id + i * TA_WARP_SIZE;
+            const float q = q_reg[i];
+            const float k = q >= 0.0f
+                ? Traits::to_float(k_max_row[elem])
+                : Traits::to_float(k_min_row[elem]);
+            dot += q * k;
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            dot += __shfl_xor_sync(0xFFFFFFFF, dot, delta);
+        }
+
+        if (lane_id == 0) {
+            block_scores[kv_block] = dot;
+        }
+    }
+    __syncwarp();
+
+    float values[ITEMS_PER_LANE];
+    int indices[ITEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ITEMS_PER_LANE; i++) {
+        const int idx = i * TA_WARP_SIZE + lane_id;
+        indices[i] = idx;
+        values[i] = (idx < num_kv_blocks && (!CAUSAL || idx <= q_block_id))
+            ? block_scores[idx]
+            : -FLT_MAX;
+    }
+
+    int32_t* out =
+        topk_out + (static_cast<int64_t>(flat_head_id) * num_q_blocks + q_block_id) * topk_count;
+
+    for (int k = 0; k < topk_count; k++) {
+        float best = values[0];
+        int best_idx = indices[0];
+        #pragma unroll
+        for (int i = 1; i < ITEMS_PER_LANE; i++) {
+            if (values[i] > best) {
+                best = values[i];
+                best_idx = indices[i];
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, best, delta);
+            const int other_idx = __shfl_xor_sync(0xFFFFFFFF, best_idx, delta);
+            if (other > best) {
+                best = other;
+                best_idx = other_idx;
+            }
+        }
+
+        const bool found = best > -FLT_MAX * 0.5f;
+        if (lane_id == 0) out[k] = found ? best_idx : -1;
+        best_idx = __shfl_sync(0xFFFFFFFF, best_idx, 0);
+
+        #pragma unroll
+        for (int i = 0; i < ITEMS_PER_LANE; i++) {
+            if (found && indices[i] == best_idx) values[i] = -FLT_MAX;
+        }
+    }
+}
+
+// Single-token decode QUEST min/max selection for grouped-query attention.
+//
+// q_grouped: [flat_kv_heads, groups, head_dim]
+// k_min/max: [flat_kv_heads, k_stat_capacity_blocks, head_dim]
+// out:       [flat_kv_heads, topk_count]
+template<typename T, int HEAD_DIM, int MAX_KV_BLOCKS>
+__global__ __launch_bounds__(TA_WARP_SIZE)
+void single_query_quest_topk_kernel(
+    const T* __restrict__ q_grouped,
+    const T* __restrict__ k_min,
+    const T* __restrict__ k_max,
+    int32_t* __restrict__ topk_out,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int topk_count) {
+    using Traits = PrecisionTraits<T>;
+    constexpr int ITEMS_PER_LANE = MAX_KV_BLOCKS / TA_WARP_SIZE;
+    constexpr int ELEMS_PER_LANE = HEAD_DIM / TA_WARP_SIZE;
+
+    const int flat_head_id = blockIdx.x;
+    const int lane_id = threadIdx.x;
+
+    const T* q_head =
+        q_grouped + static_cast<int64_t>(flat_head_id) * groups * HEAD_DIM;
+    const T* k_min_head =
+        k_min + static_cast<int64_t>(flat_head_id) * k_stat_capacity_blocks * HEAD_DIM;
+    const T* k_max_head =
+        k_max + static_cast<int64_t>(flat_head_id) * k_stat_capacity_blocks * HEAD_DIM;
+
+    extern __shared__ uint8_t smem[];
+    float* block_scores = reinterpret_cast<float*>(smem);
+
+    for (int kv_block = 0; kv_block < num_kv_blocks; kv_block++) {
+        const T* k_min_row = k_min_head + kv_block * HEAD_DIM;
+        const T* k_max_row = k_max_head + kv_block * HEAD_DIM;
+        float best = -FLT_MAX;
+
+        for (int group_id = 0; group_id < groups; group_id++) {
+            const T* q_row = q_head + group_id * HEAD_DIM;
+            float dot = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < ELEMS_PER_LANE; i++) {
+                const int elem = lane_id + i * TA_WARP_SIZE;
+                const float q = Traits::to_float(q_row[elem]);
+                const float k = q >= 0.0f
+                    ? Traits::to_float(k_max_row[elem])
+                    : Traits::to_float(k_min_row[elem]);
+                dot += q * k;
+            }
+
+            #pragma unroll
+            for (int delta = 16; delta >= 1; delta >>= 1) {
+                dot += __shfl_xor_sync(0xFFFFFFFF, dot, delta);
+            }
+
+            if (lane_id == 0 && dot > best) {
+                best = dot;
+            }
+        }
+
+        if (lane_id == 0) {
+            block_scores[kv_block] = best;
+        }
+    }
+    __syncwarp();
+
+    float values[ITEMS_PER_LANE];
+    int indices[ITEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ITEMS_PER_LANE; i++) {
+        const int idx = i * TA_WARP_SIZE + lane_id;
+        indices[i] = idx;
+        values[i] = (idx < num_kv_blocks) ? block_scores[idx] : -FLT_MAX;
+    }
+
+    int32_t* out = topk_out + static_cast<int64_t>(flat_head_id) * topk_count;
+
+    for (int k = 0; k < topk_count; k++) {
+        float best = values[0];
+        int best_idx = indices[0];
+        #pragma unroll
+        for (int i = 1; i < ITEMS_PER_LANE; i++) {
+            if (values[i] > best) {
+                best = values[i];
+                best_idx = indices[i];
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, best, delta);
+            const int other_idx = __shfl_xor_sync(0xFFFFFFFF, best_idx, delta);
+            if (other > best) {
+                best = other;
+                best_idx = other_idx;
+            }
+        }
+
+        if (lane_id == 0) {
+            out[k] = best_idx;
+        }
+        best_idx = __shfl_sync(0xFFFFFFFF, best_idx, 0);
+
+        #pragma unroll
+        for (int i = 0; i < ITEMS_PER_LANE; i++) {
+            if (indices[i] == best_idx) values[i] = -FLT_MAX;
+        }
+    }
+}
+
+// Chunk-parallel exact single-query selection. Each local CTA scores a
+// contiguous 64-block chunk for one KV head, emits that chunk's local top-k,
+// then the last completed chunk CTA merges the final top-k from all local
+// candidates. Keeping top-k candidates per chunk is exact: any global top-k
+// element must be in the top-k of its own chunk.
+template<typename T, int HEAD_DIM>
+__global__ __launch_bounds__(SQ_TOPK_LOCAL_THREADS)
+void single_query_key_mean_topk_local_kernel(
+    const T* __restrict__ q_grouped,
+    const T* __restrict__ k_mean,
+    int32_t* __restrict__ topk_out,
+    float* __restrict__ local_scores,
+    int32_t* __restrict__ local_indices,
+    int32_t* __restrict__ done_counts,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int chunk_count,
+    int local_count,
+    int topk_count) {
+    using Traits = PrecisionTraits<T>;
+    constexpr int ELEMS_PER_LANE = HEAD_DIM / TA_WARP_SIZE;
+    constexpr int ITEMS_PER_LANE = SQ_TOPK_CHUNK_BLOCKS / TA_WARP_SIZE;
+
+    const int chunk_id = blockIdx.x % chunk_count;
+    const int flat_head_id = blockIdx.x / chunk_count;
+    const int chunk_start = chunk_id * SQ_TOPK_CHUNK_BLOCKS;
+    const int tid = threadIdx.x;
+    const int lane_id = tid & (TA_WARP_SIZE - 1);
+    const int warp_id = tid / TA_WARP_SIZE;
+
+    __shared__ float block_scores[SQ_TOPK_CHUNK_BLOCKS];
+    if (tid < SQ_TOPK_CHUNK_BLOCKS) {
+        block_scores[tid] = -FLT_MAX;
+    }
+    __syncthreads();
+
+    const T* q_head =
+        q_grouped + static_cast<int64_t>(flat_head_id) * groups * HEAD_DIM;
+    const T* k_head =
+        k_mean + static_cast<int64_t>(flat_head_id) * k_mean_capacity_blocks * HEAD_DIM;
+
+    for (int local_block = warp_id; local_block < SQ_TOPK_CHUNK_BLOCKS;
+         local_block += SQ_TOPK_LOCAL_WARPS) {
+        const int kv_block = chunk_start + local_block;
+        float best = -FLT_MAX;
+
+        if (kv_block < num_kv_blocks) {
+            const T* k_row = k_head + static_cast<int64_t>(kv_block) * HEAD_DIM;
+            for (int group_id = 0; group_id < groups; group_id++) {
+                const T* q_row = q_head + group_id * HEAD_DIM;
+                float dot = 0.0f;
+                #pragma unroll
+                for (int i = 0; i < ELEMS_PER_LANE; i++) {
+                    const int elem = lane_id + i * TA_WARP_SIZE;
+                    dot += Traits::to_float(q_row[elem]) * Traits::to_float(k_row[elem]);
+                }
+
+                #pragma unroll
+                for (int delta = 16; delta >= 1; delta >>= 1) {
+                    dot += __shfl_xor_sync(0xFFFFFFFF, dot, delta);
+                }
+
+                if (lane_id == 0 && dot > best) {
+                    best = dot;
+                }
+            }
+        }
+
+        if (lane_id == 0) {
+            block_scores[local_block] = best;
+        }
+    }
+    __syncthreads();
+
+    if (warp_id != 0) {
+        return;
+    }
+
+    float values[ITEMS_PER_LANE];
+    int indices[ITEMS_PER_LANE];
+    #pragma unroll
+    for (int i = 0; i < ITEMS_PER_LANE; i++) {
+        const int local_idx = i * TA_WARP_SIZE + lane_id;
+        const int global_idx = chunk_start + local_idx;
+        indices[i] = global_idx;
+        values[i] = (global_idx < num_kv_blocks) ? block_scores[local_idx] : -FLT_MAX;
+    }
+
+    const int64_t local_base =
+        (static_cast<int64_t>(flat_head_id) * chunk_count + chunk_id) * local_count;
+    for (int rank = 0; rank < local_count; rank++) {
+        float best = values[0];
+        int best_idx = indices[0];
+        #pragma unroll
+        for (int i = 1; i < ITEMS_PER_LANE; i++) {
+            if (values[i] > best) {
+                best = values[i];
+                best_idx = indices[i];
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFF, best, delta);
+            const int other_idx = __shfl_xor_sync(0xFFFFFFFF, best_idx, delta);
+            if (other > best) {
+                best = other;
+                best_idx = other_idx;
+            }
+        }
+
+        const bool found = best > -FLT_MAX * 0.5f;
+        if (lane_id == 0) {
+            local_scores[local_base + rank] = found ? best : -FLT_MAX;
+            local_indices[local_base + rank] = found ? best_idx : -1;
+        }
+        best_idx = __shfl_sync(0xFFFFFFFF, best_idx, 0);
+
+        #pragma unroll
+        for (int i = 0; i < ITEMS_PER_LANE; i++) {
+            if (found && indices[i] == best_idx) {
+                values[i] = -FLT_MAX;
+            }
+        }
+    }
+    __syncthreads();
+
+    __shared__ int is_last_chunk;
+    if (warp_id == 0 && lane_id == 0) {
+        __threadfence();
+        const int prior = atomicAdd(done_counts + flat_head_id, 1);
+        is_last_chunk = (prior == chunk_count - 1);
+    }
+    __syncthreads();
+
+    if (!is_last_chunk || warp_id != 0) {
+        return;
+    }
+
+    const int candidate_count = chunk_count * local_count;
+    const int64_t candidate_base = static_cast<int64_t>(flat_head_id) * candidate_count;
+
+    for (int rank = 0; rank < topk_count; rank++) {
+        float thread_best = -FLT_MAX;
+        int thread_best_idx = -1;
+
+        for (int candidate = lane_id; candidate < candidate_count; candidate += TA_WARP_SIZE) {
+            const int64_t offset = candidate_base + candidate;
+            const int idx = local_indices[offset];
+            const float score = local_scores[offset];
+            if (idx >= 0 && score > thread_best) {
+                thread_best = score;
+                thread_best_idx = idx;
+            }
+        }
+
+        #pragma unroll
+        for (int delta = 16; delta >= 1; delta >>= 1) {
+            const float other_score = __shfl_down_sync(0xFFFFFFFF, thread_best, delta);
+            const int other_idx = __shfl_down_sync(0xFFFFFFFF, thread_best_idx, delta);
+            if (lane_id + delta < TA_WARP_SIZE && other_score > thread_best) {
+                thread_best = other_score;
+                thread_best_idx = other_idx;
+            }
+        }
+
+        if (lane_id == 0) {
+            topk_out[static_cast<int64_t>(flat_head_id) * topk_count + rank] = thread_best_idx;
+        }
+        const int selected_idx = __shfl_sync(0xFFFFFFFF, thread_best_idx, 0);
+
+        for (int candidate = lane_id; candidate < candidate_count; candidate += TA_WARP_SIZE) {
+            const int64_t offset = candidate_base + candidate;
+            if (local_indices[offset] == selected_idx) {
+                local_scores[offset] = -FLT_MAX;
+            }
+        }
+        __syncwarp();
+    }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int MAX_KV_BLOCKS>
+void launch_block_mean_topk(
+    const T* q_mean,
+    const T* k_mean,
+    int32_t* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    const int grid_size = flat_heads * num_q_blocks;
+    const int smem_bytes = num_kv_blocks * static_cast<int>(sizeof(float));
+
+    block_mean_topk_kernel<T, CAUSAL, HEAD_DIM, MAX_KV_BLOCKS>
+        <<<grid_size, TA_WARP_SIZE, smem_bytes>>>(
+            q_mean, k_mean, topk_out, num_q_blocks, num_kv_blocks, topk_count);
+
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "block_mean_topk kernel launch failed: %s\n", cudaGetErrorString(err));
+    }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+void dispatch_block_mean_topk(
+    const T* q_mean,
+    const T* k_mean,
+    int32_t* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    if (num_kv_blocks <= 128) {
+        launch_block_mean_topk<T, CAUSAL, HEAD_DIM, 128>(
+            q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else if (num_kv_blocks <= 512) {
+        launch_block_mean_topk<T, CAUSAL, HEAD_DIM, 512>(
+            q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else if (num_kv_blocks <= 1024) {
+        launch_block_mean_topk<T, CAUSAL, HEAD_DIM, 1024>(
+            q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else {
+        launch_block_mean_topk<T, CAUSAL, HEAD_DIM, 2048>(
+            q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM, int MAX_KV_BLOCKS>
+void launch_quest_block_topk(
+    const T* q_mean,
+    const T* k_min,
+    const T* k_max,
+    int32_t* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    const int grid_size = flat_heads * num_q_blocks;
+    const int smem_bytes = num_kv_blocks * static_cast<int>(sizeof(float));
+
+    quest_block_topk_kernel<T, CAUSAL, HEAD_DIM, MAX_KV_BLOCKS>
+        <<<grid_size, TA_WARP_SIZE, smem_bytes>>>(
+            q_mean, k_min, k_max, topk_out, num_q_blocks, num_kv_blocks, topk_count);
+
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "quest_block_topk kernel launch failed: %s\n", cudaGetErrorString(err));
+    }
+}
+
+template<typename T, bool CAUSAL, int HEAD_DIM>
+void dispatch_quest_block_topk(
+    const T* q_mean,
+    const T* k_min,
+    const T* k_max,
+    int32_t* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int topk_count) {
+    if (num_kv_blocks <= 128) {
+        launch_quest_block_topk<T, CAUSAL, HEAD_DIM, 128>(
+            q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else if (num_kv_blocks <= 512) {
+        launch_quest_block_topk<T, CAUSAL, HEAD_DIM, 512>(
+            q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else if (num_kv_blocks <= 1024) {
+        launch_quest_block_topk<T, CAUSAL, HEAD_DIM, 1024>(
+            q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    } else {
+        launch_quest_block_topk<T, CAUSAL, HEAD_DIM, 2048>(
+            q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+    }
+}
+
+template<typename T, int HEAD_DIM, int MAX_KV_BLOCKS>
+void launch_single_query_key_mean_topk(
+    const T* q_grouped,
+    const T* k_mean,
+    int32_t* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int topk_count) {
+    const int smem_bytes = num_kv_blocks * static_cast<int>(sizeof(float));
+
+    single_query_key_mean_topk_kernel<T, HEAD_DIM, MAX_KV_BLOCKS>
+        <<<flat_heads, TA_WARP_SIZE, smem_bytes>>>(
+            q_grouped, k_mean, topk_out, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "single_query_key_mean_topk kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T, int HEAD_DIM>
+void dispatch_single_query_key_mean_topk(
+    const T* q_grouped,
+    const T* k_mean,
+    int32_t* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int topk_count) {
+    if (num_kv_blocks <= 128) {
+        launch_single_query_key_mean_topk<T, HEAD_DIM, 128>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    } else if (num_kv_blocks <= 512) {
+        launch_single_query_key_mean_topk<T, HEAD_DIM, 512>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    } else if (num_kv_blocks <= 1024) {
+        launch_single_query_key_mean_topk<T, HEAD_DIM, 1024>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    } else {
+        launch_single_query_key_mean_topk<T, HEAD_DIM, 2048>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    }
+}
+
+template<typename T, int HEAD_DIM, int MAX_KV_BLOCKS>
+void launch_single_query_quest_topk(
+    const T* q_grouped,
+    const T* k_min,
+    const T* k_max,
+    int32_t* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int topk_count) {
+    const int smem_bytes = num_kv_blocks * static_cast<int>(sizeof(float));
+
+    single_query_quest_topk_kernel<T, HEAD_DIM, MAX_KV_BLOCKS>
+        <<<flat_heads, TA_WARP_SIZE, smem_bytes>>>(
+            q_grouped, k_min, k_max, topk_out, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "single_query_quest_topk kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+template<typename T, int HEAD_DIM>
+void dispatch_single_query_quest_topk(
+    const T* q_grouped,
+    const T* k_min,
+    const T* k_max,
+    int32_t* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int topk_count) {
+    if (num_kv_blocks <= 128) {
+        launch_single_query_quest_topk<T, HEAD_DIM, 128>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    } else if (num_kv_blocks <= 512) {
+        launch_single_query_quest_topk<T, HEAD_DIM, 512>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    } else if (num_kv_blocks <= 1024) {
+        launch_single_query_quest_topk<T, HEAD_DIM, 1024>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    } else {
+        launch_single_query_quest_topk<T, HEAD_DIM, 2048>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    }
+}
+
+template<typename T, int HEAD_DIM>
+void launch_single_query_key_mean_topk_chunked(
+    const T* q_grouped,
+    const T* k_mean,
+    int32_t* topk_out,
+    float* local_scores,
+    int32_t* local_indices,
+    int32_t* done_counts,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int topk_count,
+    int chunk_count,
+    int local_count) {
+    cudaMemsetAsync(done_counts, 0, static_cast<size_t>(flat_heads) * sizeof(int32_t));
+
+    const int local_grid = flat_heads * chunk_count;
+    single_query_key_mean_topk_local_kernel<T, HEAD_DIM>
+        <<<local_grid, SQ_TOPK_LOCAL_THREADS>>>(
+            q_grouped, k_mean, topk_out, local_scores, local_indices, done_counts,
+            groups, num_kv_blocks, k_mean_capacity_blocks, chunk_count, local_count,
+            topk_count);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "single_query_key_mean_topk_local kernel launch failed: %s\n",
+                cudaGetErrorString(err));
+    }
+}
+
+}  // namespace
+
+template<typename T>
+static void dispatch_block_mean_topk_typed(
+    const void* q_mean_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal) {
+    const T* q_mean = reinterpret_cast<const T*>(q_mean_raw);
+    const T* k_mean = reinterpret_cast<const T*>(k_mean_raw);
+    int32_t* topk_out = reinterpret_cast<int32_t*>(topk_out_raw);
+
+    if (num_kv_blocks > 2048) {
+        fprintf(stderr, "block_mean_topk: num_kv_blocks=%d > 2048 not supported\n", num_kv_blocks);
+        return;
+    }
+
+    if (head_dim == 64) {
+        if (causal) {
+            dispatch_block_mean_topk<T, true, 64>(
+                q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        } else {
+            dispatch_block_mean_topk<T, false, 64>(
+                q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        }
+    } else if (head_dim == 128) {
+        if (causal) {
+            dispatch_block_mean_topk<T, true, 128>(
+                q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        } else {
+            dispatch_block_mean_topk<T, false, 128>(
+                q_mean, k_mean, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        }
+    } else {
+        fprintf(stderr, "block_mean_topk: unsupported head_dim=%d\n", head_dim);
+    }
+}
+
+void block_mean_topk(
+    const void* q_mean_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_block_mean_topk_typed<__nv_bfloat16>(
+            q_mean_raw, k_mean_raw, topk_out_raw, flat_heads, num_q_blocks,
+            num_kv_blocks, head_dim, topk_count, causal);
+    } else {
+        dispatch_block_mean_topk_typed<half>(
+            q_mean_raw, k_mean_raw, topk_out_raw, flat_heads, num_q_blocks,
+            num_kv_blocks, head_dim, topk_count, causal);
+    }
+}
+
+template<typename T>
+static void dispatch_quest_block_topk_typed(
+    const void* q_mean_raw,
+    const void* k_min_raw,
+    const void* k_max_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal) {
+    const T* q_mean = reinterpret_cast<const T*>(q_mean_raw);
+    const T* k_min = reinterpret_cast<const T*>(k_min_raw);
+    const T* k_max = reinterpret_cast<const T*>(k_max_raw);
+    int32_t* topk_out = reinterpret_cast<int32_t*>(topk_out_raw);
+
+    if (num_kv_blocks > 2048) {
+        fprintf(stderr, "quest_block_topk: num_kv_blocks=%d > 2048 not supported\n", num_kv_blocks);
+        return;
+    }
+
+    if (head_dim == 64) {
+        if (causal) {
+            dispatch_quest_block_topk<T, true, 64>(
+                q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        } else {
+            dispatch_quest_block_topk<T, false, 64>(
+                q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        }
+    } else if (head_dim == 128) {
+        if (causal) {
+            dispatch_quest_block_topk<T, true, 128>(
+                q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        } else {
+            dispatch_quest_block_topk<T, false, 128>(
+                q_mean, k_min, k_max, topk_out, flat_heads, num_q_blocks, num_kv_blocks, topk_count);
+        }
+    } else {
+        fprintf(stderr, "quest_block_topk: unsupported head_dim=%d\n", head_dim);
+    }
+}
+
+void quest_block_topk(
+    const void* q_mean_raw,
+    const void* k_min_raw,
+    const void* k_max_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_quest_block_topk_typed<__nv_bfloat16>(
+            q_mean_raw, k_min_raw, k_max_raw, topk_out_raw, flat_heads, num_q_blocks,
+            num_kv_blocks, head_dim, topk_count, causal);
+    } else {
+        dispatch_quest_block_topk_typed<half>(
+            q_mean_raw, k_min_raw, k_max_raw, topk_out_raw, flat_heads, num_q_blocks,
+            num_kv_blocks, head_dim, topk_count, causal);
+    }
+}
+
+template<typename T>
+static void dispatch_single_query_key_mean_topk_typed(
+    const void* q_grouped_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count) {
+    const T* q_grouped = reinterpret_cast<const T*>(q_grouped_raw);
+    const T* k_mean = reinterpret_cast<const T*>(k_mean_raw);
+    int32_t* topk_out = reinterpret_cast<int32_t*>(topk_out_raw);
+
+    if (num_kv_blocks > 2048) {
+        fprintf(stderr, "single_query_key_mean_topk: num_kv_blocks=%d > 2048 not supported\n",
+                num_kv_blocks);
+        return;
+    }
+
+    if (head_dim == 64) {
+        dispatch_single_query_key_mean_topk<T, 64>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    } else if (head_dim == 128) {
+        dispatch_single_query_key_mean_topk<T, 128>(
+            q_grouped, k_mean, topk_out, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, topk_count);
+    } else {
+        fprintf(stderr, "single_query_key_mean_topk: unsupported head_dim=%d\n", head_dim);
+    }
+}
+
+void single_query_key_mean_topk(
+    const void* q_grouped_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_single_query_key_mean_topk_typed<__nv_bfloat16>(
+            q_grouped_raw, k_mean_raw, topk_out_raw, flat_heads, groups,
+            num_kv_blocks, k_mean_capacity_blocks, head_dim, topk_count);
+    } else {
+        dispatch_single_query_key_mean_topk_typed<half>(
+            q_grouped_raw, k_mean_raw, topk_out_raw, flat_heads, groups,
+            num_kv_blocks, k_mean_capacity_blocks, head_dim, topk_count);
+    }
+}
+
+template<typename T>
+static void dispatch_single_query_quest_topk_typed(
+    const void* q_grouped_raw,
+    const void* k_min_raw,
+    const void* k_max_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int head_dim,
+    int topk_count) {
+    const T* q_grouped = reinterpret_cast<const T*>(q_grouped_raw);
+    const T* k_min = reinterpret_cast<const T*>(k_min_raw);
+    const T* k_max = reinterpret_cast<const T*>(k_max_raw);
+    int32_t* topk_out = reinterpret_cast<int32_t*>(topk_out_raw);
+
+    if (num_kv_blocks > 2048) {
+        fprintf(stderr, "single_query_quest_topk: num_kv_blocks=%d > 2048 not supported\n",
+                num_kv_blocks);
+        return;
+    }
+
+    if (head_dim == 64) {
+        dispatch_single_query_quest_topk<T, 64>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    } else if (head_dim == 128) {
+        dispatch_single_query_quest_topk<T, 128>(
+            q_grouped, k_min, k_max, topk_out, flat_heads, groups, num_kv_blocks,
+            k_stat_capacity_blocks, topk_count);
+    } else {
+        fprintf(stderr, "single_query_quest_topk: unsupported head_dim=%d\n", head_dim);
+    }
+}
+
+void single_query_quest_topk(
+    const void* q_grouped_raw,
+    const void* k_min_raw,
+    const void* k_max_raw,
+    void* topk_out_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_single_query_quest_topk_typed<__nv_bfloat16>(
+            q_grouped_raw, k_min_raw, k_max_raw, topk_out_raw, flat_heads, groups,
+            num_kv_blocks, k_stat_capacity_blocks, head_dim, topk_count);
+    } else {
+        dispatch_single_query_quest_topk_typed<half>(
+            q_grouped_raw, k_min_raw, k_max_raw, topk_out_raw, flat_heads, groups,
+            num_kv_blocks, k_stat_capacity_blocks, head_dim, topk_count);
+    }
+}
+
+template<typename T>
+static void dispatch_single_query_key_mean_topk_chunked_typed(
+    const void* q_grouped_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    void* local_scores_raw,
+    void* local_indices_raw,
+    void* done_counts_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    int chunk_count,
+    int local_count) {
+    const T* q_grouped = reinterpret_cast<const T*>(q_grouped_raw);
+    const T* k_mean = reinterpret_cast<const T*>(k_mean_raw);
+    int32_t* topk_out = reinterpret_cast<int32_t*>(topk_out_raw);
+    float* local_scores = reinterpret_cast<float*>(local_scores_raw);
+    int32_t* local_indices = reinterpret_cast<int32_t*>(local_indices_raw);
+    int32_t* done_counts = reinterpret_cast<int32_t*>(done_counts_raw);
+
+    if (num_kv_blocks > 2048) {
+        fprintf(stderr, "single_query_key_mean_topk_chunked: num_kv_blocks=%d > 2048 not supported\n",
+                num_kv_blocks);
+        return;
+    }
+    if (chunk_count <= 0 || local_count <= 0) {
+        return;
+    }
+
+    if (head_dim == 64) {
+        launch_single_query_key_mean_topk_chunked<T, 64>(
+            q_grouped, k_mean, topk_out, local_scores, local_indices, done_counts,
+            flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+            topk_count, chunk_count, local_count);
+    } else if (head_dim == 128) {
+        launch_single_query_key_mean_topk_chunked<T, 128>(
+            q_grouped, k_mean, topk_out, local_scores, local_indices, done_counts,
+            flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+            topk_count, chunk_count, local_count);
+    } else {
+        fprintf(stderr, "single_query_key_mean_topk_chunked: unsupported head_dim=%d\n", head_dim);
+    }
+}
+
+void single_query_key_mean_topk_chunked(
+    const void* q_grouped_raw,
+    const void* k_mean_raw,
+    void* topk_out_raw,
+    void* local_scores_raw,
+    void* local_indices_raw,
+    void* done_counts_raw,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    int chunk_count,
+    int local_count,
+    bool is_bf16) {
+    if (is_bf16) {
+        dispatch_single_query_key_mean_topk_chunked_typed<__nv_bfloat16>(
+            q_grouped_raw, k_mean_raw, topk_out_raw, local_scores_raw,
+            local_indices_raw, done_counts_raw, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, head_dim, topk_count, chunk_count, local_count);
+    } else {
+        dispatch_single_query_key_mean_topk_chunked_typed<half>(
+            q_grouped_raw, k_mean_raw, topk_out_raw, local_scores_raw,
+            local_indices_raw, done_counts_raw, flat_heads, groups, num_kv_blocks,
+            k_mean_capacity_blocks, head_dim, topk_count, chunk_count, local_count);
+    }
+}
+
+__global__ __launch_bounds__(256)
+void pack_topk_mask_kernel(
+    const int32_t* __restrict__ topk,
+    unsigned long long* __restrict__ topk_mask,
+    int topk_count,
+    int total_units,
+    int word_count) {
+    const int row_id = blockIdx.x;
+    const int tid = threadIdx.x;
+    unsigned long long* mask_row = topk_mask + static_cast<int64_t>(row_id) * word_count;
+
+    for (int word = tid; word < word_count; word += blockDim.x) {
+        mask_row[word] = 0ULL;
+    }
+    __syncthreads();
+
+    const int32_t* topk_row = topk + static_cast<int64_t>(row_id) * topk_count;
+    for (int i = tid; i < topk_count; i += blockDim.x) {
+        const int unit_id = topk_row[i];
+        if (unit_id >= 0 && unit_id < total_units) {
+            const int word = unit_id >> 6;
+            if (word < word_count) {
+                atomicOr(mask_row + word, 1ULL << (unit_id & 63));
+            }
+        }
+    }
+}
+
+void pack_topk_mask(
+    const int32_t* topk,
+    void* topk_mask_raw,
+    int row_count,
+    int topk_count,
+    int total_units,
+    int word_count) {
+    auto topk_mask = reinterpret_cast<unsigned long long*>(topk_mask_raw);
+    if (row_count <= 0 || word_count <= 0) {
+        return;
+    }
+
+    pack_topk_mask_kernel<<<row_count, 256>>>(
+        topk, topk_mask, topk_count, total_units, word_count);
+
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "pack_topk_mask kernel launch failed: %s\n", cudaGetErrorString(err));
+    }
+}

--- a/thrift-attention/csrc/include/thriftattention/sm120/cuda_common.cuh
+++ b/thrift-attention/csrc/include/thriftattention/sm120/cuda_common.cuh
@@ -1,0 +1,374 @@
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+constexpr int TA_WARP_SIZE = 32;
+
+__host__ __device__ inline int ta_cdiv(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+__host__ __device__ inline int ta_sage_perm32(int x) {
+    return (x / 8) * 2 + ((x % 8) / 2) * 8 + (x % 2);
+}
+
+__host__ __device__ inline int ta_sage_perm32_inv(int x) {
+    #pragma unroll
+    for (int i = 0; i < 32; i++) {
+        if (ta_sage_perm32(i) == x) {
+            return i;
+        }
+    }
+    return x;
+}
+
+__host__ __device__ inline int ta_sage_perm_seq(int x, bool inverse = false) {
+    const int base = (x / 32) * 32;
+    const int local = x & 31;
+    return base + (inverse ? ta_sage_perm32_inv(local) : ta_sage_perm32(local));
+}
+
+// K/V are stored in the physical order consumed by the shuffle-free P operand.
+// This names the direction used by the quantizers and causal masks explicitly.
+__host__ __device__ inline int ta_kv_logical_from_physical(int physical) {
+    return ta_sage_perm_seq(physical, false);
+}
+
+__host__ __device__ inline int ta_kv_physical_from_logical(int logical) {
+    return ta_sage_perm_seq(logical, true);
+}
+
+template <int STRIDE>
+__device__ inline uint32_t ta_swizzle(uint32_t index) {
+    if constexpr (STRIDE == 16) {
+        return index;
+    }
+    const uint32_t row_idx = (index / STRIDE) % 8;
+    const uint32_t bits_to_xor = row_idx / max(64 / STRIDE, 1);
+    return index ^ (bits_to_xor << 4);
+}
+
+__device__ inline void ta_ldmatrix_x4(uint32_t reg[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+         : "=r"(reg[0]), "=r"(reg[1]), "=r"(reg[2]), "=r"(reg[3])
+         : "r"(addr));
+}
+
+__device__ inline void ta_ldmatrix_x2(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+__device__ inline void ta_ldmatrix_x2_trans(uint32_t reg[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
+         : "=r"(reg[0]), "=r"(reg[1])
+         : "r"(addr));
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__ inline void ta_gmem_to_smem(uint32_t dst, const T* src, int tid, int src_stride) {
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int num_iters = (HEIGHT * WIDTH) / (num_elements * TB_SIZE);
+
+    for (int iter = 0; iter < num_iters; iter++) {
+        const int index = (iter * TB_SIZE + tid) * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+        const uint32_t dst_addr = ta_swizzle<WIDTH * static_cast<int>(sizeof(T))>(
+            dst + (row * WIDTH + col) * static_cast<int>(sizeof(T)));
+        const T* src_addr = src + row * src_stride + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__ inline void ta_gmem_to_smem_linear(uint32_t dst, const T* src, int tid, int src_stride) {
+    constexpr int num_elements = 16 / sizeof(T);
+    constexpr int total_vectors = (HEIGHT * WIDTH) / num_elements;
+
+    for (int vec = tid; vec < total_vectors; vec += TB_SIZE) {
+        const int index = vec * num_elements;
+        const int row = index / WIDTH;
+        const int col = index % WIDTH;
+        const uint32_t dst_addr = dst + (row * WIDTH + col) * static_cast<int>(sizeof(T));
+        const T* src_addr = src + row * src_stride + col;
+        asm volatile("cp.async.cg.shared.global [%0], [%1], 16;"
+            :: "r"(dst_addr), "l"(src_addr));
+    }
+}
+
+template <int HEIGHT, int WIDTH, int TB_SIZE, typename T>
+__device__ inline void ta_load_scales(uint32_t dst, const T* src, int src_stride, int tid) {
+    constexpr int cp_size = WIDTH * sizeof(T);
+    static_assert(cp_size < 16);
+
+    auto load_row = [&](int row) {
+        const uint32_t dst_addr = dst + row * WIDTH * sizeof(T);
+        const T* src_addr = src + row * src_stride;
+        if constexpr (cp_size == 2) {
+            uint16_t value;
+            asm volatile("ld.global.u16 %0, [%1];"
+                : "=h"(value)
+                : "l"(src_addr));
+            asm volatile("st.shared.u16 [%0], %1;"
+                :: "r"(dst_addr), "h"(value));
+        } else {
+            asm volatile("cp.async.ca.shared.global [%0], [%1], %2;"
+                :: "r"(dst_addr), "l"(src_addr), "n"(cp_size));
+        }
+    };
+
+    for (int iter = 0; iter < HEIGHT / TB_SIZE; iter++) {
+        load_row(iter * TB_SIZE + tid);
+    }
+    if constexpr (HEIGHT % TB_SIZE != 0) {
+        const int row = HEIGHT / TB_SIZE * TB_SIZE + tid;
+        if (row < HEIGHT) {
+            load_row(row);
+        }
+    }
+}
+
+__device__ inline uint32_t ta_ld_shared_u16(uint32_t addr) {
+    uint16_t value;
+    asm volatile("ld.shared.u16 %0, [%1];"
+        : "=h"(value)
+        : "r"(addr));
+    return static_cast<uint32_t>(value);
+}
+
+__device__ inline uint32_t ta_cvt_8xf32_to_e2m1_packed(
+    float f0, float f1, float f2, float f3,
+    float f4, float f5, float f6, float f7) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b8 a0, a1, a2, a3;\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a0, %1, %2;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a1, %3, %4;\n\t"
+        "mov.b16 lo, {a0, a1};\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a2, %5, %6;\n\t"
+        "cvt.rn.satfinite.e2m1x2.f32 a3, %7, %8;\n\t"
+        "mov.b16 hi, {a2, a3};\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3),
+          "f"(f4), "f"(f5), "f"(f6), "f"(f7));
+    return packed;
+}
+
+__device__ inline uint32_t ta_cvt_2xf32_to_e8m0_packed(float f0, float f1) {
+    uint16_t packed;
+    asm volatile(
+        "{cvt.rp.satfinite.ue8m0x2.f32 %0, %2, %1;}"
+        : "=h"(packed)
+        : "f"(f0), "f"(f1));
+    return static_cast<uint32_t>(packed);
+}
+
+__device__ inline uint32_t ta_cvt_4xf32_to_e4m3_packed(
+    float f0, float f1, float f2, float f3) {
+    uint32_t packed;
+    asm volatile(
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 lo, %1, %2;\n\t"
+        "cvt.rn.satfinite.e4m3x2.f32 hi, %3, %4;\n\t"
+        "mov.b32 %0, {lo, hi};\n\t"
+        "}"
+        : "=r"(packed)
+        : "f"(f0), "f"(f1), "f"(f2), "f"(f3));
+    return packed;
+}
+
+__device__ inline void ta_mma_m16n8k64_nvfp4(
+    uint32_t a[4],
+    uint32_t b[2],
+    uint32_t scale_a,
+    uint32_t scale_b,
+    float acc[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4"
+        ".block_scale.scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "f"(acc[0]), "f"(acc[1]), "f"(acc[2]), "f"(acc[3]),
+          "r"(scale_a), "h"(byte_id), "h"(thread_id),
+          "r"(scale_b), "h"(byte_id), "h"(thread_id));
+}
+
+__device__ inline void ta_mma_m16n8k64_mxfp4(
+    uint32_t a[4],
+    uint32_t b[2],
+    uint32_t scale_a,
+    uint32_t scale_b,
+    float acc[4]) {
+    const uint16_t byte_id = 0;
+    const uint16_t thread_id = 0;
+    asm volatile(
+        "mma.sync.aligned.m16n8k64.row.col.kind::mxf4"
+        ".block_scale.scale_vec::2X.f32.e2m1.e2m1.f32.ue8m0 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13}, "
+        "{%14}, {%15, %16}, "
+        "{%17}, {%18, %19};"
+        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "f"(acc[0]), "f"(acc[1]), "f"(acc[2]), "f"(acc[3]),
+          "r"(scale_a), "h"(byte_id), "h"(thread_id),
+          "r"(scale_b), "h"(byte_id), "h"(thread_id));
+}
+
+__device__ __forceinline__ void ta_mma_m16n8k16_f16(
+    const uint32_t (&a)[4],
+    const uint32_t (&b)[2],
+    float (&acc)[4]) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};"
+        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "f"(acc[0]), "f"(acc[1]), "f"(acc[2]), "f"(acc[3]));
+}
+
+__device__ __forceinline__ void ta_mma_m16n8k16_bf16(
+    const uint32_t (&a)[4],
+    const uint32_t (&b)[2],
+    float (&acc)[4]) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0, %1, %2, %3}, "
+        "{%4, %5, %6, %7}, "
+        "{%8, %9}, "
+        "{%10, %11, %12, %13};"
+        : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+          "r"(b[0]), "r"(b[1]),
+          "f"(acc[0]), "f"(acc[1]), "f"(acc[2]), "f"(acc[3]));
+}
+
+template <typename T>
+struct PrecisionTraits;
+
+template <>
+struct PrecisionTraits<half> {
+    using scalar = half;
+    using vec2 = __half2;
+
+    static __device__ __forceinline__ float to_float(scalar x) {
+        return __half2float(x);
+    }
+
+    static __device__ __forceinline__ scalar from_float(float x) {
+        return __float2half_rn(x);
+    }
+
+    static __device__ __forceinline__ vec2 pack2(float a, float b) {
+        return __floats2half2_rn(a, b);
+    }
+
+    static __device__ __forceinline__ vec2 make_vec2(scalar a, scalar b) {
+        return __halves2half2(a, b);
+    }
+
+    static __device__ __forceinline__ vec2 abs2(vec2 x) {
+        return __habs2(x);
+    }
+
+    static __device__ __forceinline__ vec2 max2(vec2 a, vec2 b) {
+        return __hmax2(a, b);
+    }
+
+    static __device__ __forceinline__ scalar low(vec2 x) {
+        return __low2half(x);
+    }
+
+    static __device__ __forceinline__ scalar high(vec2 x) {
+        return __high2half(x);
+    }
+
+    static __device__ __forceinline__ float2 to_float2(vec2 x) {
+        return __half22float2(x);
+    }
+
+    static __device__ __forceinline__ void mma(
+        const uint32_t (&a)[4],
+        const uint32_t (&b)[2],
+        float (&acc)[4]) {
+        ta_mma_m16n8k16_f16(a, b, acc);
+    }
+};
+
+template <>
+struct PrecisionTraits<__nv_bfloat16> {
+    using scalar = __nv_bfloat16;
+    using vec2 = __nv_bfloat162;
+
+    static __device__ __forceinline__ float to_float(scalar x) {
+        return __bfloat162float(x);
+    }
+
+    static __device__ __forceinline__ scalar from_float(float x) {
+        return __float2bfloat16_rn(x);
+    }
+
+    static __device__ __forceinline__ vec2 pack2(float a, float b) {
+        return __floats2bfloat162_rn(a, b);
+    }
+
+    static __device__ __forceinline__ vec2 make_vec2(scalar a, scalar b) {
+        return __halves2bfloat162(a, b);
+    }
+
+    static __device__ __forceinline__ vec2 abs2(vec2 x) {
+        return __habs2(x);
+    }
+
+    static __device__ __forceinline__ vec2 max2(vec2 a, vec2 b) {
+        return __hmax2(a, b);
+    }
+
+    static __device__ __forceinline__ scalar low(vec2 x) {
+        return __low2bfloat16(x);
+    }
+
+    static __device__ __forceinline__ scalar high(vec2 x) {
+        return __high2bfloat16(x);
+    }
+
+    static __device__ __forceinline__ float2 to_float2(vec2 x) {
+        return __bfloat1622float2(x);
+    }
+
+    static __device__ __forceinline__ void mma(
+        const uint32_t (&a)[4],
+        const uint32_t (&b)[2],
+        float (&acc)[4]) {
+        ta_mma_m16n8k16_bf16(a, b, acc);
+    }
+};

--- a/thrift-attention/flake.lock
+++ b/thrift-attention/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "kernel-builder": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1781689680,
+        "narHash": "sha256-h1SSwX195HdbFHvvPl1nBVu5794YYoyXiYXJOCWGVsA=",
+        "owner": "huggingface",
+        "repo": "kernels",
+        "rev": "19a568f64aa291880427d4ab56ee48bfeb26234b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "huggingface",
+        "repo": "kernels",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776927958,
+        "narHash": "sha256-XOzEtft7E0P6TgQViLUOQeGHlEYiQ0+FY24BPEksj6s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "kernel-builder": "kernel-builder"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "kernel-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776914043,
+        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/thrift-attention/flake.nix
+++ b/thrift-attention/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for thrift-attention kernels";
+
+  inputs = {
+    kernel-builder.url = "github:huggingface/kernels";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/thrift-attention/tests/test_thrift_attention.py
+++ b/thrift-attention/tests/test_thrift_attention.py
@@ -1,0 +1,15 @@
+import pytest
+import torch
+
+import thrift_attention
+
+
+def test_exports_flash_attention_entrypoints():
+    assert callable(thrift_attention.flash_attn_func)
+    assert callable(thrift_attention.flash_attn_varlen_func)
+
+
+def test_unsupported_dropout_is_explicit():
+    q = torch.empty(1, 64, 2, 64)
+    with pytest.raises(NotImplementedError, match="dropout_p=0.0"):
+        thrift_attention.flash_attn_func(q, q, q, dropout_p=0.1)

--- a/thrift-attention/torch-ext/thrift_attention/__init__.py
+++ b/thrift-attention/torch-ext/thrift_attention/__init__.py
@@ -1,0 +1,303 @@
+import math
+
+import torch
+
+from ._ops import ops
+
+
+BLOCK_SIZE = 64
+DEFAULT_FRACTION = 0.05
+
+
+def flash_attn_func(
+    q,
+    k,
+    v,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+):
+    check_flash_options(
+        q,
+        dropout_p,
+        softmax_scale,
+        window_size,
+        softcap,
+        alibi_slopes,
+        return_attn_probs,
+    )
+    check_qkv(q, k, v)
+
+    q_hnd = q.transpose(1, 2).contiguous()
+    k_hnd = k.transpose(1, 2).contiguous()
+    v_hnd = v.transpose(1, 2).contiguous()
+
+    if q_hnd.shape[2] == 1:
+        out = single_query_attention(q_hnd, k_hnd, v_hnd)
+    else:
+        out = tiled_attention(q_hnd, k_hnd, v_hnd, causal)
+    return out.transpose(1, 2).contiguous()
+
+
+def flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    block_table=None,
+):
+    if block_table is not None:
+        raise NotImplementedError("ThriftAttention does not support paged varlen block tables")
+    check_flash_options(
+        q,
+        dropout_p,
+        softmax_scale,
+        window_size,
+        softcap,
+        alibi_slopes,
+        return_attn_probs,
+    )
+    if q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+        raise ValueError("varlen q, k, and v must be shaped [total_tokens, heads, head_dim]")
+    if cu_seqlens_q.ndim != 1 or cu_seqlens_k.ndim != 1:
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must be rank-1 tensors")
+    if cu_seqlens_q.numel() != cu_seqlens_k.numel():
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must describe the same batch size")
+
+    outputs = []
+    for idx in range(cu_seqlens_q.numel() - 1):
+        q_start = int(cu_seqlens_q[idx].item())
+        q_end = int(cu_seqlens_q[idx + 1].item())
+        k_start = int(cu_seqlens_k[idx].item())
+        k_end = int(cu_seqlens_k[idx + 1].item())
+        out = flash_attn_func(
+            q[q_start:q_end].unsqueeze(0),
+            k[k_start:k_end].unsqueeze(0),
+            v[k_start:k_end].unsqueeze(0),
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            softcap=softcap,
+            alibi_slopes=alibi_slopes,
+            deterministic=deterministic,
+            return_attn_probs=return_attn_probs,
+        )
+        outputs.append(out.squeeze(0))
+
+    if outputs:
+        return torch.cat(outputs, dim=0)
+    return q.new_empty(q.shape)
+
+
+def check_flash_options(q, dropout_p, softmax_scale, window_size, softcap, alibi_slopes, return_attn_probs):
+    if dropout_p != 0.0:
+        raise NotImplementedError("ThriftAttention only supports dropout_p=0.0")
+    if softmax_scale is not None:
+        expected = q.shape[-1] ** -0.5
+        if not math.isclose(float(softmax_scale), expected, rel_tol=1e-5, abs_tol=1e-8):
+            raise NotImplementedError("ThriftAttention only supports the default softmax scale")
+    if window_size != (-1, -1):
+        raise NotImplementedError("ThriftAttention does not support sliding-window attention")
+    if softcap != 0.0:
+        raise NotImplementedError("ThriftAttention does not support softcap")
+    if alibi_slopes is not None:
+        raise NotImplementedError("ThriftAttention does not support ALiBi slopes")
+    if return_attn_probs:
+        raise NotImplementedError("ThriftAttention does not return attention probabilities")
+
+
+def check_qkv(q, k, v):
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("q, k, and v must be shaped [batch, seq, heads, head_dim]")
+    if not q.is_cuda or not k.is_cuda or not v.is_cuda:
+        raise ValueError("q, k, and v must be CUDA tensors")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError("q, k, and v must be float16 or bfloat16")
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError("q, k, and v must have the same dtype")
+    if q.device != k.device or q.device != v.device:
+        raise ValueError("q, k, and v must be on the same device")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError("q, k, and v must have the same batch size")
+    if k.shape[1] != v.shape[1]:
+        raise ValueError("k and v must have the same sequence length")
+    if k.shape[2] != v.shape[2]:
+        raise ValueError("k and v must have the same KV head count")
+    if q.shape[2] % k.shape[2] != 0:
+        raise ValueError("q heads must be divisible by KV heads")
+    if q.shape[3] != k.shape[3] or q.shape[3] != v.shape[3]:
+        raise ValueError("q, k, and v must have the same head_dim")
+    if q.shape[3] not in (64, 128):
+        raise ValueError("ThriftAttention supports head_dim 64 or 128")
+
+
+def single_query_attention(q, k, v):
+    if k.shape[2] % BLOCK_SIZE != 0:
+        raise ValueError("ThriftAttention single-query attention requires KV length divisible by 64")
+
+    is_bf16 = q.dtype == torch.bfloat16
+    batch, q_heads, _, head_dim = q.shape
+    kv_heads = k.shape[1]
+    groups = q_heads // kv_heads
+    if groups > 16:
+        raise NotImplementedError("ThriftAttention single-query kernels support at most 16 Q heads per KV head")
+
+    q_grouped = q.reshape(batch, kv_heads, groups, head_dim).contiguous()
+    num_kv_blocks = k.shape[2] // BLOCK_SIZE
+    selected = select_key_blocks(q_grouped, k, num_kv_blocks, is_bf16)
+
+    q_packed, q_scale = ops.nvfp4_quantize(q_grouped, is_bf16)
+    k_packed, k_scale = ops.nvfp4_quantize(k.contiguous(), is_bf16)
+    v_packed_t, v_scale_t = ops.nvfp4_quantize_transposed(v.contiguous(), is_bf16)
+    out = ops.thrift_attention_single_query_nvfp4_packed(
+        q_grouped,
+        k.contiguous(),
+        v.contiguous(),
+        selected,
+        q_packed,
+        k_packed,
+        v_packed_t,
+        q_scale,
+        k_scale,
+        v_scale_t,
+        is_bf16,
+    )
+    return out.reshape(batch, q_heads, 1, head_dim).contiguous()
+
+
+def tiled_attention(q, k, v, causal):
+    original_q_len = q.shape[2]
+    q, k, v = pad_tiled_inputs(q, k, v, causal)
+
+    is_bf16 = q.dtype == torch.bfloat16
+    selected = select_block_pairs(q, k, causal, is_bf16)
+
+    q_packed, q_scale = ops.nvfp4_quantize(q.contiguous(), is_bf16)
+    k_packed, k_scale = ops.nvfp4_quantize_permuted(k.contiguous(), is_bf16)
+    v_packed_t, v_scale_t = ops.nvfp4_quantize_transposed(v.contiguous(), is_bf16)
+    if causal:
+        attention = ops.thrift_attention_causal_nvfp4_packed
+    else:
+        attention = ops.thrift_attention_noncausal_nvfp4_packed
+    out = attention(
+        q,
+        k,
+        v,
+        selected,
+        q_packed,
+        k_packed,
+        v_packed_t,
+        q_scale,
+        k_scale,
+        v_scale_t,
+        is_bf16,
+    )
+    return out[:, :, :original_q_len, :].contiguous()
+
+
+def pad_tiled_inputs(q, k, v, causal):
+    q_len = q.shape[2]
+    kv_len = k.shape[2]
+    if q_len == kv_len and q_len % BLOCK_SIZE == 0:
+        return q.contiguous(), k.contiguous(), v.contiguous()
+    if q_len == kv_len and causal:
+        padded_len = ((q_len + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+        if padded_len == q_len:
+            return q.contiguous(), k.contiguous(), v.contiguous()
+        pad = padded_len - q_len
+        q_pad = q.new_zeros(q.shape[0], q.shape[1], pad, q.shape[3])
+        k_pad = k.new_zeros(k.shape[0], k.shape[1], pad, k.shape[3])
+        v_pad = v.new_zeros(v.shape[0], v.shape[1], pad, v.shape[3])
+        return (
+            torch.cat((q, q_pad), dim=2).contiguous(),
+            torch.cat((k, k_pad), dim=2).contiguous(),
+            torch.cat((v, v_pad), dim=2).contiguous(),
+        )
+    if q_len % BLOCK_SIZE == 0 and kv_len % BLOCK_SIZE == 0:
+        return q.contiguous(), k.contiguous(), v.contiguous()
+    raise ValueError("ThriftAttention tiled attention requires block-aligned sequence lengths")
+
+
+def select_block_pairs(q, k, causal, is_bf16):
+    num_kv_blocks = k.shape[2] // BLOCK_SIZE
+    selected_count = resolve_top_k(num_kv_blocks, causal)
+    q_mean = block_means(q, is_bf16)
+    k_mean = block_means(k, is_bf16)
+    if q.shape[1] != k.shape[1]:
+        groups = q.shape[1] // k.shape[1]
+        k_mean = k_mean.repeat_interleave(groups, dim=1).contiguous()
+    if num_kv_blocks <= 2048:
+        return ops.block_mean_topk(q_mean, k_mean, selected_count, causal, is_bf16)
+
+    scores = (
+        q_mean.reshape(q.shape[0] * q.shape[1], q_mean.shape[2], q.shape[3]).float()
+        @ k_mean.reshape(q.shape[0] * q.shape[1], num_kv_blocks, q.shape[3])
+        .float()
+        .transpose(-1, -2)
+    )
+    if causal:
+        mask = torch.triu(
+            torch.ones(q_mean.shape[2], num_kv_blocks, device=q.device, dtype=torch.bool),
+            diagonal=1,
+        )
+        scores.masked_fill_(mask.unsqueeze(0), float("-inf"))
+    indices = scores.topk(selected_count, dim=-1).indices.to(torch.int32)
+    if causal:
+        valid_counts = torch.arange(1, q_mean.shape[2] + 1, device=q.device).clamp(max=num_kv_blocks)
+        ranks = torch.arange(selected_count, device=q.device)
+        indices.masked_fill_(ranks.view(1, 1, -1) >= valid_counts.view(1, -1, 1), -1)
+    return indices.contiguous()
+
+
+def select_key_blocks(q_grouped, k, num_kv_blocks, is_bf16):
+    selected_count = resolve_top_k(num_kv_blocks, False)
+    k_mean = block_means(k, is_bf16)
+    if num_kv_blocks <= 2048:
+        return ops.single_query_key_mean_topk(q_grouped, k_mean, selected_count, num_kv_blocks, is_bf16)
+    scores = (q_grouped.float().unsqueeze(3) * k_mean.float().unsqueeze(2)).sum(dim=-1)
+    scores = scores.amax(dim=2).reshape(q_grouped.shape[0] * q_grouped.shape[1], num_kv_blocks)
+    return scores.topk(selected_count, dim=-1).indices.to(torch.int32).contiguous()
+
+
+def block_means(x, is_bf16):
+    batch, heads, seq_len, head_dim = x.shape
+    out_dtype = torch.bfloat16 if is_bf16 else torch.float16
+    return (
+        x.reshape(batch, heads, seq_len // BLOCK_SIZE, BLOCK_SIZE, head_dim)
+        .float()
+        .mean(dim=3)
+        .to(out_dtype)
+        .contiguous()
+    )
+
+
+def resolve_top_k(num_blocks, causal):
+    if num_blocks <= 0:
+        return 0
+    if not causal:
+        return max(1, min(num_blocks, round(DEFAULT_FRACTION * num_blocks)))
+
+    b = -(2 * num_blocks + 1)
+    c = DEFAULT_FRACTION * num_blocks * (num_blocks + 1)
+    discriminant = b * b - 4.0 * c
+    if discriminant < 0.0:
+        return num_blocks
+    top_k_float = (-b - math.sqrt(discriminant)) / 2.0
+    return max(1, min(num_blocks, round(top_k_float)))

--- a/thrift-attention/torch-ext/torch_binding.cpp
+++ b/thrift-attention/torch-ext/torch_binding.cpp
@@ -1,0 +1,1436 @@
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+void check_hi_qkv(const at::Tensor& q, const at::Tensor& k, const at::Tensor& v) {
+    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Q/K/V must be CUDA tensors");
+    TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4,
+                "Q/K/V must be 4D [batch, heads, seq, head_dim]");
+    TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0),
+                "Q/K/V batch dimensions must match");
+    TORCH_CHECK(k.size(1) == v.size(1), "K and V head dimensions must match");
+    TORCH_CHECK(k.size(2) == v.size(2), "K and V sequence lengths must match");
+    TORCH_CHECK(q.size(3) == k.size(3) && q.size(3) == v.size(3),
+                "Q/K/V head dimensions must match");
+}
+
+void check_packed_qkv(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t) {
+    TORCH_CHECK(q_packed.is_cuda() && k_packed.is_cuda() && v_packed_t.is_cuda(),
+                "packed Q/K/V must be CUDA tensors");
+    TORCH_CHECK(q_scale.is_cuda() && k_scale.is_cuda() && v_scale_t.is_cuda(),
+                "Q/K/V scales must be CUDA tensors");
+    TORCH_CHECK(q_packed.dim() == 4 && k_packed.dim() == 4 && v_packed_t.dim() == 4,
+                "packed Q/K/V must be 4D tensors");
+    TORCH_CHECK(q_packed.size(0) == k_packed.size(0), "packed Q/K batch dimensions must match");
+    TORCH_CHECK(q_packed.size(1) % k_packed.size(1) == 0,
+                "Q heads must be divisible by KV heads");
+    TORCH_CHECK(q_packed.size(3) == k_packed.size(3), "packed Q/K head dimensions must match");
+}
+
+int single_query_mixed_target_split_ctas(int total_kv_blocks) {
+    if (const char* env = std::getenv("SAGE_MIXED_SPLIT_CTAS")) {
+        const int value = std::atoi(env);
+        if (value > 0) {
+            return value;
+        }
+    }
+    return (total_kv_blocks <= 512) ? 384
+         : (total_kv_blocks <= 1024) ? 384
+         : 896;
+}
+
+}  // namespace
+
+// Implemented in csrc/cuda/sm120/nvfp4/fp4_attention.cu.
+void fp4_attention_causal_nvfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+void fp4_attention_noncausal_nvfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/mxfp4/fp4_attention.cu.
+void fp4_attention_causal_mxfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+void fp4_attention_noncausal_mxfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/nvfp4/single_query_fp4_attention.cu.
+void fp4_attention_single_query_nvfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* workspace,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/mxfp4/single_query_fp4_attention.cu.
+void fp4_attention_single_query_mxfp4(
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* workspace,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+
+// Implemented in csrc/cuda/sm120/nvfp4/thrift_attention.cu.
+void thrift_attention_causal_nvfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const void* selected_blocks, int topk_count,
+    const void* topk_mask, int topk_word_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* rowmax_state, void* rowsum_state,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+void thrift_attention_noncausal_nvfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const void* selected_blocks, int topk_count,
+    const void* topk_mask, int topk_word_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* rowmax_state, void* rowsum_state,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/mxfp4/thrift_attention.cu.
+void thrift_attention_causal_mxfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const void* selected_blocks, int topk_count,
+    const void* topk_mask, int topk_word_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* rowmax_state, void* rowsum_state,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+void thrift_attention_noncausal_mxfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const void* selected_blocks, int topk_count,
+    const void* topk_mask, int topk_word_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* rowmax_state, void* rowsum_state,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/nvfp4/single_query_attention.cu.
+void thrift_attention_single_query_nvfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const int32_t* selected_blocks, int topk_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* workspace,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+// Implemented in csrc/cuda/sm120/mxfp4/single_query_attention.cu.
+void thrift_attention_single_query_mxfp4(
+    const void* Q_fp16, const void* K_fp16, const void* V_fp16,
+    const int32_t* selected_blocks, int topk_count,
+    const void* Q, const void* K, const void* V,
+    const void* S_Q, const void* S_K, const void* S_V,
+    void* O, void* workspace,
+    int bs, int q_len, int kv_len, int kv_capacity,
+    int num_q_heads, int num_kv_heads, int head_dim, bool is_bf16);
+
+// Implemented in csrc/cuda/sm120/nvfp4/quantization.cu.
+void nvfp4_quantise(void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool is_bf16);
+void nvfp4_quantise_permute_seq(
+    void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool inverse, bool is_bf16);
+void nvfp4_quantise_transpose(void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool is_bf16);
+void nvfp4_quantise_transpose_permute_seq(
+    void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool inverse, bool is_bf16);
+// Implemented in csrc/cuda/sm120/mxfp4/quantization.cu.
+void mxfp4_quantise(void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool is_bf16);
+void mxfp4_quantise_permute_seq(
+    void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool inverse, bool is_bf16);
+void mxfp4_quantise_transpose(void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool is_bf16);
+void mxfp4_quantise_transpose_permute_seq(
+    void* X, void* X_fp4, void* X_scale, int bs, int seq_len, int head_dim, bool inverse, bool is_bf16);
+
+// Implemented in csrc/cuda/sm120/shared/block_selection.cu.
+void block_mean_topk(
+    const void* q_mean,
+    const void* k_mean,
+    void* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal,
+    bool is_bf16);
+void quest_block_topk(
+    const void* q_mean,
+    const void* k_min,
+    const void* k_max,
+    void* topk_out,
+    int flat_heads,
+    int num_q_blocks,
+    int num_kv_blocks,
+    int head_dim,
+    int topk_count,
+    bool causal,
+    bool is_bf16);
+void single_query_key_mean_topk(
+    const void* q_grouped,
+    const void* k_mean,
+    void* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    bool is_bf16);
+void single_query_quest_topk(
+    const void* q_grouped,
+    const void* k_min,
+    const void* k_max,
+    void* topk_out,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_stat_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    bool is_bf16);
+void single_query_key_mean_topk_chunked(
+    const void* q_grouped,
+    const void* k_mean,
+    void* topk_out,
+    void* local_scores,
+    void* local_indices,
+    void* done_counts,
+    int flat_heads,
+    int groups,
+    int num_kv_blocks,
+    int k_mean_capacity_blocks,
+    int head_dim,
+    int topk_count,
+    int chunk_count,
+    int local_count,
+    bool is_bf16);
+void pack_topk_mask(
+    const int32_t* topk,
+    void* topk_mask,
+    int row_count,
+    int topk_count,
+    int total_units,
+    int word_count);
+
+static at::Tensor fp4_attention_nvfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool causal,
+    bool is_bf16) {
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+
+    if (causal) {
+        fp4_attention_causal_nvfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    } else {
+        fp4_attention_noncausal_nvfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    }
+
+    return out;
+}
+
+static at::Tensor fp4_attention_causal_nvfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return fp4_attention_nvfp4_packed(
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, true, is_bf16);
+}
+
+static at::Tensor fp4_attention_noncausal_nvfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return fp4_attention_nvfp4_packed(
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, false, is_bf16);
+}
+
+static at::Tensor fp4_attention_mxfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool causal,
+    bool is_bf16) {
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+
+    if (causal) {
+        fp4_attention_causal_mxfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    } else {
+        fp4_attention_noncausal_mxfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    }
+
+    return out;
+}
+
+static at::Tensor fp4_attention_causal_mxfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return fp4_attention_mxfp4_packed(
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, true, is_bf16);
+}
+
+static at::Tensor fp4_attention_noncausal_mxfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return fp4_attention_mxfp4_packed(
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, false, is_bf16);
+}
+
+static at::Tensor fp4_attention_single_query_nvfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(q_len >= 1 && q_len <= 16,
+                "single-query FP4 attention expects grouped query length in [1, 16], got ",
+                q_len);
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+
+    constexpr int block_kv = 64;
+    const int total_kv_blocks = (kv_len + block_kv - 1) / block_kv;
+    const bool use_split = total_kv_blocks >= 128;
+
+    auto dispatch = [&](void* workspace) {
+        fp4_attention_single_query_nvfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), workspace,
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    };
+
+    if (!use_split) {
+        dispatch(nullptr);
+        return out;
+    }
+
+    int num_kv_splits = std::max(1, std::min(total_kv_blocks, (256 + flat_q_heads - 1) / flat_q_heads));
+    num_kv_splits = std::min(num_kv_splits, total_kv_blocks);
+    const int64_t workspace_elems =
+        static_cast<int64_t>(flat_q_heads) * num_kv_splits * 16 * (head_dim + 2) + flat_q_heads;
+    at::Tensor workspace = at::empty({workspace_elems},
+        at::TensorOptions().dtype(at::kFloat).device(q_packed.device()));
+    dispatch(workspace.data_ptr());
+    return out;
+}
+
+static at::Tensor fp4_attention_single_query_mxfp4_packed(
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(q_len >= 1 && q_len <= 16,
+                "single-query FP4 attention expects grouped query length in [1, 16], got ",
+                q_len);
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+
+    constexpr int block_kv = 64;
+    const int total_kv_blocks = (kv_len + block_kv - 1) / block_kv;
+    const bool use_split = total_kv_blocks >= 128;
+
+    auto dispatch = [&](void* workspace) {
+        fp4_attention_single_query_mxfp4(
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), workspace,
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    };
+
+    if (!use_split) {
+        dispatch(nullptr);
+        return out;
+    }
+
+    int num_kv_splits = std::max(1, std::min(total_kv_blocks, (256 + flat_q_heads - 1) / flat_q_heads));
+    num_kv_splits = std::min(num_kv_splits, total_kv_blocks);
+    const int64_t workspace_elems =
+        static_cast<int64_t>(flat_q_heads) * num_kv_splits * 16 * (head_dim + 2) + flat_q_heads;
+    at::Tensor workspace = at::empty({workspace_elems},
+        at::TensorOptions().dtype(at::kFloat).device(q_packed.device()));
+    dispatch(workspace.data_ptr());
+    return out;
+}
+
+static at::Tensor thrift_attention_nvfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool causal,
+    bool is_bf16) {
+    check_hi_qkv(q_hi, k_hi, v_hi);
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+    TORCH_CHECK(selected_blocks.is_cuda(), "selected_blocks must be a CUDA tensor");
+    TORCH_CHECK(selected_blocks.dtype() == at::kInt, "selected_blocks must be int32");
+    TORCH_CHECK(selected_blocks.is_contiguous(), "selected_blocks must be contiguous");
+    TORCH_CHECK(selected_blocks.dim() == 3,
+                "selected_blocks must be [batch * heads, q_blocks, top_k]");
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    constexpr int block_q = 64;
+    const int num_q_blocks = (q_len + block_q - 1) / block_q;
+    const int topk_count = selected_blocks.size(2);
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(selected_blocks.size(0) == flat_q_heads,
+                "selected_blocks first dimension must equal batch * Q heads");
+    TORCH_CHECK(selected_blocks.size(1) == num_q_blocks,
+                "selected_blocks second dimension must equal number of Q blocks");
+
+    if (topk_count == 0) {
+        return fp4_attention_nvfp4_packed(
+            q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, causal, is_bf16);
+    }
+
+    constexpr int topk_unit_tokens = 64;
+    const int total_topk_units = (kv_len + topk_unit_tokens - 1) / topk_unit_tokens;
+    const int topk_word_count = (total_topk_units + 63) / 64;
+    TORCH_CHECK(topk_word_count <= 32,
+                "ThriftAttention supports at most 2048 64-token KV blocks, got ",
+                total_topk_units);
+
+    auto mask_opts = at::TensorOptions().dtype(at::kLong).device(selected_blocks.device());
+    at::Tensor topk_mask = at::empty({flat_q_heads, num_q_blocks, topk_word_count}, mask_opts);
+    pack_topk_mask(
+        static_cast<const int32_t*>(selected_blocks.data_ptr()),
+        topk_mask.data_ptr(),
+        flat_q_heads * num_q_blocks, topk_count, total_topk_units, topk_word_count);
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+    auto state_opts = at::TensorOptions().dtype(at::kFloat).device(q_packed.device());
+    at::Tensor rowmax_state = at::empty({batch, num_q_heads, q_len}, state_opts);
+    at::Tensor rowsum_state = at::empty({batch, num_q_heads, q_len}, state_opts);
+
+    if (causal) {
+        thrift_attention_causal_nvfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            selected_blocks.data_ptr(), topk_count,
+            topk_mask.data_ptr(), topk_word_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), rowmax_state.data_ptr(), rowsum_state.data_ptr(),
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    } else {
+        thrift_attention_noncausal_nvfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            selected_blocks.data_ptr(), topk_count,
+            topk_mask.data_ptr(), topk_word_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), rowmax_state.data_ptr(), rowsum_state.data_ptr(),
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    }
+
+    return out;
+}
+
+static at::Tensor thrift_attention_causal_nvfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return thrift_attention_nvfp4_packed(
+        q_hi, k_hi, v_hi, selected_blocks,
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, true, is_bf16);
+}
+
+static at::Tensor thrift_attention_noncausal_nvfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return thrift_attention_nvfp4_packed(
+        q_hi, k_hi, v_hi, selected_blocks,
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, false, is_bf16);
+}
+
+static at::Tensor thrift_attention_mxfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool causal,
+    bool is_bf16) {
+    check_hi_qkv(q_hi, k_hi, v_hi);
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+    TORCH_CHECK(selected_blocks.is_cuda(), "selected_blocks must be a CUDA tensor");
+    TORCH_CHECK(selected_blocks.dtype() == at::kInt, "selected_blocks must be int32");
+    TORCH_CHECK(selected_blocks.is_contiguous(), "selected_blocks must be contiguous");
+    TORCH_CHECK(selected_blocks.dim() == 3,
+                "selected_blocks must be [batch * heads, q_blocks, top_k]");
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    constexpr int block_q = 64;
+    const int num_q_blocks = (q_len + block_q - 1) / block_q;
+    const int topk_count = selected_blocks.size(2);
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(selected_blocks.size(0) == flat_q_heads,
+                "selected_blocks first dimension must equal batch * Q heads");
+    TORCH_CHECK(selected_blocks.size(1) == num_q_blocks,
+                "selected_blocks second dimension must equal number of Q blocks");
+
+    if (topk_count == 0) {
+        return fp4_attention_mxfp4_packed(
+            q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, causal, is_bf16);
+    }
+
+    constexpr int topk_unit_tokens = 64;
+    const int total_topk_units = (kv_len + topk_unit_tokens - 1) / topk_unit_tokens;
+    const int topk_word_count = (total_topk_units + 63) / 64;
+    TORCH_CHECK(topk_word_count <= 32,
+                "ThriftAttention supports at most 2048 64-token KV blocks, got ",
+                total_topk_units);
+
+    auto mask_opts = at::TensorOptions().dtype(at::kLong).device(selected_blocks.device());
+    at::Tensor topk_mask = at::empty({flat_q_heads, num_q_blocks, topk_word_count}, mask_opts);
+    pack_topk_mask(
+        static_cast<const int32_t*>(selected_blocks.data_ptr()),
+        topk_mask.data_ptr(),
+        flat_q_heads * num_q_blocks, topk_count, total_topk_units, topk_word_count);
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+    auto state_opts = at::TensorOptions().dtype(at::kFloat).device(q_packed.device());
+    at::Tensor rowmax_state = at::empty({batch, num_q_heads, q_len}, state_opts);
+    at::Tensor rowsum_state = at::empty({batch, num_q_heads, q_len}, state_opts);
+
+    if (causal) {
+        thrift_attention_causal_mxfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            selected_blocks.data_ptr(), topk_count,
+            topk_mask.data_ptr(), topk_word_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), rowmax_state.data_ptr(), rowsum_state.data_ptr(),
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    } else {
+        thrift_attention_noncausal_mxfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            selected_blocks.data_ptr(), topk_count,
+            topk_mask.data_ptr(), topk_word_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), rowmax_state.data_ptr(), rowsum_state.data_ptr(),
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    }
+
+    return out;
+}
+
+static at::Tensor thrift_attention_causal_mxfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return thrift_attention_mxfp4_packed(
+        q_hi, k_hi, v_hi, selected_blocks,
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, true, is_bf16);
+}
+
+static at::Tensor thrift_attention_noncausal_mxfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    return thrift_attention_mxfp4_packed(
+        q_hi, k_hi, v_hi, selected_blocks,
+        q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, false, is_bf16);
+}
+
+static at::Tensor thrift_attention_single_query_nvfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    check_hi_qkv(q_hi, k_hi, v_hi);
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+    TORCH_CHECK(selected_blocks.is_cuda(), "selected_blocks must be a CUDA tensor");
+    TORCH_CHECK(selected_blocks.dtype() == at::kInt, "selected_blocks must be int32");
+    TORCH_CHECK(selected_blocks.is_contiguous(), "selected_blocks must be contiguous");
+    TORCH_CHECK(selected_blocks.dim() == 2,
+                "selected_blocks must be [batch * grouped_heads, top_k]");
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int topk_count = selected_blocks.size(1);
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(q_len >= 1 && q_len <= 16,
+                "single-query ThriftAttention expects grouped query length in [1, 16], got ",
+                q_len);
+    TORCH_CHECK(q_hi.size(0) == batch && q_hi.size(1) == num_q_heads &&
+                q_hi.size(2) == q_len && q_hi.size(3) == head_dim,
+                "q_hi shape must match packed Q");
+    TORCH_CHECK(selected_blocks.size(0) == flat_q_heads,
+                "selected_blocks first dimension must equal batch * grouped_heads");
+
+    constexpr int block_kv = 64;
+    const int total_kv_blocks = (kv_len + block_kv - 1) / block_kv;
+    TORCH_CHECK(topk_count >= 0 && topk_count <= total_kv_blocks,
+                "selected block count must be in [0, number of KV blocks]");
+
+    if (topk_count == 0) {
+        return fp4_attention_single_query_nvfp4_packed(
+            q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, is_bf16);
+    }
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+    const bool use_split = total_kv_blocks >= 64;
+
+    auto dispatch = [&](void* workspace) {
+        thrift_attention_single_query_nvfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            static_cast<const int32_t*>(selected_blocks.data_ptr()), topk_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), workspace,
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    };
+
+    if (!use_split) {
+        dispatch(nullptr);
+        return out;
+    }
+
+    const int target_split_ctas = single_query_mixed_target_split_ctas(total_kv_blocks);
+    int num_kv_splits =
+        std::max(1, std::min(total_kv_blocks, (target_split_ctas + flat_q_heads - 1) / flat_q_heads));
+    num_kv_splits = std::min(num_kv_splits, total_kv_blocks);
+    const int64_t workspace_elems =
+        static_cast<int64_t>(flat_q_heads) * num_kv_splits * q_len * (head_dim + 2) + flat_q_heads;
+    at::Tensor workspace = at::empty({workspace_elems},
+        at::TensorOptions().dtype(at::kFloat).device(q_packed.device()));
+    dispatch(workspace.data_ptr());
+    return out;
+}
+
+static at::Tensor thrift_attention_single_query_mxfp4_packed(
+    const at::Tensor& q_hi,
+    const at::Tensor& k_hi,
+    const at::Tensor& v_hi,
+    const at::Tensor& selected_blocks,
+    const at::Tensor& q_packed,
+    const at::Tensor& k_packed,
+    const at::Tensor& v_packed_t,
+    const at::Tensor& q_scale,
+    const at::Tensor& k_scale,
+    const at::Tensor& v_scale_t,
+    bool is_bf16 = false) {
+    check_hi_qkv(q_hi, k_hi, v_hi);
+    check_packed_qkv(q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t);
+    TORCH_CHECK(selected_blocks.is_cuda(), "selected_blocks must be a CUDA tensor");
+    TORCH_CHECK(selected_blocks.dtype() == at::kInt, "selected_blocks must be int32");
+    TORCH_CHECK(selected_blocks.is_contiguous(), "selected_blocks must be contiguous");
+    TORCH_CHECK(selected_blocks.dim() == 2,
+                "selected_blocks must be [batch * grouped_heads, top_k]");
+
+    const int batch = q_packed.size(0);
+    const int num_q_heads = q_packed.size(1);
+    const int num_kv_heads = k_packed.size(1);
+    const int flat_q_heads = batch * num_q_heads;
+    const int q_len = q_packed.size(2);
+    const int kv_len = k_packed.size(2);
+    const int head_dim = q_packed.size(3) * 2;
+    const int topk_count = selected_blocks.size(1);
+    const int kv_capacity = static_cast<int>(k_packed.stride(1)) / (head_dim / 2);
+    const at::ScalarType out_dtype = is_bf16 ? at::kBFloat16 : at::kHalf;
+    TORCH_CHECK(q_len >= 1 && q_len <= 16,
+                "single-query ThriftAttention expects grouped query length in [1, 16], got ",
+                q_len);
+    TORCH_CHECK(q_hi.size(0) == batch && q_hi.size(1) == num_q_heads &&
+                q_hi.size(2) == q_len && q_hi.size(3) == head_dim,
+                "q_hi shape must match packed Q");
+    TORCH_CHECK(selected_blocks.size(0) == flat_q_heads,
+                "selected_blocks first dimension must equal batch * grouped_heads");
+
+    constexpr int block_kv = 64;
+    const int total_kv_blocks = (kv_len + block_kv - 1) / block_kv;
+    TORCH_CHECK(topk_count >= 0 && topk_count <= total_kv_blocks,
+                "selected block count must be in [0, number of KV blocks]");
+
+    if (topk_count == 0) {
+        return fp4_attention_single_query_mxfp4_packed(
+            q_packed, k_packed, v_packed_t, q_scale, k_scale, v_scale_t, is_bf16);
+    }
+
+    at::Tensor out = at::empty({batch, num_q_heads, q_len, head_dim},
+        at::TensorOptions().dtype(out_dtype).device(q_packed.device()));
+    const bool use_split = total_kv_blocks >= 64;
+
+    auto dispatch = [&](void* workspace) {
+        thrift_attention_single_query_mxfp4(
+            q_hi.data_ptr(), k_hi.data_ptr(), v_hi.data_ptr(),
+            static_cast<const int32_t*>(selected_blocks.data_ptr()), topk_count,
+            q_packed.data_ptr(), k_packed.data_ptr(), v_packed_t.data_ptr(),
+            q_scale.data_ptr(), k_scale.data_ptr(), v_scale_t.data_ptr(),
+            out.data_ptr(), workspace,
+            flat_q_heads, q_len, kv_len, kv_capacity,
+            num_q_heads, num_kv_heads, head_dim, is_bf16);
+    };
+
+    if (!use_split) {
+        dispatch(nullptr);
+        return out;
+    }
+
+    const int target_split_ctas = single_query_mixed_target_split_ctas(total_kv_blocks);
+    int num_kv_splits =
+        std::max(1, std::min(total_kv_blocks, (target_split_ctas + flat_q_heads - 1) / flat_q_heads));
+    num_kv_splits = std::min(num_kv_splits, total_kv_blocks);
+    const int64_t workspace_elems =
+        static_cast<int64_t>(flat_q_heads) * num_kv_splits * q_len * (head_dim + 2) + flat_q_heads;
+    at::Tensor workspace = at::empty({workspace_elems},
+        at::TensorOptions().dtype(at::kFloat).device(q_packed.device()));
+    dispatch(workspace.data_ptr());
+    return out;
+}
+
+static std::vector<at::Tensor> nvfp4_quantize(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_f8 = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, seq_len, head_dim / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, seq_len, head_dim / 16}, opts_f8);
+
+    nvfp4_quantise(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> nvfp4_quantize_permuted(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_f8 = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, seq_len, head_dim / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, seq_len, head_dim / 16}, opts_f8);
+
+    nvfp4_quantise_permute_seq(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, false, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> nvfp4_quantize_transposed(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    constexpr int seq_block = 128;
+    const int padded_seq = ((seq_len + seq_block - 1) / seq_block) * seq_block;
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_f8 = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, head_dim, padded_seq / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, head_dim, padded_seq / 16}, opts_f8);
+
+    nvfp4_quantise_transpose(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> nvfp4_quantize_transposed_permuted(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    constexpr int seq_block = 128;
+    const int padded_seq = ((seq_len + seq_block - 1) / seq_block) * seq_block;
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_f8 = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, head_dim, padded_seq / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, head_dim, padded_seq / 16}, opts_f8);
+
+    nvfp4_quantise_transpose_permute_seq(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, false, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> mxfp4_quantize(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_e8m0 = at::TensorOptions().dtype(at::kFloat8_e8m0fnu).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, seq_len, head_dim / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, seq_len, head_dim / 32}, opts_e8m0);
+
+    mxfp4_quantise(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> mxfp4_quantize_permuted(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_e8m0 = at::TensorOptions().dtype(at::kFloat8_e8m0fnu).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, seq_len, head_dim / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, seq_len, head_dim / 32}, opts_e8m0);
+
+    mxfp4_quantise_permute_seq(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, false, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> mxfp4_quantize_transposed(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    constexpr int seq_block = 128;
+    const int padded_seq = ((seq_len + seq_block - 1) / seq_block) * seq_block;
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_e8m0 = at::TensorOptions().dtype(at::kFloat8_e8m0fnu).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, head_dim, padded_seq / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, head_dim, padded_seq / 32}, opts_e8m0);
+
+    mxfp4_quantise_transpose(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static std::vector<at::Tensor> mxfp4_quantize_transposed_permuted(const at::Tensor& x, bool is_bf16 = false) {
+    TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(x.dim() == 4, "x must be 4D [batch, heads, seq, head_dim]");
+
+    const int batch = x.size(0);
+    const int heads = x.size(1);
+    const int seq_len = x.size(2);
+    const int head_dim = x.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+
+    constexpr int seq_block = 128;
+    const int padded_seq = ((seq_len + seq_block - 1) / seq_block) * seq_block;
+    auto opts_u8 = at::TensorOptions().dtype(at::kByte).device(x.device());
+    auto opts_e8m0 = at::TensorOptions().dtype(at::kFloat8_e8m0fnu).device(x.device());
+    at::Tensor x_packed = at::empty({batch, heads, head_dim, padded_seq / 2}, opts_u8);
+    at::Tensor x_scale = at::empty({batch, heads, head_dim, padded_seq / 32}, opts_e8m0);
+
+    mxfp4_quantise_transpose_permute_seq(
+        x.data_ptr(), x_packed.data_ptr(), x_scale.data_ptr(),
+        batch * heads, seq_len, head_dim, false, is_bf16);
+
+    return {x_packed, x_scale};
+}
+
+static at::Tensor block_mean_topk_impl(
+    const at::Tensor& q_mean,
+    const at::Tensor& k_mean,
+    int topk_count,
+    bool causal = true,
+    bool is_bf16 = false) {
+    TORCH_CHECK(q_mean.is_cuda() && k_mean.is_cuda(),
+                "q_mean and k_mean must be CUDA tensors");
+    TORCH_CHECK(q_mean.is_contiguous() && k_mean.is_contiguous(),
+                "q_mean and k_mean must be contiguous");
+    TORCH_CHECK(q_mean.dim() == 4 && k_mean.dim() == 4,
+                "q_mean and k_mean must be 4D tensors");
+    TORCH_CHECK(q_mean.size(0) == k_mean.size(0),
+                "q_mean and k_mean batch dimensions must match");
+    TORCH_CHECK(q_mean.size(1) == k_mean.size(1),
+                "q_mean and k_mean head dimensions must match");
+    TORCH_CHECK(q_mean.size(3) == k_mean.size(3),
+                "q_mean and k_mean head_dim must match");
+
+    const int batch = q_mean.size(0);
+    const int heads = q_mean.size(1);
+    const int flat_heads = batch * heads;
+    const int num_q_blocks = q_mean.size(2);
+    const int num_kv_blocks = k_mean.size(2);
+    const int head_dim = q_mean.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+    TORCH_CHECK(num_kv_blocks <= 2048,
+                "block selector supports <= 2048 KV blocks, got ", num_kv_blocks);
+    TORCH_CHECK(topk_count >= 0 && topk_count <= num_kv_blocks,
+                "topk_count must be in [0, num_kv_blocks]");
+
+    auto opts = at::TensorOptions().dtype(at::kInt).device(q_mean.device());
+    at::Tensor topk = at::empty({flat_heads, num_q_blocks, topk_count}, opts);
+    if (topk_count == 0) {
+        return topk;
+    }
+
+    block_mean_topk(
+        q_mean.data_ptr(), k_mean.data_ptr(), topk.data_ptr(),
+        flat_heads, num_q_blocks, num_kv_blocks, head_dim, topk_count, causal, is_bf16);
+
+    return topk;
+}
+
+static at::Tensor quest_block_topk_impl(
+    const at::Tensor& q_mean,
+    const at::Tensor& k_min,
+    const at::Tensor& k_max,
+    int topk_count,
+    bool causal = true,
+    bool is_bf16 = false) {
+    TORCH_CHECK(q_mean.is_cuda() && k_min.is_cuda() && k_max.is_cuda(),
+                "q_mean, k_min, and k_max must be CUDA tensors");
+    TORCH_CHECK(q_mean.is_contiguous() && k_min.is_contiguous() && k_max.is_contiguous(),
+                "q_mean, k_min, and k_max must be contiguous");
+    TORCH_CHECK(q_mean.dim() == 4 && k_min.dim() == 4 && k_max.dim() == 4,
+                "q_mean, k_min, and k_max must be 4D tensors");
+    TORCH_CHECK(k_min.sizes() == k_max.sizes(),
+                "k_min and k_max shapes must match");
+    TORCH_CHECK(q_mean.size(0) == k_min.size(0),
+                "q_mean and key stat batch dimensions must match");
+    TORCH_CHECK(q_mean.size(1) == k_min.size(1),
+                "q_mean and key stat head dimensions must match");
+    TORCH_CHECK(q_mean.size(3) == k_min.size(3),
+                "q_mean and key stat head_dim must match");
+
+    const int batch = q_mean.size(0);
+    const int heads = q_mean.size(1);
+    const int flat_heads = batch * heads;
+    const int num_q_blocks = q_mean.size(2);
+    const int num_kv_blocks = k_min.size(2);
+    const int head_dim = q_mean.size(3);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+    TORCH_CHECK(num_kv_blocks <= 2048,
+                "QUEST block selector supports <= 2048 KV blocks, got ", num_kv_blocks);
+    TORCH_CHECK(topk_count >= 0 && topk_count <= num_kv_blocks,
+                "topk_count must be in [0, num_kv_blocks]");
+
+    auto opts = at::TensorOptions().dtype(at::kInt).device(q_mean.device());
+    at::Tensor topk = at::empty({flat_heads, num_q_blocks, topk_count}, opts);
+    if (topk_count == 0) {
+        return topk;
+    }
+
+    quest_block_topk(
+        q_mean.data_ptr(), k_min.data_ptr(), k_max.data_ptr(), topk.data_ptr(),
+        flat_heads, num_q_blocks, num_kv_blocks, head_dim, topk_count, causal, is_bf16);
+
+    return topk;
+}
+
+static at::Tensor single_query_key_mean_topk_impl(
+    const at::Tensor& q_grouped,
+    const at::Tensor& k_mean,
+    int topk_count,
+    int num_kv_blocks,
+    bool is_bf16 = false) {
+    TORCH_CHECK(q_grouped.is_cuda() && k_mean.is_cuda(),
+                "q_grouped and k_mean must be CUDA tensors");
+    TORCH_CHECK(q_grouped.is_contiguous() && k_mean.is_contiguous(),
+                "q_grouped and k_mean must be contiguous");
+    TORCH_CHECK(q_grouped.dim() == 4 && k_mean.dim() == 4,
+                "q_grouped and k_mean must be 4D tensors");
+    TORCH_CHECK(q_grouped.size(0) == k_mean.size(0),
+                "q_grouped and k_mean batch dimensions must match");
+    TORCH_CHECK(q_grouped.size(1) == k_mean.size(1),
+                "q_grouped and k_mean KV-head dimensions must match");
+    TORCH_CHECK(q_grouped.size(3) == k_mean.size(3),
+                "q_grouped and k_mean head_dim must match");
+
+    const int batch = q_grouped.size(0);
+    const int kv_heads = q_grouped.size(1);
+    const int flat_heads = batch * kv_heads;
+    const int groups = q_grouped.size(2);
+    const int head_dim = q_grouped.size(3);
+    const int k_mean_capacity_blocks = k_mean.size(2);
+    TORCH_CHECK(groups >= 1 && groups <= 16,
+                "grouped single-query selector expects groups in [1, 16], got ", groups);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+    TORCH_CHECK(num_kv_blocks >= 0 && num_kv_blocks <= k_mean_capacity_blocks,
+                "num_kv_blocks must be in [0, k_mean capacity]");
+    TORCH_CHECK(num_kv_blocks <= 2048,
+                "single-query block selector supports <= 2048 KV blocks, got ", num_kv_blocks);
+    TORCH_CHECK(topk_count >= 0 && topk_count <= num_kv_blocks,
+                "topk_count must be in [0, num_kv_blocks]");
+
+    auto opts = at::TensorOptions().dtype(at::kInt).device(q_grouped.device());
+    at::Tensor topk = at::empty({flat_heads, topk_count}, opts);
+    if (topk_count == 0) {
+        return topk;
+    }
+
+    if (num_kv_blocks <= 128) {
+        single_query_key_mean_topk(
+            q_grouped.data_ptr(), k_mean.data_ptr(), topk.data_ptr(),
+            flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+            head_dim, topk_count, is_bf16);
+        return topk;
+    }
+
+    constexpr int chunk_blocks = 64;
+    const int chunk_count = (num_kv_blocks + chunk_blocks - 1) / chunk_blocks;
+    const int local_count = std::min(topk_count, chunk_blocks);
+    at::Tensor local_scores = at::empty(
+        {flat_heads, chunk_count, local_count},
+        at::TensorOptions().dtype(at::kFloat).device(q_grouped.device()));
+    at::Tensor local_indices = at::empty({flat_heads, chunk_count, local_count}, opts);
+    at::Tensor done_counts = at::empty({flat_heads}, opts);
+    done_counts.zero_();
+    single_query_key_mean_topk_chunked(
+        q_grouped.data_ptr(), k_mean.data_ptr(), topk.data_ptr(),
+        local_scores.data_ptr(), local_indices.data_ptr(), done_counts.data_ptr(),
+        flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+        head_dim, topk_count, chunk_count, local_count, is_bf16);
+
+    return topk;
+}
+
+static at::Tensor single_query_quest_topk_impl(
+    const at::Tensor& q_grouped,
+    const at::Tensor& k_min,
+    const at::Tensor& k_max,
+    int topk_count,
+    int num_kv_blocks,
+    bool is_bf16 = false) {
+    TORCH_CHECK(q_grouped.is_cuda() && k_min.is_cuda() && k_max.is_cuda(),
+                "q_grouped, k_min, and k_max must be CUDA tensors");
+    TORCH_CHECK(q_grouped.is_contiguous() && k_min.is_contiguous() && k_max.is_contiguous(),
+                "q_grouped, k_min, and k_max must be contiguous");
+    TORCH_CHECK(q_grouped.dim() == 4 && k_min.dim() == 4 && k_max.dim() == 4,
+                "q_grouped, k_min, and k_max must be 4D tensors");
+    TORCH_CHECK(k_min.sizes() == k_max.sizes(),
+                "k_min and k_max shapes must match");
+    TORCH_CHECK(q_grouped.size(0) == k_min.size(0),
+                "q_grouped and key stat batch dimensions must match");
+    TORCH_CHECK(q_grouped.size(1) == k_min.size(1),
+                "q_grouped and key stat KV-head dimensions must match");
+    TORCH_CHECK(q_grouped.size(3) == k_min.size(3),
+                "q_grouped and key stat head_dim must match");
+
+    const int batch = q_grouped.size(0);
+    const int kv_heads = q_grouped.size(1);
+    const int flat_heads = batch * kv_heads;
+    const int groups = q_grouped.size(2);
+    const int head_dim = q_grouped.size(3);
+    const int k_stat_capacity_blocks = k_min.size(2);
+    TORCH_CHECK(groups >= 1 && groups <= 16,
+                "grouped single-query selector expects groups in [1, 16], got ", groups);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+    TORCH_CHECK(num_kv_blocks >= 0 && num_kv_blocks <= k_stat_capacity_blocks,
+                "num_kv_blocks must be in [0, key stat capacity]");
+    TORCH_CHECK(num_kv_blocks <= 2048,
+                "QUEST single-query block selector supports <= 2048 KV blocks, got ", num_kv_blocks);
+    TORCH_CHECK(topk_count >= 0 && topk_count <= num_kv_blocks,
+                "topk_count must be in [0, num_kv_blocks]");
+
+    auto opts = at::TensorOptions().dtype(at::kInt).device(q_grouped.device());
+    at::Tensor topk = at::empty({flat_heads, topk_count}, opts);
+    if (topk_count == 0) {
+        return topk;
+    }
+
+    single_query_quest_topk(
+        q_grouped.data_ptr(), k_min.data_ptr(), k_max.data_ptr(), topk.data_ptr(),
+        flat_heads, groups, num_kv_blocks, k_stat_capacity_blocks,
+        head_dim, topk_count, is_bf16);
+
+    return topk;
+}
+
+static at::Tensor single_query_key_mean_topk_into_impl(
+    const at::Tensor& q_grouped,
+    const at::Tensor& k_mean,
+    at::Tensor& topk,
+    at::Tensor& local_scores,
+    at::Tensor& local_indices,
+    at::Tensor& done_counts,
+    int num_kv_blocks,
+    bool is_bf16 = false) {
+    TORCH_CHECK(q_grouped.is_cuda() && k_mean.is_cuda(),
+                "q_grouped and k_mean must be CUDA tensors");
+    TORCH_CHECK(topk.is_cuda() && local_scores.is_cuda() &&
+                local_indices.is_cuda() && done_counts.is_cuda(),
+                "top-k workspace tensors must be CUDA tensors");
+    TORCH_CHECK(q_grouped.is_contiguous() && k_mean.is_contiguous() &&
+                topk.is_contiguous() && local_scores.is_contiguous() &&
+                local_indices.is_contiguous() && done_counts.is_contiguous(),
+                "q_grouped, k_mean, and top-k workspace tensors must be contiguous");
+    TORCH_CHECK(topk.dtype() == at::kInt && local_indices.dtype() == at::kInt &&
+                done_counts.dtype() == at::kInt,
+                "topk, local_indices, and done_counts must be int32");
+    TORCH_CHECK(local_scores.dtype() == at::kFloat,
+                "local_scores must be float32");
+    TORCH_CHECK(q_grouped.dim() == 4 && k_mean.dim() == 4,
+                "q_grouped and k_mean must be 4D tensors");
+    TORCH_CHECK(q_grouped.size(0) == k_mean.size(0),
+                "q_grouped and k_mean batch dimensions must match");
+    TORCH_CHECK(q_grouped.size(1) == k_mean.size(1),
+                "q_grouped and k_mean KV-head dimensions must match");
+    TORCH_CHECK(q_grouped.size(3) == k_mean.size(3),
+                "q_grouped and k_mean head_dim must match");
+
+    const int batch = q_grouped.size(0);
+    const int kv_heads = q_grouped.size(1);
+    const int flat_heads = batch * kv_heads;
+    const int groups = q_grouped.size(2);
+    const int head_dim = q_grouped.size(3);
+    const int k_mean_capacity_blocks = k_mean.size(2);
+    const int topk_count = topk.size(1);
+    TORCH_CHECK(topk.dim() == 2 && topk.size(0) == flat_heads,
+                "topk must be shaped [batch * kv_heads, topk_count]");
+    TORCH_CHECK(done_counts.dim() == 1 && done_counts.size(0) == flat_heads,
+                "done_counts must be shaped [batch * kv_heads]");
+    TORCH_CHECK(groups >= 1 && groups <= 16,
+                "grouped single-query selector expects groups in [1, 16], got ", groups);
+    TORCH_CHECK(head_dim == 64 || head_dim == 128,
+                "head_dim must be 64 or 128, got ", head_dim);
+    TORCH_CHECK(num_kv_blocks >= 0 && num_kv_blocks <= k_mean_capacity_blocks,
+                "num_kv_blocks must be in [0, k_mean capacity]");
+    TORCH_CHECK(num_kv_blocks <= 2048,
+                "single-query block selector supports <= 2048 KV blocks, got ", num_kv_blocks);
+    TORCH_CHECK(topk_count >= 0 && topk_count <= num_kv_blocks,
+                "topk_count must be in [0, num_kv_blocks]");
+    if (topk_count == 0) {
+        return topk;
+    }
+    done_counts.zero_();
+
+    if (num_kv_blocks <= 128) {
+        single_query_key_mean_topk(
+            q_grouped.data_ptr(), k_mean.data_ptr(), topk.data_ptr(),
+            flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+            head_dim, topk_count, is_bf16);
+        return topk;
+    }
+
+    constexpr int chunk_blocks = 64;
+    const int chunk_count = (num_kv_blocks + chunk_blocks - 1) / chunk_blocks;
+    const int local_count = std::min(topk_count, chunk_blocks);
+    TORCH_CHECK(local_scores.dim() == 3 && local_scores.size(0) == flat_heads &&
+                local_scores.size(1) >= chunk_count && local_scores.size(2) >= local_count,
+                "local_scores workspace is too small");
+    TORCH_CHECK(local_indices.dim() == 3 && local_indices.size(0) == flat_heads &&
+                local_indices.size(1) >= chunk_count && local_indices.size(2) >= local_count,
+                "local_indices workspace is too small");
+    single_query_key_mean_topk_chunked(
+        q_grouped.data_ptr(), k_mean.data_ptr(), topk.data_ptr(),
+        local_scores.data_ptr(), local_indices.data_ptr(), done_counts.data_ptr(),
+        flat_heads, groups, num_kv_blocks, k_mean_capacity_blocks,
+        head_dim, topk_count, chunk_count, local_count, is_bf16);
+
+    return topk;
+}
+
+static at::Tensor block_mean_topk_dispatch(
+    const at::Tensor& q_mean,
+    const at::Tensor& k_mean,
+    int64_t topk_count,
+    bool causal,
+    bool is_bf16) {
+    return block_mean_topk_impl(
+        q_mean,
+        k_mean,
+        static_cast<int>(topk_count),
+        causal,
+        is_bf16);
+}
+
+static at::Tensor single_query_key_mean_topk_dispatch(
+    const at::Tensor& q_grouped,
+    const at::Tensor& k_mean,
+    int64_t topk_count,
+    int64_t num_kv_blocks,
+    bool is_bf16) {
+    return single_query_key_mean_topk_impl(
+        q_grouped,
+        k_mean,
+        static_cast<int>(topk_count),
+        static_cast<int>(num_kv_blocks),
+        is_bf16);
+}
+
+}  // namespace
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+    ops.def("nvfp4_quantize(Tensor x, bool is_bf16) -> Tensor[]");
+    ops.impl("nvfp4_quantize", torch::kCUDA, &nvfp4_quantize);
+
+    ops.def("nvfp4_quantize_permuted(Tensor x, bool is_bf16) -> Tensor[]");
+    ops.impl("nvfp4_quantize_permuted", torch::kCUDA, &nvfp4_quantize_permuted);
+
+    ops.def("nvfp4_quantize_transposed(Tensor x, bool is_bf16) -> Tensor[]");
+    ops.impl("nvfp4_quantize_transposed", torch::kCUDA, &nvfp4_quantize_transposed);
+
+    ops.def("block_mean_topk(Tensor q_mean, Tensor k_mean, int topk_count, bool causal, bool is_bf16) -> Tensor");
+    ops.impl("block_mean_topk", torch::kCUDA, &block_mean_topk_dispatch);
+
+    ops.def("single_query_key_mean_topk(Tensor q_grouped, Tensor k_mean, int topk_count, int num_kv_blocks, bool is_bf16) -> Tensor");
+    ops.impl("single_query_key_mean_topk", torch::kCUDA, &single_query_key_mean_topk_dispatch);
+
+    ops.def("thrift_attention_causal_nvfp4_packed(Tensor q_hi, Tensor k_hi, Tensor v_hi, Tensor selected_blocks, Tensor q_packed, Tensor k_packed, Tensor v_packed_t, Tensor q_scale, Tensor k_scale, Tensor v_scale_t, bool is_bf16) -> Tensor");
+    ops.impl("thrift_attention_causal_nvfp4_packed", torch::kCUDA, &thrift_attention_causal_nvfp4_packed);
+
+    ops.def("thrift_attention_noncausal_nvfp4_packed(Tensor q_hi, Tensor k_hi, Tensor v_hi, Tensor selected_blocks, Tensor q_packed, Tensor k_packed, Tensor v_packed_t, Tensor q_scale, Tensor k_scale, Tensor v_scale_t, bool is_bf16) -> Tensor");
+    ops.impl("thrift_attention_noncausal_nvfp4_packed", torch::kCUDA, &thrift_attention_noncausal_nvfp4_packed);
+
+    ops.def("thrift_attention_single_query_nvfp4_packed(Tensor q_hi, Tensor k_hi, Tensor v_hi, Tensor selected_blocks, Tensor q_packed, Tensor k_packed, Tensor v_packed_t, Tensor q_scale, Tensor k_scale, Tensor v_scale_t, bool is_bf16) -> Tensor");
+    ops.impl("thrift_attention_single_query_nvfp4_packed", torch::kCUDA, &thrift_attention_single_query_nvfp4_packed);
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/thrift-attention/torch-ext/torch_binding.h
+++ b/thrift-attention/torch-ext/torch_binding.h
@@ -1,0 +1,1 @@
+#pragma once


### PR DESCRIPTION
Related: joesharratt1229/ThriftAttention#13

### PR Purpose:

Adds a Kernel Hub package for ThriftAttention.

This makes the Transformers path possible with:

```python
attn_implementation="kernels-community/thrift-attention"
```

## Changes

- Adds the thrift-attention kernel directory.
- Adds build.toml, flake files, and Hub card metadata.
- Copies the ThriftAttention CUDA sources into the kernel package.
- Adds Torch op bindings for the NVFP4 ThriftAttention path.
- Exposes FlashAttention-style entry points for the Transformers loader.

## Testing
tested on RTX pro 6000 96Gb, just some basic checks.
<details><summary>relevant log lines:</summary>
<p>

```
thrift-attn
94121f20210091ee77e3a182eb6315b269225162
94121f2 thrift-attention: add ThriftAttention Kernel Hub package
FILE_COUNT
21
MISSING_PATH_CHECK
missing []
paths_checked 15
Revision: 94121f20210091ee77e3a182eb6315b269225162
kernel-builder: github:huggingface/kernels/19a568f64aa291880427d4ab56ee48bfeb26234b
```

</p>
</details>