### PR TITLE
Add RDNA3.5 (gfx1150/gfx1151) configs for aiter-flash-attn

### DIFF
--- a/aiter-flash-attn/README.md
+++ b/aiter-flash-attn/README.md
@@ -8,7 +8,7 @@ tags:
 Self-contained repackaging of the Triton FlashAttention MHA kernels from the
 [ROCm/aiter](https://github.com/ROCm/aiter) project, exposed as a Hugging Face
 Hub kernel. Provides FlashAttention on AMD ROCm GPUs (MI300X / gfx942,
-gfx950, gfx1250) without taking on `aiter` as a pip dependency.
+gfx950, gfx1250, gfx1150, gfx1151) without taking on `aiter` as a pip dependency.
 
 Original code: https://github.com/ROCm/aiter (MIT, © Advanced Micro Devices, Inc.).
 
@@ -37,8 +37,11 @@ learnable attention sinks (e.g. gpt-oss).
 - gfx942 (MI300X)
 - gfx950 (MI355X)
 - gfx1250
+- gfx1150 (Strix Point / RDNA3.5)
+- gfx1151 (Strix Halo / RDNA3.5)
 
-Tuning configs for these architectures ship under `torch-ext/aiter_flash_attn/configs/`.
+Tuning configs for these architectures ship under `torch-ext/aiter_flash_attn/configs/`. The gfx1150 config
+reuses the gfx1151 tuning, since both are RDNA3.5.
 
 ## Quickstart
 

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/configs/gfx1150-MHA-DEFAULT.json
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/configs/gfx1150-MHA-DEFAULT.json
@@ -1,0 +1,92 @@
+{
+  "fwd": {
+    "dropout_or_fp32": {
+      "BLOCK_M": 32,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 2,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "default": {
+      "BLOCK_M": 64,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 4,
+      "num_ctas": 1,
+      "num_stages": 2
+    },
+    "pe": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe_dropout_or_fp32": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    }
+  },
+  "bkwd_fused" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "dkdvdq_kernel_N64" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }, 
+    "dkdvdq_kernel_N128" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }
+  },
+  "bkwd_onekernel" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "onekernel" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 128,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 1
+    },
+    "onekernel_pe" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 64,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 2
+    }
+  }
+}

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/configs/gfx1151-MHA-DEFAULT.json
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/configs/gfx1151-MHA-DEFAULT.json
@@ -1,0 +1,92 @@
+{
+  "fwd": {
+    "dropout_or_fp32": {
+      "BLOCK_M": 32,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 2,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "default": {
+      "BLOCK_M": 64,
+      "BLOCK_N": 32,
+      "PRELOAD_V": false,
+      "waves_per_eu": 1,
+      "num_warps": 4,
+      "num_ctas": 1,
+      "num_stages": 2
+    },
+    "pe": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    },
+    "pe_dropout_or_fp32": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": true,
+      "waves_per_eu": 1,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 1
+    }
+  },
+  "bkwd_fused" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "dkdvdq_kernel_N64" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }, 
+    "dkdvdq_kernel_N128" : {
+        "BLOCK_M": 16,
+        "BLOCK_N": 128,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "BLK_SLICE_FACTOR": 1,
+        "matrix_instr_nonkdim": 16
+    }
+  },
+  "bkwd_onekernel" : {
+    "preprocess_kernel": {
+      "PRE_BLOCK": 128
+    }, 
+    "onekernel" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 128,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 1,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 1
+    },
+    "onekernel_pe" : {
+        "BLOCK_M1": 32,
+        "BLOCK_N1": 64,
+        "BLOCK_M2": 128,
+        "BLOCK_N2": 32,
+        "BLK_SLICE_FACTOR": 2,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_ctas": 1,
+        "num_stages": 2
+    }
+  }
+}


### PR DESCRIPTION
On RDNA3.5 the kernel had no MHA tuning config, so `_get_config` hit a `FileNotFoundError` (`gfx1150-MHA-DEFAULT.json`) on the first attention call.

gfx1151 (Strix Halo) is taken straight from upstream aiter. gfx1150 (Strix Point) reuses it since both are RDNA3.5.

Tested on a gfx1150: Triton compiles the kernel fine and the forward output matches the SDPA baseline in a small transformers training run.