### PR TITLE
feat: prefer reading the build toml from current ref

### DIFF
--- a/.github/scripts/dispatch.py
+++ b/.github/scripts/dispatch.py
@@ -109,12 +109,25 @@ def parse_kernel_arg(token: str) -> tuple[str | None, list[str] | None]:
     return name, backends
 
 
-def read_backends(kernel_name: str) -> list[str] | None:
-    build_toml = Path(kernel_name) / "build.toml"
-    if not build_toml.exists():
-        return None
-    with open(build_toml, "rb") as f:
-        config = tomllib.load(f)
+def read_backends(kernel_name: str, ref: str = "") -> list[str] | None:
+    # ref reads build.toml from that revision (the PR branch), not the working tree.
+    if ref:
+        try:
+            raw = subprocess.run(
+                ["git", "show", f"{ref}:{kernel_name}/build.toml"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            return None
+        config = tomllib.loads(raw)
+    else:
+        build_toml = Path(kernel_name) / "build.toml"
+        if not build_toml.exists():
+            return None
+        with open(build_toml, "rb") as f:
+            config = tomllib.load(f)
     backends = config.get("general", {}).get("backends")
     if backends is None:
         backends = config.get("backends")
@@ -251,9 +264,10 @@ def _plan_build_actions(
     target_branch: str,
     upload: bool,
     bot_comment_id: str,
+    metadata_ref: str = "",
     requested_backends: list[str] | None = None,
 ) -> None:
-    backends = read_backends(kernel_name)
+    backends = read_backends(kernel_name, metadata_ref)
     if requested_backends is not None and backends is not None:
         backends = [b for b in backends if b in requested_backends]
         if not backends:
@@ -327,6 +341,7 @@ def plan_dispatch(
     bot_comment_id: str = "",
     run_security: bool = False,
     security_only: bool = False,
+    metadata_ref: str = "",
     requested_backends: list[str] | None = None,
 ) -> DispatchPlan:
     want_security = run_security or security_only
@@ -340,6 +355,7 @@ def plan_dispatch(
             mode=mode,
             repo_prefix=repo_prefix,
             dispatch_key_prefix=dispatch_key_prefix,
+            metadata_ref=metadata_ref,
             skip_build=skip_build,
             pr_number=pr_number,
             head_sha=head_sha,
@@ -497,6 +513,7 @@ def dispatch(
     bot_comment_id: str = "",
     run_security: bool = False,
     security_only: bool = False,
+    metadata_ref: str = "",
     requested_backends: list[str] | None = None,
 ) -> DispatchResult:
     if not security_only and (not kernel_name or not KERNEL_NAME_RE.match(kernel_name)):
@@ -520,6 +537,7 @@ def dispatch(
         bot_comment_id=bot_comment_id,
         run_security=run_security,
         security_only=security_only,
+        metadata_ref=metadata_ref,
         requested_backends=requested_backends,
     )
     if dry_run:

--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -909,6 +909,8 @@ def main(*, dry_run: bool = False):
             # The audit is per-PR, so request it only once (on the first kernel).
             run_security=run_security and index == 0,
             dry_run=dry_run,
+            # Read backends from the PR commit (dry-run reads the working tree).
+            metadata_ref="" if dry_run else (pr_head_sha or ""),
         )
         emit_dispatch_diagnostics(release_result, dry_run=dry_run)
         for wf, dk in release_result.dispatched:

--- a/.github/scripts/test_dispatch.py
+++ b/.github/scripts/test_dispatch.py
@@ -1,5 +1,6 @@
 import io
 import os
+import subprocess
 import sys
 import urllib.error
 from unittest import mock
@@ -72,6 +73,32 @@ def test_security_only_plans_only_security():
         assert action.dispatch_key.startswith("pr42-security-")
         assert action.body["inputs"]["pr_number"] == "42"
         assert action.body["inputs"]["head_sha"] == "deadbeef"
+
+
+# Metadata read from a git ref (PR branch) instead of the working tree.
+
+
+def test_read_backends_from_ref_uses_git_show():
+    run = mock.Mock(return_value=mock.Mock(stdout='backends = ["cuda", "rocm"]\n'))
+    with mock.patch.object(dispatch.subprocess, "run", run):
+        backends = dispatch.read_backends("somekernel", ref="abc123")
+    assert backends == ["cuda", "rocm"]
+    assert run.call_args.args[0] == ["git", "show", "abc123:somekernel/build.toml"]
+
+
+def test_read_backends_from_ref_missing_returns_none():
+    err = subprocess.CalledProcessError(128, ["git", "show"])
+    with mock.patch.object(dispatch.subprocess, "run", side_effect=err):
+        assert dispatch.read_backends("missing", ref="abc123") is None
+
+
+def test_metadata_ref_routes_metal_less_kernel_without_mac_build():
+    # Regression: a cuda-only kernel read from the ref must not trigger build-mac.yaml.
+    run = mock.Mock(return_value=mock.Mock(stdout='backends = ["cuda"]\n'))
+    with mock.patch.object(dispatch.subprocess, "run", run):
+        plan = dispatch.plan_dispatch("newkernel", metadata_ref="prsha")
+    builds = _workflows([a for a in plan.actions if a.kind == "build"])
+    assert builds == ["build.yaml"]
 
 
 # Orchestration: kernel-name validation and the dry-run no-I/O contract.

--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -19,6 +19,9 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+      - name: Fetch PR head for metadata
+        # Make the PR commit available so the bot can read its build.toml (data only).
+        run: git fetch --depth=1 origin "refs/pull/${{ github.event.issue.number }}/head"
       - name: Handle /kernel-bot command
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Re-targets #982 at `main`. That PR was merged into `kernel-bot-refactor`, which had already been squash-merged and closed via #983 three weeks earlier — so the change never reached `main`.

The kernel bot checks out the default branch, so it read `build.toml` from `main` rather than from the PR. A kernel whose `build.toml` is added or whose `backends` change in the PR got the wrong workflow set — a new cuda-only kernel would still dispatch `build-mac.yaml`.

`read_backends` now takes an optional `ref` and reads via `git show <ref>:<kernel>/build.toml`. Empty ref keeps the working-tree read, so dry-run and local behavior are unchanged. `pr-comment-build.yaml` fetches the PR head at depth 1 so the blob is available.

Cherry-picked onto current `main`, which required reconciling with #1016: `select_workflows` there takes `backends` as a parameter so `parse_kernel_arg` can support inline overrides (`relu[cuda,rocm]`). Kept that design and threaded `metadata_ref` only through `read_backends` — applying the original version as-written would have bypassed the requested-backends filter. Tests rewritten from `unittest` to pytest to match `main`.

57 tests pass.