### PR TITLE
feat: filter kernel bot build backends

### DIFF
--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -27,13 +27,6 @@ WORKFLOWS = {
 
 KERNEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
-# A kernel argument, optionally scoped to a subset of backends:
-#   "flash-attn2"            -> ("flash-attn2", None)     (all declared backends)
-#   "flash-attn2[xpu,cpu]"   -> ("flash-attn2", ["xpu", "cpu"])
-KERNEL_ARG_RE = re.compile(
-    r"^(?P<name>[A-Za-z0-9_-]+)(?:\[(?P<backends>[A-Za-z0-9_]+(?:,[A-Za-z0-9_]+)*)\])?$"
-)
-
 # Workflow file -> its YAML `name:`; must match the context the build reports.
 WORKFLOW_DISPLAY_NAMES = {
     "build.yaml": "Build",
@@ -106,18 +99,20 @@ def parse_kernel_arg(token: str) -> tuple[str | None, list[str] | None]:
     """Split ``kernel`` or ``kernel[b1,b2]`` into ``(name, backends)``.
 
     ``backends`` is ``None`` when no scope was given (all declared backends).
-    Returns ``(None, None)`` for a malformed token.
+    Returns ``(None, None)`` for a syntactically malformed token. Backend names
+    are not checked here; the caller warns about and drops unknown ones.
     """
-    match = KERNEL_ARG_RE.match(token)
-    if not match:
+    name, bracket, rest = token.partition("[")
+    if not KERNEL_NAME_RE.match(name):
         return None, None
-    raw = match.group("backends")
-    return match.group("name"), (raw.split(",") if raw else None)
-
-
-# Sentinel: lets select_workflows() tell "read build.toml" from an explicitly
-# passed backend list (None included, meaning unreadable).
-_READ_FROM_TOML = object()
+    if not bracket:
+        return name, None
+    if not rest.endswith("]"):
+        return None, None
+    backends = rest[:-1].split(",")
+    if not all(backends):  # reject empty components: "[]", "[cpu,]", "[,]"
+        return None, None
+    return name, backends
 
 
 def read_backends(kernel_name: str) -> list[str] | None:
@@ -135,10 +130,8 @@ def read_backends(kernel_name: str) -> list[str] | None:
 
 
 def select_workflows(
-    kernel_name: str, *, notes: list[str], backends=_READ_FROM_TOML
+    kernel_name: str, backends: list[str] | None, *, notes: list[str]
 ) -> set[str]:
-    if backends is _READ_FROM_TOML:
-        backends = read_backends(kernel_name)
     if backends is None:
         notes.append(
             f"Could not read backends for {kernel_name}, dispatching all workflows"
@@ -275,7 +268,7 @@ def _plan_build_actions(
             plan.skipped = sorted(WORKFLOWS["build"])
             return
 
-    workflows = select_workflows(kernel_name, notes=plan.notes, backends=backends)
+    workflows = select_workflows(kernel_name, backends, notes=plan.notes)
     plan.skipped = sorted(set(WORKFLOWS["build"]) - workflows)
     backends = backends or []
 

--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -96,12 +96,6 @@ class DispatchPlan:
 
 
 def parse_kernel_arg(token: str) -> tuple[str | None, list[str] | None]:
-    """Split ``kernel`` or ``kernel[b1,b2]`` into ``(name, backends)``.
-
-    ``backends`` is ``None`` when no scope was given (all declared backends).
-    Returns ``(None, None)`` for a syntactically malformed token. Backend names
-    are not checked here; the caller warns about and drops unknown ones.
-    """
     name, bracket, rest = token.partition("[")
     if not KERNEL_NAME_RE.match(name):
         return None, None
@@ -256,8 +250,6 @@ def _plan_build_actions(
     requested_backends: list[str] | None = None,
 ) -> None:
     backends = read_backends(kernel_name)
-    # Narrow to the requested backends, so both workflow selection and the
-    # per-workflow `backends` CSV skip everything the user did not ask for.
     if requested_backends is not None and backends is not None:
         backends = [b for b in backends if b in requested_backends]
         if not backends:

--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -27,6 +27,13 @@ WORKFLOWS = {
 
 KERNEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# A kernel argument, optionally scoped to a subset of backends:
+#   "flash-attn2"            -> ("flash-attn2", None)     (all declared backends)
+#   "flash-attn2[xpu,cpu]"   -> ("flash-attn2", ["xpu", "cpu"])
+KERNEL_ARG_RE = re.compile(
+    r"^(?P<name>[A-Za-z0-9_-]+)(?:\[(?P<backends>[A-Za-z0-9_]+(?:,[A-Za-z0-9_]+)*)\])?$"
+)
+
 # Workflow file -> its YAML `name:`; must match the context the build reports.
 WORKFLOW_DISPLAY_NAMES = {
     "build.yaml": "Build",
@@ -95,6 +102,29 @@ class DispatchPlan:
 # Reading build.toml and selecting workflows
 
 
+def parse_kernel_arg(token: str) -> tuple[str | None, list[str] | None]:
+    """Split a ``kernel`` or ``kernel[b1,b2]`` token.
+
+    Returns ``(name, backends)`` where ``backends`` is ``None`` when no
+    backend scope was given (meaning "all declared backends"), or a list of
+    the requested backend names. Returns ``(None, None)`` if the token is not
+    a valid kernel argument.
+    """
+    match = KERNEL_ARG_RE.match(token)
+    if not match:
+        return None, None
+    name = match.group("name")
+    raw = match.group("backends")
+    if raw is None:
+        return name, None
+    return name, raw.split(",")
+
+
+# Sentinel so select_workflows can distinguish "read backends from build.toml"
+# from an explicitly-passed backend list (including None, meaning unreadable).
+_READ_FROM_TOML = object()
+
+
 def read_backends(kernel_name: str) -> list[str] | None:
     build_toml = Path(kernel_name) / "build.toml"
     if not build_toml.exists():
@@ -109,8 +139,11 @@ def read_backends(kernel_name: str) -> list[str] | None:
     return None
 
 
-def select_workflows(kernel_name: str, *, notes: list[str]) -> set[str]:
-    backends = read_backends(kernel_name)
+def select_workflows(
+    kernel_name: str, *, notes: list[str], backends=_READ_FROM_TOML
+) -> set[str]:
+    if backends is _READ_FROM_TOML:
+        backends = read_backends(kernel_name)
     if backends is None:
         notes.append(
             f"Could not read backends for {kernel_name}, dispatching all workflows"
@@ -219,6 +252,44 @@ def _windows_scoped_backends(
     return kept
 
 
+def _resolve_effective_backends(
+    kernel_name: str, requested_backends: list[str] | None, plan: DispatchPlan
+) -> list[str] | None:
+    """Combine a kernel's declared backends with an optional user filter.
+
+    Returns the list of backends to actually build. When ``requested_backends``
+    is ``None`` the declared list is returned unchanged (``None`` if
+    build.toml is unreadable, so callers fall back to all workflows). When a
+    filter is given, returns the declared backends intersected with it, or an
+    empty list if nothing matches (caller should build nothing).
+    """
+    declared = read_backends(kernel_name)
+    if requested_backends is None:
+        return declared
+
+    if declared is None:
+        # build.toml is unreadable; trust the explicit request as-is.
+        plan.notes.append(
+            f"Could not read backends for {kernel_name}; "
+            f"using requested backends {requested_backends}"
+        )
+        return list(requested_backends)
+
+    unknown = [b for b in requested_backends if b not in declared]
+    if unknown:
+        plan.notes.append(
+            f"Ignoring requested backend(s) {unknown} not declared by "
+            f"{kernel_name} (declared: {declared})"
+        )
+    effective = [b for b in declared if b in requested_backends]
+    if not effective:
+        plan.notes.append(
+            f"None of the requested backends {requested_backends} are declared "
+            f"by {kernel_name} (declared: {declared}); nothing to build"
+        )
+    return effective
+
+
 def _plan_build_actions(
     plan: DispatchPlan,
     kernel_name: str,
@@ -232,9 +303,16 @@ def _plan_build_actions(
     head_sha: str,
     target_branch: str,
     upload: bool,
+    requested_backends: list[str] | None = None,
 ) -> None:
-    backends = read_backends(kernel_name) or []
-    workflows = select_workflows(kernel_name, notes=plan.notes)
+    effective = _resolve_effective_backends(kernel_name, requested_backends, plan)
+    # A user filter that matched no declared backend -> build nothing.
+    if requested_backends is not None and effective == []:
+        plan.skipped = sorted(WORKFLOWS["build"])
+        return
+
+    backends = effective or []
+    workflows = select_workflows(kernel_name, notes=plan.notes, backends=effective)
     plan.skipped = sorted(set(WORKFLOWS["build"]) - workflows)
 
     for workflow in sorted(workflows):
@@ -294,6 +372,7 @@ def plan_dispatch(
     upload: bool = True,
     run_security: bool = False,
     security_only: bool = False,
+    requested_backends: list[str] | None = None,
 ) -> DispatchPlan:
     want_security = run_security or security_only
     plan = DispatchPlan(kernel_name=kernel_name, head_sha=head_sha)
@@ -311,6 +390,7 @@ def plan_dispatch(
             head_sha=head_sha,
             target_branch=target_branch,
             upload=upload,
+            requested_backends=requested_backends,
         )
 
     if want_security:
@@ -460,6 +540,7 @@ def dispatch(
     upload: bool = True,
     run_security: bool = False,
     security_only: bool = False,
+    requested_backends: list[str] | None = None,
 ) -> DispatchResult:
     if not security_only and (not kernel_name or not KERNEL_NAME_RE.match(kernel_name)):
         result = DispatchResult(kernel_name=kernel_name)
@@ -481,6 +562,7 @@ def dispatch(
         upload=upload,
         run_security=run_security,
         security_only=security_only,
+        requested_backends=requested_backends,
     )
     if dry_run:
         return _result_from_plan(plan)
@@ -542,7 +624,10 @@ def main() -> int:
         "kernel_name",
         nargs="?",
         default="",
-        help="Kernel directory name (not required with --security-only)",
+        help=(
+            "Kernel directory name, optionally scoped to a subset of backends "
+            "as 'kernel[backend1,backend2]' (not required with --security-only)"
+        ),
     )
     parser.add_argument(
         "--ref", default="main", help="Git ref to dispatch on (default: main)"
@@ -622,6 +707,18 @@ def main() -> int:
         )
         return 1
 
+    kernel_name = args.kernel_name
+    requested_backends = None
+    if kernel_name:
+        kernel_name, requested_backends = parse_kernel_arg(kernel_name)
+        if kernel_name is None:
+            print(
+                f"Error: invalid kernel argument {args.kernel_name!r} "
+                "(expected 'kernel' or 'kernel[backend1,backend2]').",
+                file=sys.stderr,
+            )
+            return 1
+
     common = dict(
         mode=args.mode,
         repo_prefix=args.repo_prefix,
@@ -634,11 +731,12 @@ def main() -> int:
         run_security=args.security,
         security_only=args.security_only,
         dispatch_key_prefix=args.dispatch_key_prefix,
+        requested_backends=requested_backends,
     )
 
     if args.dry_run:
         result = dispatch(
-            args.kernel_name,
+            kernel_name or "",
             token="",
             repo=args.repo or "",
             ref=args.ref,
@@ -662,7 +760,7 @@ def main() -> int:
             return 1
 
         result = dispatch(
-            args.kernel_name,
+            kernel_name or "",
             token=token,
             repo=repo,
             ref=args.ref,

--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -103,25 +103,20 @@ class DispatchPlan:
 
 
 def parse_kernel_arg(token: str) -> tuple[str | None, list[str] | None]:
-    """Split a ``kernel`` or ``kernel[b1,b2]`` token.
+    """Split ``kernel`` or ``kernel[b1,b2]`` into ``(name, backends)``.
 
-    Returns ``(name, backends)`` where ``backends`` is ``None`` when no
-    backend scope was given (meaning "all declared backends"), or a list of
-    the requested backend names. Returns ``(None, None)`` if the token is not
-    a valid kernel argument.
+    ``backends`` is ``None`` when no scope was given (all declared backends).
+    Returns ``(None, None)`` for a malformed token.
     """
     match = KERNEL_ARG_RE.match(token)
     if not match:
         return None, None
-    name = match.group("name")
     raw = match.group("backends")
-    if raw is None:
-        return name, None
-    return name, raw.split(",")
+    return match.group("name"), (raw.split(",") if raw else None)
 
 
-# Sentinel so select_workflows can distinguish "read backends from build.toml"
-# from an explicitly-passed backend list (including None, meaning unreadable).
+# Sentinel: lets select_workflows() tell "read build.toml" from an explicitly
+# passed backend list (None included, meaning unreadable).
 _READ_FROM_TOML = object()
 
 
@@ -252,44 +247,6 @@ def _windows_scoped_backends(
     return kept
 
 
-def _resolve_effective_backends(
-    kernel_name: str, requested_backends: list[str] | None, plan: DispatchPlan
-) -> list[str] | None:
-    """Combine a kernel's declared backends with an optional user filter.
-
-    Returns the list of backends to actually build. When ``requested_backends``
-    is ``None`` the declared list is returned unchanged (``None`` if
-    build.toml is unreadable, so callers fall back to all workflows). When a
-    filter is given, returns the declared backends intersected with it, or an
-    empty list if nothing matches (caller should build nothing).
-    """
-    declared = read_backends(kernel_name)
-    if requested_backends is None:
-        return declared
-
-    if declared is None:
-        # build.toml is unreadable; trust the explicit request as-is.
-        plan.notes.append(
-            f"Could not read backends for {kernel_name}; "
-            f"using requested backends {requested_backends}"
-        )
-        return list(requested_backends)
-
-    unknown = [b for b in requested_backends if b not in declared]
-    if unknown:
-        plan.notes.append(
-            f"Ignoring requested backend(s) {unknown} not declared by "
-            f"{kernel_name} (declared: {declared})"
-        )
-    effective = [b for b in declared if b in requested_backends]
-    if not effective:
-        plan.notes.append(
-            f"None of the requested backends {requested_backends} are declared "
-            f"by {kernel_name} (declared: {declared}); nothing to build"
-        )
-    return effective
-
-
 def _plan_build_actions(
     plan: DispatchPlan,
     kernel_name: str,
@@ -305,15 +262,22 @@ def _plan_build_actions(
     upload: bool,
     requested_backends: list[str] | None = None,
 ) -> None:
-    effective = _resolve_effective_backends(kernel_name, requested_backends, plan)
-    # A user filter that matched no declared backend -> build nothing.
-    if requested_backends is not None and effective == []:
-        plan.skipped = sorted(WORKFLOWS["build"])
-        return
+    backends = read_backends(kernel_name)
+    # Narrow to the requested backends, so both workflow selection and the
+    # per-workflow `backends` CSV skip everything the user did not ask for.
+    if requested_backends is not None and backends is not None:
+        backends = [b for b in backends if b in requested_backends]
+        if not backends:
+            plan.notes.append(
+                f"None of the requested backends {requested_backends} are "
+                f"declared by {kernel_name}; skipping build"
+            )
+            plan.skipped = sorted(WORKFLOWS["build"])
+            return
 
-    backends = effective or []
-    workflows = select_workflows(kernel_name, notes=plan.notes, backends=effective)
+    workflows = select_workflows(kernel_name, notes=plan.notes, backends=backends)
     plan.skipped = sorted(set(WORKFLOWS["build"]) - workflows)
+    backends = backends or []
 
     for workflow in sorted(workflows):
         scoped = sorted(
@@ -625,8 +589,8 @@ def main() -> int:
         nargs="?",
         default="",
         help=(
-            "Kernel directory name, optionally scoped to a subset of backends "
-            "as 'kernel[backend1,backend2]' (not required with --security-only)"
+            "Kernel directory name, optionally scoped as "
+            "'kernel[backend1,backend2]' (not required with --security-only)"
         ),
     )
     parser.add_argument(

--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -10,14 +10,20 @@ import urllib.request
 import uuid
 
 from dispatch import (
+    BACKEND_TO_WORKFLOWS,
     WORKFLOWS,
     dispatch,
     format_dry_run_payloads,
+    parse_kernel_arg,
 )
 
 KERNEL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
-COMMENT_CHARS_RE = re.compile(r"^/kernel-bot[ A-Za-z0-9_./-]*$")
+# Kernels may be scoped to backends, e.g. `flash-attn2[xpu,cpu]`, so the gate
+# additionally allows `[`, `]`, and `,`.
+COMMENT_CHARS_RE = re.compile(r"^/kernel-bot[ A-Za-z0-9_./,\[\]-]*$")
+# Backends a kernel may be scoped to (typos are rejected up front).
+KNOWN_BACKENDS = set(BACKEND_TO_WORKFLOWS)
 COMMAND_PERMISSIONS = {
     "build": {"admin", "write"},
     "security": {"admin", "write"},
@@ -35,6 +41,7 @@ RUN_LOOKUP_PAGE_SIZE = 100
 COMMAND_USAGE = (
     "Invalid command. Use `/kernel-bot <build|security|security-and-build|build-and-stage|merge-and-upload|release> "
     "<kernel1> [kernel2 ...] [--branch <target_branch>]`.\n"
+    "A kernel may be scoped to a subset of backends, e.g. `flash-attn2[xpu,cpu]`.\n"
     "The `security` command does not require kernel names."
 )
 
@@ -43,6 +50,8 @@ COMMAND_USAGE = (
 class ParsedCommand:
     command: str | None = None
     kernels: list[str] = field(default_factory=list)
+    # Kernel name -> requested backend subset (absent means "all backends").
+    backends: dict[str, list[str]] = field(default_factory=dict)
     branch: str | None = None
     error: str | None = None
 
@@ -415,18 +424,37 @@ def parse_command(comment: str) -> ParsedCommand:
         )
 
     kernels = []
+    backends: dict[str, list[str]] = {}
     seen = set()
-    for kernel in args:
-        if not KERNEL_RE.match(kernel):
-            return ParsedCommand(error=f"Invalid kernel name `{kernel}`.")
-        if kernel not in seen:
-            kernels.append(kernel)
-            seen.add(kernel)
+    for token in args:
+        name, requested = parse_kernel_arg(token)
+        if name is None:
+            return ParsedCommand(error=f"Invalid kernel name `{token}`.")
+        if requested is not None:
+            unknown = [b for b in requested if b not in KNOWN_BACKENDS]
+            if unknown:
+                known = ", ".join(sorted(KNOWN_BACKENDS))
+                return ParsedCommand(
+                    error=(
+                        f"Unknown backend(s) `{', '.join(unknown)}` in `{token}`. "
+                        f"Known backends: {known}."
+                    )
+                )
+        if name not in seen:
+            kernels.append(name)
+            seen.add(name)
+        if requested is not None:
+            scoped = backends.setdefault(name, [])
+            for b in requested:
+                if b not in scoped:
+                    scoped.append(b)
 
     if branch is not None and not BRANCH_RE.match(branch):
         return ParsedCommand(error=f"Invalid target branch `{branch}`.")
 
-    return ParsedCommand(command=command, kernels=kernels, branch=branch)
+    return ParsedCommand(
+        command=command, kernels=kernels, backends=backends, branch=branch
+    )
 
 
 def parse_numeric_id(raw_value: str | None):
@@ -629,6 +657,7 @@ def main(*, dry_run: bool = False):
 
     command = parsed_command.command
     kernels = parsed_command.kernels
+    kernel_backends = parsed_command.backends
     requested_branch = parsed_command.branch
     if command is None:
         print("Internal error: command parsing returned no command.", file=sys.stderr)
@@ -767,7 +796,11 @@ def main(*, dry_run: bool = False):
         "merge-and-upload": "merge, build and upload",
         "release": "release (linux + mac + windows)",
     }[command]
-    command_summary = f"/kernel-bot {command} {' '.join(kernels)}"
+    kernel_tokens = [
+        f"{k}[{','.join(kernel_backends[k])}]" if kernel_backends.get(k) else k
+        for k in kernels
+    ]
+    command_summary = f"/kernel-bot {command} {' '.join(kernel_tokens)}"
     if requested_branch is not None:
         command_summary += f" --branch {requested_branch}"
     # `/kernel-bot security-and-build` runs the security audit concurrently with the build.
@@ -875,6 +908,7 @@ def main(*, dry_run: bool = False):
             head_sha=pr_head_sha or "",
             target_branch=target_branch,
             upload=dispatch_upload,
+            requested_backends=kernel_backends.get(kernel_name),
             # The audit is per-PR, so request it only once (on the first kernel).
             run_security=run_security and index == 0,
             dry_run=dry_run,

--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -19,10 +19,7 @@ from dispatch import (
 
 KERNEL_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
-# Kernels may be scoped to backends, e.g. `flash-attn2[xpu,cpu]`, so the gate
-# additionally allows `[`, `]`, and `,`.
 COMMENT_CHARS_RE = re.compile(r"^/kernel-bot[ A-Za-z0-9_./,\[\]-]*$")
-# Backends a kernel may be scoped to (typos are rejected up front).
 KNOWN_BACKENDS = set(BACKEND_TO_WORKFLOWS)
 COMMAND_PERMISSIONS = {
     "build": {"admin", "write"},
@@ -50,7 +47,6 @@ COMMAND_USAGE = (
 class ParsedCommand:
     command: str | None = None
     kernels: list[str] = field(default_factory=list)
-    # Kernel name -> requested backend subset (absent means "all backends").
     backends: dict[str, list[str]] = field(default_factory=dict)
     branch: str | None = None
     error: str | None = None

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -26,8 +26,7 @@ def _workflows(actions):
 
 
 def _select(backends):
-    with mock.patch.object(dispatch, "read_backends", return_value=backends):
-        return dispatch.select_workflows("somekernel", notes=[])
+    return dispatch.select_workflows("somekernel", backends, notes=[])
 
 
 def _build_actions(plan):
@@ -132,6 +131,8 @@ def test_records_http_failure():
         ("flash-attn2", ("flash-attn2", None)),
         ("flash-attn2[xpu,cpu]", ("flash-attn2", ["xpu", "cpu"])),
         ("relu[cpu]", ("relu", ["cpu"])),
+        # Unknown backends parse here; the caller rejects them by name.
+        ("flash-attn2[bogus]", ("flash-attn2", ["bogus"])),
         ("bad/name", (None, None)),
         ("kernel[]", (None, None)),  # empty scope is not valid
         ("kernel[,]", (None, None)),  # dangling comma is not valid
@@ -197,11 +198,8 @@ ROUTING_TRUTH_TABLE = [
 def test_truth_table(backends, windows_allowed, expected):
     kernel = "k"
     allowlist = {kernel} if windows_allowed else set()
-    with (
-        mock.patch.object(dispatch, "read_backends", return_value=backends),
-        mock.patch.object(dispatch, "WINDOWS_KERNELS", allowlist),
-    ):
-        assert dispatch.select_workflows(kernel, notes=[]) == expected
+    with mock.patch.object(dispatch, "WINDOWS_KERNELS", allowlist):
+        assert dispatch.select_workflows(kernel, backends, notes=[]) == expected
 
 
 # Invariants over every real kernel: assert properties, not exact per-kernel output.
@@ -243,7 +241,7 @@ def test_every_build_toml_parses(kernels):
 def test_every_kernel_routes_to_at_least_one_known_build(kernels):
     build_workflows = set(dispatch.WORKFLOWS["build"])
     for kernel in kernels:
-        workflows = dispatch.select_workflows(kernel, notes=[])
+        workflows = dispatch.select_workflows(kernel, dispatch.read_backends(kernel), notes=[])
         assert workflows, f"{kernel} routes to no build workflow"
         assert workflows <= build_workflows, (
             f"{kernel} routes to unknown workflow(s): {workflows - build_workflows}"

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -153,18 +153,17 @@ def test_requested_backends_filter_narrows_workflows_and_scope():
     assert _backends_csv(build[0]) == ["cpu", "xpu"]
 
 
-def test_requested_backends_unknown_are_ignored_with_note():
+def test_requested_backends_undeclared_are_dropped():
     plan = _plan(backends=["cpu", "cuda"], requested_backends=["cpu", "rocm"])
     build = _build_actions(plan)
     assert _backends_csv(build[0]) == ["cpu"]  # rocm not declared -> dropped
-    assert any("Ignoring requested backend" in n for n in plan.notes)
 
 
 def test_requested_backends_none_match_skips_all_builds():
     plan = _plan(backends=["cpu", "cuda"], requested_backends=["rocm"])
     assert _build_actions(plan) == []
     assert plan.skipped == sorted(dispatch.WORKFLOWS["build"])
-    assert any("nothing to build" in n for n in plan.notes)
+    assert any("skipping build" in n for n in plan.notes)
 
 
 def test_requested_backends_thread_through_dispatch_dry_run():

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -30,6 +30,14 @@ def _select(backends):
         return dispatch.select_workflows("somekernel", notes=[])
 
 
+def _build_actions(plan):
+    return [a for a in plan.actions if a.kind == "build"]
+
+
+def _backends_csv(action):
+    return sorted(b for b in action.body["inputs"]["backends"].split(",") if b)
+
+
 # Fallback routing when build.toml is unreadable or declares unknown backends.
 def test_unreadable_backends_falls_back_to_all_builds():
     assert _select(None) == set(dispatch.WORKFLOWS["build"])
@@ -115,6 +123,65 @@ def test_records_http_failure():
         result = dispatch.execute_plan(plan, token="t", repo="owner/repo")
     assert result.dispatched == []
     assert [code for _, code in result.failed] == [500]
+
+
+# parse_kernel_arg: the `kernel` / `kernel[b1,b2]` argument grammar.
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        ("flash-attn2", ("flash-attn2", None)),
+        ("flash-attn2[xpu,cpu]", ("flash-attn2", ["xpu", "cpu"])),
+        ("relu[cpu]", ("relu", ["cpu"])),
+        ("bad/name", (None, None)),
+        ("kernel[]", (None, None)),  # empty scope is not valid
+        ("kernel[,]", (None, None)),  # dangling comma is not valid
+        ("kernel[cpu,]", (None, None)),
+    ],
+)
+def test_parse_kernel_arg(token, expected):
+    assert dispatch.parse_kernel_arg(token) == expected
+
+
+# requested_backends: user-supplied filter narrows workflows and the scoped CSV.
+def test_requested_backends_filter_narrows_workflows_and_scope():
+    plan = _plan(
+        backends=["cpu", "cuda", "xpu"], requested_backends=["xpu", "cpu"]
+    )
+    build = _build_actions(plan)
+    # cuda dropped -> Windows gated off for the non-allowlisted kernel -> Linux only.
+    assert _workflows(build) == ["build.yaml"]
+    assert _backends_csv(build[0]) == ["cpu", "xpu"]
+
+
+def test_requested_backends_unknown_are_ignored_with_note():
+    plan = _plan(backends=["cpu", "cuda"], requested_backends=["cpu", "rocm"])
+    build = _build_actions(plan)
+    assert _backends_csv(build[0]) == ["cpu"]  # rocm not declared -> dropped
+    assert any("Ignoring requested backend" in n for n in plan.notes)
+
+
+def test_requested_backends_none_match_skips_all_builds():
+    plan = _plan(backends=["cpu", "cuda"], requested_backends=["rocm"])
+    assert _build_actions(plan) == []
+    assert plan.skipped == sorted(dispatch.WORKFLOWS["build"])
+    assert any("nothing to build" in n for n in plan.notes)
+
+
+def test_requested_backends_thread_through_dispatch_dry_run():
+    with mock.patch.object(
+        dispatch, "read_backends", return_value=["cpu", "cuda", "xpu"]
+    ):
+        result = dispatch.dispatch(
+            "somekernel",
+            token="",
+            repo="owner/repo",
+            dry_run=True,
+            requested_backends=["xpu"],
+        )
+    csvs = [body["inputs"]["backends"] for _, body in result.dry_run_payloads]
+    assert csvs, "expected at least one dispatched build"
+    assert all("cuda" not in c.split(",") for c in csvs)
+    assert any("xpu" in c.split(",") for c in csvs)
 
 
 # select_workflows: backend-union and Windows-gate cases (single-backend rows omitted).

--- a/.github/scripts/test_pr_comment_kernel_bot.py
+++ b/.github/scripts/test_pr_comment_kernel_bot.py
@@ -72,6 +72,38 @@ def test_invalid_kernel_name_is_error():
     assert bot.parse_command("/kernel-bot build bad/name").error is not None
 
 
+def test_build_with_backend_scope():
+    parsed = bot.parse_command("/kernel-bot build flash-attn2[xpu,cpu]")
+    assert parsed.error is None
+    assert parsed.kernels == ["flash-attn2"]
+    assert parsed.backends == {"flash-attn2": ["xpu", "cpu"]}
+
+
+def test_backend_scope_mixes_with_plain_kernels():
+    parsed = bot.parse_command("/kernel-bot build activation flash-attn2[xpu]")
+    assert parsed.error is None
+    assert parsed.kernels == ["activation", "flash-attn2"]
+    assert parsed.backends == {"flash-attn2": ["xpu"]}
+
+
+def test_backend_scope_unknown_backend_is_error():
+    parsed = bot.parse_command("/kernel-bot build flash-attn2[gpu]")
+    assert parsed.error is not None
+    assert "gpu" in parsed.error
+
+
+def test_backend_scopes_union_across_repeats():
+    parsed = bot.parse_command("/kernel-bot build relu[cpu] relu[xpu]")
+    assert parsed.kernels == ["relu"]
+    assert parsed.backends == {"relu": ["cpu", "xpu"]}
+
+
+def test_supported_characters_allows_backend_scope():
+    assert bot.comment_has_only_supported_characters(
+        "/kernel-bot build flash-attn2[xpu,cpu]"
+    )
+
+
 def test_invalid_branch_name_is_error():
     parsed = bot.parse_command("/kernel-bot build foo --branch bad~branch")
     assert parsed.error is not None

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,7 +168,6 @@ jobs:
         env:
           KERNEL: ${{ steps.validate.outputs.kernel }}
           MODE: ${{ inputs.mode }}
-          # Optional comma-separated allowlist; empty means build every backend.
           BACKENDS_FILTER: ${{ inputs.backends }}
         run: |
           if [ "$MODE" = "pr" ]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,6 +168,8 @@ jobs:
         env:
           KERNEL: ${{ steps.validate.outputs.kernel }}
           MODE: ${{ inputs.mode }}
+          # Optional comma-separated allowlist; empty means build every backend.
+          BACKENDS_FILTER: ${{ inputs.backends }}
         run: |
           if [ "$MODE" = "pr" ]; then
             NIX_TARGET="backendCi"

--- a/.github/workflows/generate-build-matrix.py
+++ b/.github/workflows/generate-build-matrix.py
@@ -12,6 +12,10 @@ with one entry per (backend, arch) combination. Each entry includes max_jobs
 and cores, falling back to DEFAULT_MAX_JOBS and DEFAULT_CORES respectively,
 with per-kernel/backend overrides read from build-concurrency.json at the
 repo root.
+
+The optional BACKENDS_FILTER environment variable (a comma-separated list)
+restricts the matrix to those backends. When empty or unset, every backend
+nix exposes is built. Filter names not exposed by nix are simply ignored.
 """
 
 import json
@@ -70,6 +74,10 @@ def main():
         print("KERNEL environment variable is not set or empty", file=sys.stderr)
         sys.exit(1)
 
+    backends_filter = {
+        b.strip() for b in os.environ.get("BACKENDS_FILTER", "").split(",") if b.strip()
+    }
+
     backends_by_arch = {
         "x86_64-linux": json.loads(sys.argv[1]),
         "aarch64-linux": json.loads(sys.argv[2]),
@@ -93,7 +101,22 @@ def main():
         }
         for arch, runner in ARCHES
         for backend in backends_by_arch[arch]
+        if not backends_filter or backend in backends_filter
     ]
+
+    if backends_filter:
+        dropped = {
+            backend
+            for backends in backends_by_arch.values()
+            for backend in backends
+            if backend not in backends_filter
+        }
+        if dropped:
+            print(
+                f"BACKENDS_FILTER={sorted(backends_filter)} excluded backends "
+                f"{sorted(dropped)} for kernel {kernel!r}",
+                file=sys.stderr,
+            )
 
     print(json.dumps({"include": include}))
 

--- a/.github/workflows/generate-build-matrix.py
+++ b/.github/workflows/generate-build-matrix.py
@@ -13,9 +13,8 @@ and cores, falling back to DEFAULT_MAX_JOBS and DEFAULT_CORES respectively,
 with per-kernel/backend overrides read from build-concurrency.json at the
 repo root.
 
-The optional BACKENDS_FILTER environment variable (a comma-separated list)
-restricts the matrix to those backends. When empty or unset, every backend
-nix exposes is built. Filter names not exposed by nix are simply ignored.
+The optional BACKENDS_FILTER environment variable (comma-separated) restricts
+the matrix to those backends; empty or unset builds every backend nix exposes.
 """
 
 import json
@@ -103,20 +102,6 @@ def main():
         for backend in backends_by_arch[arch]
         if not backends_filter or backend in backends_filter
     ]
-
-    if backends_filter:
-        dropped = {
-            backend
-            for backends in backends_by_arch.values()
-            for backend in backends
-            if backend not in backends_filter
-        }
-        if dropped:
-            print(
-                f"BACKENDS_FILTER={sorted(backends_filter)} excluded backends "
-                f"{sorted(dropped)} for kernel {kernel!r}",
-                file=sys.stderr,
-            )
 
     print(json.dumps({"include": include}))
 

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -42,7 +42,7 @@ jobs:
               exit 0
               ;;
           esac
-          if ! printf '%s' "$COMMENT_BODY" | grep -Eq '^/kernel-bot[ A-Za-z0-9_./-]*$'; then
+          if ! printf '%s' "$COMMENT_BODY" | grep -Eq '^/kernel-bot[][ A-Za-z0-9_,./-]*$'; then
             echo "Ignoring /kernel-bot comment with unsupported characters."
             exit 0
           fi


### PR DESCRIPTION
the PR updates the kernel bot to enable filtering the backends to target

```bash
python .github/scripts/pr_comment_kernel_bot.py \
--dry-run "/kernel-bot build flash-attn2[xpu,cpu]" \
--pr-number 1007
```
outputs
```
Skipping Windows build for flash-attn2 (not in WINDOWS_KERNELS allowlist)

[dry-run] build.yaml:
{
  "ref": "main",
  "inputs": {
    "kernel_name": "flash-attn2",
    "dispatch_key": "pr1007-flash-attn2-build.yaml-3b9a156aa092",
    "mode": "release",
    "backends": "cpu,xpu",
    "repo_prefix": "kernels-community",
    "pr_number": "1007",
    "head_sha": "f80fa0a5bdcae73fe8549f57abed832eb6e304e6",
    "target_branch": "pr-1007",
    "upload": "false"
  }
}
```

and with no filter


```bash
python .github/scripts/pr_comment_kernel_bot.py \
--dry-run "/kernel-bot build flash-attn2" \
--pr-number 1007
```
outputs
```
Skipping Windows build for flash-attn2 (not in WINDOWS_KERNELS allowlist)

[dry-run] build.yaml:
{
  "ref": "main",
  "inputs": {
    "kernel_name": "flash-attn2",
    "dispatch_key": "pr1007-flash-attn2-build.yaml-bd3fc94efa15",
    "mode": "release",
    "backends": "cpu,cuda,xpu",
    "repo_prefix": "kernels-community",
    "pr_number": "1007",
    "head_sha": "f80fa0a5bdcae73fe8549f57abed832eb6e304e6",
    "target_branch": "pr-1007",
    "upload": "false"
  }
}
```