### PR TITLE
fix: install envsubst on runners via nix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,6 +237,12 @@ jobs:
           fi
           ( cd "$KERNEL" && cp -rL result build && rm result && chmod -R u+w build )
 
+      # cosign-installer >= v4.1.1 requires envsubst (gettext), which is not
+      # preinstalled on the custom runner images.
+      - name: Add envsubst to PATH
+        if: inputs.mode != 'pr'
+        run: echo "$(nix build nixpkgs#gettext --no-link --print-out-paths)/bin" >> "$GITHUB_PATH"
+
       - name: Install Cosign
         if: inputs.mode != 'pr'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/sign-old-builds.yaml
+++ b/.github/workflows/sign-old-builds.yaml
@@ -39,6 +39,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      # cosign-installer >= v4.1.1 requires envsubst (gettext), which is not
+      # preinstalled on the custom runner images.
+      - name: Add envsubst to PATH
+        run: echo "$(nix build nixpkgs#gettext --no-link --print-out-paths)/bin" >> "$GITHUB_PATH"
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 


### PR DESCRIPTION
this PR simply installs envsubst onto the runners so cosign-installer >= v4.1.1 does not error. 

we began to see the following error after bumping cosign

```
/home/runner/_work/_temp/369cc807-edb4-41ef-9bf6-c1194058077e.sh: line 3: envsubst: command not found
```

example:
https://github.com/huggingface/kernels-community/actions/runs/29145431986/job/86526134895#step:8:258