### PR TITLE
Fix tiled MLP for ZeRO-3 and FSDP

### DIFF
--- a/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
+++ b/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 
 import torch
+import torch.distributed as dist
 
 from .utils import ensure_contiguous
 
@@ -86,6 +87,10 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         x_shards = list(torch.chunk(x, chunks=shards, dim=0))
         incoming_grad_shards = list(torch.chunk(incoming_grad, chunks=shards, dim=0))
 
+        # ZeRO-3 partitioned parameters carry a ds_id; collect them once so the per-shard loop only
+        # flips the ready flag. Parameters on other backends have no ds_id and are left untouched.
+        ds_params = [p for p in compute_params if hasattr(p, "ds_id")] if compute_params else []
+
         for i, x_shard in enumerate(x_shards):
             x_shard.requires_grad_(x_requires_grad)
 
@@ -96,14 +101,10 @@ class LigerTiledMLPFunction(torch.autograd.Function):
             x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
             incoming_grad_shard = incoming_grad_shards[i]
 
-            # Under ZeRO-3 each shard's recompute would queue the same parameter for gradient reduction,
-            # so defer DeepSpeed's reduction until the last shard has accumulated into param.grad. The
-            # ds_id attribute marks a ZeRO-3 partitioned parameter, leaving other backends untouched.
-            if compute_params:
-                is_last_shard = i + 1 == len(x_shards)
-                for param in compute_params:
-                    if hasattr(param, "ds_id"):
-                        param.ds_grad_is_ready = is_last_shard
+            # Defer DeepSpeed's reduction until the last shard has accumulated into param.grad; the flag
+            # is read by ZeRO's hook during each shard's backward, so it must be set per shard.
+            for param in ds_params:
+                param.ds_grad_is_ready = i + 1 == len(x_shards)
 
             with torch.enable_grad():
                 output = fn(mlp_module, x_shard)
@@ -144,7 +145,6 @@ def apply_tiled_mlp(
     # All ranks must run the same number of shards: a sharded-parameter backend (DeepSpeed ZeRO-3, FSDP)
     # gathers weights inside each shard's recompute, so a rank that runs fewer shards stops participating
     # in those collectives and deadlocks the others. Harmonize on the per-rank maximum.
-    dist = torch.distributed
     if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
         num_shards_tensor = torch.tensor(num_shards, device=x.device)
         dist.all_reduce(num_shards_tensor, op=dist.ReduceOp.MAX)

--- a/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
+++ b/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
@@ -44,6 +44,7 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         ctx.fn = fn
         ctx.mlp_module = mlp_module
         ctx.shards = shards
+        ctx.compute_params = compute_params
         ctx.save_for_backward(x)
 
         # x.shape could be [bs, seqlen, hidden_size] or [seqlen, hidden_size] (moe experts)
@@ -61,6 +62,7 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         (x,) = ctx.saved_tensors
         mlp_module = ctx.mlp_module
         shards = ctx.shards
+        compute_params = ctx.compute_params
 
         grad_output = grads[0]
 
@@ -93,6 +95,15 @@ class LigerTiledMLPFunction(torch.autograd.Function):
 
             x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
             incoming_grad_shard = incoming_grad_shards[i]
+
+            # Under ZeRO-3 each shard's recompute would queue the same parameter for gradient reduction,
+            # so defer DeepSpeed's reduction until the last shard has accumulated into param.grad. The
+            # ds_id attribute marks a ZeRO-3 partitioned parameter, leaving other backends untouched.
+            if compute_params:
+                is_last_shard = i + 1 == len(x_shards)
+                for param in compute_params:
+                    if hasattr(param, "ds_id"):
+                        param.ds_grad_is_ready = is_last_shard
 
             with torch.enable_grad():
                 output = fn(mlp_module, x_shard)
@@ -129,6 +140,15 @@ def apply_tiled_mlp(
 
     # Ensure num_shards is at least 1
     num_shards = max(1, num_shards)
+
+    # All ranks must run the same number of shards: a sharded-parameter backend (DeepSpeed ZeRO-3, FSDP)
+    # gathers weights inside each shard's recompute, so a rank that runs fewer shards stops participating
+    # in those collectives and deadlocks the others. Harmonize on the per-rank maximum.
+    dist = torch.distributed
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        num_shards_tensor = torch.tensor(num_shards, device=x.device)
+        dist.all_reduce(num_shards_tensor, op=dist.ReduceOp.MAX)
+        num_shards = int(num_shards_tensor.item())
 
     return LigerTiledMLPFunction.apply(
         fn,


### PR DESCRIPTION
The tiled MLP kernel passes `compute_params` through but never uses it, and computes `num_shards` locally on each rank. Both bite under sharded-parameter backends:

- DeepSpeed ZeRO-3 crashes: the per-shard recompute fires ZeRO's gradient hook multiple times for the same parameter, so the same `ds_id` lands in the reduction bucket twice and it asserts.
- ZeRO-3 / FSDP can deadlock: if ranks see different sequence lengths they pick different `num_shards`, so they issue a different number of weight all-gathers and hang.

This ports the fixes that DeepSpeed's own TiledMLP uses:

- In the backward, defer ZeRO-3 reduction by setting `param.ds_grad_is_ready = False` for every shard except the last (gated on the `ds_id` marker, so non-ZeRO backends are untouched).
- In `apply_tiled_mlp`, all-reduce `num_shards` to the per-rank max when distributed, so every rank runs the same number of shards.

Same fix is going into linkedin/Liger-Kernel. Verified there on 2x H100: tiled gradients match a non-tiled reference under FSDP2 and DeepSpeed ZeRO-3 (with and without gradient checkpointing). No change for single-GPU or non-distributed runs.
