### PR TITLE
mamba-ssm: add causal-conv1d layers

### DIFF
--- a/mamba-ssm/torch-ext/mamba_ssm/__init__.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/__init__.py
@@ -1,12 +1,17 @@
 __version__ = "2.2.4"
 
-from .ops import selective_state_update, mamba_chunk_scan_combined, mamba_split_conv1d_scan_combined
-from .ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
-from .modules import Mamba, Mamba2
+from . import layers
 from .models import MambaLMHeadModel
+from .modules import Mamba, Mamba2
+from .ops import mamba_chunk_scan_combined, mamba_split_conv1d_scan_combined, selective_state_update
+from .ops.selective_scan_interface import mamba_inner_fn, selective_scan_fn
+
 
 falcon_mamba_inner_fn = mamba_inner_fn
 __all__ = [
+    # wrappers
+    "layers",
+    # originals
     "selective_scan_fn", "mamba_inner_fn", "falcon_mamba_inner_fn", "selective_state_update", "mamba_chunk_scan_combined", "mamba_split_conv1d_scan_combined",
     "Mamba", "Mamba2", "MambaLMHeadModel",
 ]

--- a/mamba-ssm/torch-ext/mamba_ssm/layers.py
+++ b/mamba-ssm/torch-ext/mamba_ssm/layers.py
@@ -1,0 +1,46 @@
+import torch.nn as nn
+
+from ._causal_conv1d import causal_conv1d_fn as cuda_causal_conv1d_fn
+from ._causal_conv1d import causal_conv1d_update as cuda_causal_conv1d_update
+
+
+class causal_conv1d_fn(nn.Module):
+    def forward(
+        self,
+        hidden_states,
+        weight,
+        bias=None,
+        activation=None,
+        **kwargs,
+    ):
+        # For varlen
+        seq_idx = kwargs.pop("seq_idx", None)
+
+        return cuda_causal_conv1d_fn(
+            x=hidden_states,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+            seq_idx=seq_idx,
+        )
+
+
+class causal_conv1d_update(nn.Module):
+    def forward(
+        self,
+        hidden_states,
+        conv_state,
+        weight,
+        bias=None,
+        activation=None,
+    ):
+        return cuda_causal_conv1d_update(
+            x=hidden_states,
+            conv_state=conv_state,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+        )
+
+
+__all__ = ["causal_conv1d_fn", "causal_conv1d_update"]


### PR DESCRIPTION
As per title, allow causal conv1d to be available through layers. Imo in the future we could do the same for the mamba ops but they are much more involved and will be a bigger project so refraining as this is timely