### PR TITLE
ci: security hardening

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -44,10 +44,25 @@ jobs:
             fi
             echo "kernel=$KERNEL" >> $GITHUB_OUTPUT
           fi
+
+      # Reject kernel names outside the safe charset before they are used in Hub
+      # repo paths (guards against path traversal / repo retargeting).
+      - name: Validate kernel name
+        if: steps.kernel.outputs.skip != 'true'
+        env:
+          KERNEL: ${{ steps.kernel.outputs.kernel }}
+        run: |
+          case "$KERNEL" in
+            ''|*[!A-Za-z0-9_-]*)
+              echo "Invalid kernel name '$KERNEL': must match ^[A-Za-z0-9_-]+$"
+              exit 1
+              ;;
+          esac
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: steps.kernel.outputs.skip != 'true'
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Install kernels
         if: steps.kernel.outputs.skip != 'true'
         run: pip install "kernels[benchmark] @ git+https://github.com/huggingface/kernels#subdirectory=kernels"

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -47,6 +47,7 @@ jobs:
 
       # Reject kernel names outside the safe charset before they are used in Hub
       # repo paths (guards against path traversal / repo retargeting).
+      # Accepts e.g.: flash-attn3, rejects: $(myevilcommand).
       - name: Validate kernel name
         if: steps.kernel.outputs.skip != 'true'
         env:

--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -70,6 +70,7 @@ jobs:
       fail-fast: false
     steps:
       # Reject kernel names outside the safe charset before any step uses them.
+      # Accepts e.g.: flash-attn3, rejects: $(myevilcommand).
       - name: Validate kernel name
         env:
           KERNEL: ${{ inputs.kernel_name }}

--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -69,17 +69,33 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      # Reject kernel names outside the safe charset before any step uses them.
+      - name: Validate kernel name
+        env:
+          KERNEL: ${{ inputs.kernel_name }}
+        run: |
+          case "$KERNEL" in
+            ''|*[!A-Za-z0-9_-]*)
+              echo "Invalid kernel_name input: must match ^[A-Za-z0-9_-]+$"
+              exit 1
+              ;;
+          esac
+
       # Post a running commit status so the PR shows the build is in progress.
       - name: Set running status
         if: inputs.head_sha != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="pending" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="Build in progress" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"
 
       # Guard against injection via pr_number input.
       - name: Validate PR number
@@ -154,8 +170,9 @@ jobs:
         if: steps.validate.outputs.skip == 'false' && inputs.skip_build != true
         env:
           KERNEL: ${{ steps.validate.outputs.kernel }}
+          MODE: ${{ inputs.mode }}
         run: |
-          if [ "${{ inputs.mode }}" = "pr" ]; then
+          if [ "$MODE" = "pr" ]; then
             ( cd "$KERNEL" && nix build -L .#ci && ls -l result/ )
           else
             ( cd "$KERNEL" && nix build -L )
@@ -222,6 +239,10 @@ jobs:
       - name: Set commit status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
           BUILD="${{ needs.build-kernel.result }}"
 
@@ -236,8 +257,8 @@ jobs:
             DESC="Build did not complete (${BUILD})"
           fi
 
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$STATE" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="$DESC" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -70,12 +70,16 @@ jobs:
       - name: Set running status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="pending" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="Build in progress" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"
 
   # Build the kernel for each CUDA/XPU variant; release mode uploads to the Hub.
   build-kernel:
@@ -105,6 +109,17 @@ jobs:
 
     runs-on: windows-2022
     steps:
+      # Reject kernel names outside the safe charset before any step uses them.
+      - name: Validate kernel name
+        shell: pwsh
+        env:
+          KERNEL: ${{ inputs.kernel_name }}
+        run: |
+          if ("$env:KERNEL" -notmatch '^[A-Za-z0-9_-]+$') {
+            Write-Error "Invalid kernel_name input: must match ^[A-Za-z0-9_-]+$"
+            exit 1
+          }
+
       # Guard against injection via pr_number input.
       - name: Validate PR number
         if: inputs.pr_number != ''
@@ -375,6 +390,10 @@ jobs:
       - name: Set commit status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
           BUILD="${{ needs.build-kernel.result }}"
 
@@ -389,8 +408,8 @@ jobs:
             DESC="Build did not complete (${BUILD})"
           fi
 
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$STATE" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="$DESC" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -110,6 +110,7 @@ jobs:
     runs-on: windows-2022
     steps:
       # Reject kernel names outside the safe charset before any step uses them.
+      # Accepts e.g.: flash-attn3, rejects: $(myevilcommand).
       - name: Validate kernel name
         shell: pwsh
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,11 +209,13 @@ jobs:
       - name: Build kernel
         env:
           KERNEL: ${{ needs.setup.outputs.kernel }}
+          MODE: ${{ inputs.mode }}
+          BACKEND: ${{ matrix.backend }}
         run: |
-          if [ "${{ inputs.mode }}" = "pr" ]; then
-            ( cd "$KERNEL" && nix build -L .#backendCi.${{ matrix.backend }} && ls -l result/ )
+          if [ "$MODE" = "pr" ]; then
+            ( cd "$KERNEL" && nix build -L ".#backendCi.$BACKEND" && ls -l result/ )
           else
-            ( cd "$KERNEL" && nix build -L .#backendBundle.${{ matrix.backend }} && ls -l result/ )
+            ( cd "$KERNEL" && nix build -L ".#backendBundle.$BACKEND" && ls -l result/ )
           fi
           ( cd "$KERNEL" && cp -rL result build && rm result && chmod -R u+w build )
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       # Reject kernel names outside the safe charset before any step uses them.
+      # Accepts e.g.: flash-attn3, rejects: $(myevilcommand).
       - name: Validate kernel name
         env:
           KERNEL: ${{ inputs.kernel_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,17 +70,33 @@ jobs:
       kernel: ${{ steps.validate.outputs.kernel }}
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
+      # Reject kernel names outside the safe charset before any step uses them.
+      - name: Validate kernel name
+        env:
+          KERNEL: ${{ inputs.kernel_name }}
+        run: |
+          case "$KERNEL" in
+            ''|*[!A-Za-z0-9_-]*)
+              echo "Invalid kernel_name input: must match ^[A-Za-z0-9_-]+$"
+              exit 1
+              ;;
+          esac
+
       # Post a running commit status so the PR shows the build is in progress.
       - name: Set running status
         if: inputs.head_sha != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="pending" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="Build in progress" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"
 
       # Guard against injection via pr_number input.
       - name: Validate PR number
@@ -150,8 +166,9 @@ jobs:
         id: matrix
         env:
           KERNEL: ${{ steps.validate.outputs.kernel }}
+          MODE: ${{ inputs.mode }}
         run: |
-          if [ "${{ inputs.mode }}" = "pr" ]; then
+          if [ "$MODE" = "pr" ]; then
             NIX_TARGET="backendCi"
           else
             NIX_TARGET="backendBundle"
@@ -385,6 +402,10 @@ jobs:
       - name: Set commit status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: ${{ github.workflow }} / ${{ inputs.kernel_name }}
         run: |
           BUILD="${{ needs.build-kernel.result }}"
           TEST="${{ needs.test-kernel-gpu.result }}"
@@ -400,8 +421,8 @@ jobs:
             DESC="Build did not complete (build: ${BUILD}, test: ${TEST})"
           fi
 
-          gh api repos/${{ github.repository }}/statuses/${{ inputs.head_sha }} \
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
             -f state="$STATE" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f target_url="$RUN_URL" \
             -f description="$DESC" \
-            -f context="${{ github.workflow }} / ${{ inputs.kernel_name }}"
+            -f context="$STATUS_CONTEXT"

--- a/.github/workflows/generate-build-matrix.py
+++ b/.github/workflows/generate-build-matrix.py
@@ -19,6 +19,8 @@ import os
 import sys
 from pathlib import Path
 
+VALID_BACKENDS = frozenset({"cuda", "cpu", "rocm", "metal", "xpu"})
+
 ARCHES = [
     ("x86_64-linux", "aws-highmemory-32-plus-nix"),
     ("aarch64-linux", "aws-r8g-8xl-plus-nix"),
@@ -34,6 +36,25 @@ def load_concurrency_overrides() -> dict:
         with open(overrides_path) as f:
             return json.load(f)
     return {}
+
+
+def validate_backend(backend) -> str:
+    if backend not in VALID_BACKENDS:
+        print(
+            f"Invalid backend name: {backend!r} "
+            f"(expected one of {sorted(VALID_BACKENDS)})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return backend
+
+
+def validate_int(value, name: str) -> int:
+    # bool is a subclass of int, but we don't want to accept it either.
+    if isinstance(value, bool) or not isinstance(value, int):
+        print(f"Invalid {name} value: {value!r} (expected integer)", file=sys.stderr)
+        sys.exit(1)
+    return value
 
 
 def main():
@@ -58,13 +79,17 @@ def main():
 
     include = [
         {
-            "backend": backend,
+            "backend": validate_backend(backend),
             "arch": arch,
             "runner": runner,
-            "max_jobs": kernel_overrides.get(backend, {}).get(
-                "max-jobs", DEFAULT_MAX_JOBS
+            "max_jobs": validate_int(
+                kernel_overrides.get(backend, {}).get("max-jobs", DEFAULT_MAX_JOBS),
+                "max-jobs",
             ),
-            "cores": kernel_overrides.get(backend, {}).get("cores", DEFAULT_CORES),
+            "cores": validate_int(
+                kernel_overrides.get(backend, {}).get("cores", DEFAULT_CORES),
+                "cores",
+            ),
         }
         for arch, runner in ARCHES
         for backend in backends_by_arch[arch]

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -69,6 +69,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh pr diff "${PR_NUMBER}" --repo "${REPO}" > /tmp/changes.diff
 
+      # NOTE: in the invocation of Claude below, we restrict it to read-only
+      # local tools to avoid potential token exfiltration attacks.
       - name: Run security audit
         id: audit
         env:
@@ -215,7 +217,13 @@ jobs:
           === DIFF ===
           PROMPT
             cat /tmp/changes.diff
-          } | claude -p --model claude-opus-4-8 > /tmp/audit_result.txt
+          } | claude -p \
+                --model claude-opus-4-8 \
+                --permission-mode plan \
+                --allowedTools "Read,Grep,Glob,LS" \
+                --disallowedTools "Bash,BashOutput,Edit,Write,MultiEdit,NotebookEdit,WebFetch,WebSearch,Task,KillShell" \
+                --max-turns 40 \
+              > /tmp/audit_result.txt
 
           # Validate LLM output format before trusting it
           if grep -qE '^NO_FINDINGS$' /tmp/audit_result.txt && [ $(wc -l < /tmp/audit_result.txt) -eq 1 ]; then


### PR DESCRIPTION
- Do not directly interpolate variables used in shell-based executions.
- Restrict Claude to local, read-only tools.
- Proactively verify `KERNEL` before it is used.