### PR TITLE
sonic-moe: never scatter the uninitialized tail of the colvec reduce …

### DIFF
--- a/sonic-moe/torch-ext/sonic_moe/functional/__init__.py
+++ b/sonic-moe/torch-ext/sonic_moe/functional/__init__.py
@@ -266,6 +266,7 @@ class _DownProjection(torch.autograd.Function):
             expert_frequency_offset,
             x_gather_idx,
             s_scatter_idx,
+            s_reverse_scatter_idx,
         )
 
         return o
@@ -285,6 +286,7 @@ class _DownProjection(torch.autograd.Function):
             expert_frequency_offset,
             x_gather_idx,
             s_scatter_idx,
+            s_reverse_scatter_idx,
         ) = ctx.saved_tensors
 
         dw2 = torch.empty_like(w2)
@@ -310,6 +312,7 @@ class _DownProjection(torch.autograd.Function):
             expert_frequency_offset=expert_frequency_offset,
             x_gather_idx=x_gather_idx,
             s_scatter_idx=s_scatter_idx,
+            s_reverse_scatter_idx=s_reverse_scatter_idx,
             activation_type=activation_type.value,
         )
 

--- a/sonic-moe/torch-ext/sonic_moe/functional/__init__.py
+++ b/sonic-moe/torch-ext/sonic_moe/functional/__init__.py
@@ -374,7 +374,6 @@ def moe_TC_softmax_topk_layer(
     if type(activation_type) == str:
         activation_type = ActivationType(activation_type)
 
-    assert not torch.compiler.is_compiling()
     assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
 
     a, h = _UpProjection.apply(
@@ -474,7 +473,6 @@ def moe_general_routing_inputs(
         num_activated_expert_per_token_offset,
     )
 
-    assert not torch.compiler.is_compiling()
     assert is_glu(activation_type), "QuACK GEMM does not support non GLU activation yet"
 
     a, h = _UpProjection.apply(

--- a/sonic-moe/torch-ext/sonic_moe/functional/backward.py
+++ b/sonic-moe/torch-ext/sonic_moe/functional/backward.py
@@ -237,31 +237,36 @@ def _up_projection_backward_weight(
 _up_projection_backward_weight.compile_cache = {}
 
 
-def _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, out):
-    """Scatter `ds_scattered` back to slot order, dropping the rows no GEMM tile ever wrote.
+def _gather_valid_rows(ds_scattered, s_reverse_scatter_idx, out):
+    """Gather the colvec-reduce rows back to slot order through the inverse permutation.
 
     `cu_seqlens_m` (= `expert_frequency_offset`) stops at the number of entries routed to a local
     expert, so under expert parallelism the rows `[sum_valid, TK)` of `ds_scattered` are read straight
     out of an uninitialized buffer — QuACK allocates `colvec_reduce_partial` with `torch.empty` and
-    only the covered tiles write it. Dropping those rows is necessary but not sufficient on its own:
-    the tail of `s_scatter_idx` is zero-filled, so a plain `out[s_scatter_idx] = ds_scattered` aliases
-    every uninitialized row onto `out[0]` with duplicate indices, leaving the surviving value
-    unspecified. Redirecting them to a scratch slot at index `TK` keeps the write pattern
-    conflict-free, and because the scratch buffer starts zeroed and is copied over `out` in full, the
-    slots that own no row end at a defined 0 rather than at whatever `out` was allocated with.
+    only the covered tiles write it. Scattering with `out[s_scatter_idx] = ds_scattered` propagates
+    that: the tail of `s_scatter_idx` is zero-filled, so every uninitialized row is aliased onto
+    `out[0]` with duplicate indices, and the surviving value is unspecified.
 
-    Sync-free on purpose: the bound is compared on device, because `int(expert_frequency_offset[-1])`
-    would stall the host once per MoE layer per step.
+    Going through the inverse permutation removes both hazards by construction rather than masking
+    them. `s_reverse_scatter_idx` already holds `TK` at sentinel lanes (see
+    `_general_metadata_compute_stage2`), so appending one zero row makes every slot resolve to either
+    its own row or a defined 0, and a gather writes each output element exactly once — no duplicate
+    index can reach `out`, and no lane addresses the uninitialized tail.
 
-    Without EP there are no sentinels, `sum_valid == TK`, every row is valid, and this reduces to the
-    scatter it replaces.
+    Sync-free: no bound is read on the host, unlike an `int(expert_frequency_offset[-1])` slice, which
+    would stall once per MoE layer per step.
+
+    Without sentinels `s_reverse_scatter_idx` is a full permutation of `[0, TK)`, the appended row is
+    unreachable, and this is exactly the scatter it replaces. Note that only the general-routing
+    metadata writes the `TK` marker; the bitmatrix path (`_bitmatrix_metadata_compute_stage2`) leaves
+    sentinel lanes at their zero-init, but it cannot see sentinels either — its histogram would
+    atomically add at `expert == E`, past the end of the `[E, n_tiles]` partial-sum buffer. Adding
+    sentinel support there means writing the `TK` marker there too.
     """
-    TK = s_scatter_idx.numel()
-    row_valid = torch.arange(TK, device=out.device) < expert_frequency_offset[-1]
-    dest = torch.where(row_valid, s_scatter_idx.long(), TK)
+    TK = s_reverse_scatter_idx.numel()
     padded = torch.zeros(TK + 1, dtype=out.dtype, device=out.device)
-    padded.index_put_((dest,), ds_scattered.to(out.dtype))
-    out.view(-1).copy_(padded[:TK])
+    padded[:TK].copy_(ds_scattered)
+    torch.index_select(padded, 0, s_reverse_scatter_idx, out=out.view(-1))
 
 
 @torch.library.custom_op(add_op_namespace_prefix("_down_projection_backward_act"), mutates_args={"dh", "ds", "db2", "a_prime"})
@@ -278,6 +283,7 @@ def _down_projection_backward_act(
     expert_frequency_offset: torch.Tensor,
     x_gather_idx: torch.Tensor,
     s_scatter_idx: torch.Tensor,
+    s_reverse_scatter_idx: torch.Tensor,
     activation_type: str,
 ) -> None:
     assert activation_type in (
@@ -300,7 +306,7 @@ def _down_projection_backward_act(
         dynamic_scheduler=False,
     )
     if db2 is None:
-        _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, ds)
+        _gather_valid_rows(ds_scattered, s_reverse_scatter_idx, ds)
     else:
         H = w2.size(0)
         E = expert_frequency_offset.size(0) - 1
@@ -308,11 +314,14 @@ def _down_projection_backward_act(
 
         # Same hazard as the `db2 is None` path above, same treatment. Untested: no model we run has
         # an expert bias, so this branch is fixed for consistency rather than validated.
-        old_ds_partial = torch.zeros(TK, 1, device=ds_scattered.device, dtype=ds_scattered.dtype)
-        _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, old_ds_partial)
+        old_ds_partial = torch.empty(TK, 1, device=ds_scattered.device, dtype=ds_scattered.dtype)
+        _gather_valid_rows(ds_scattered, s_reverse_scatter_idx, old_ds_partial)
 
         BLOCK_H = min(triton.next_power_of_2(H), 2048)
         NUM_H_BLOCKS = triton.cdiv(H, BLOCK_H)
+        # Zero-init, unlike `old_ds_partial` above: the kernel below only walks the grouped rows each
+        # expert owns, so with sentinels the slots in `[sum_valid, TK)` are never stored to, and `ds`
+        # is copied from this buffer wholesale.
         new_ds_partial = torch.zeros(TK, NUM_H_BLOCKS, dtype=torch.float32, device=ds.device)
 
         db2_and_ds_kernel[(E, NUM_H_BLOCKS)](

--- a/sonic-moe/torch-ext/sonic_moe/functional/backward.py
+++ b/sonic-moe/torch-ext/sonic_moe/functional/backward.py
@@ -238,30 +238,14 @@ _up_projection_backward_weight.compile_cache = {}
 
 
 def _gather_valid_rows(ds_scattered, s_reverse_scatter_idx, out):
-    """Gather the colvec-reduce rows back to slot order through the inverse permutation.
+    """Gather the colvec-reduce rows back to slot order.
 
-    `cu_seqlens_m` (= `expert_frequency_offset`) stops at the number of entries routed to a local
-    expert, so under expert parallelism the rows `[sum_valid, TK)` of `ds_scattered` are read straight
-    out of an uninitialized buffer — QuACK allocates `colvec_reduce_partial` with `torch.empty` and
-    only the covered tiles write it. Scattering with `out[s_scatter_idx] = ds_scattered` propagates
-    that: the tail of `s_scatter_idx` is zero-filled, so every uninitialized row is aliased onto
-    `out[0]` with duplicate indices, and the surviving value is unspecified.
-
-    Going through the inverse permutation removes both hazards by construction rather than masking
-    them. `s_reverse_scatter_idx` already holds `TK` at sentinel lanes (see
-    `_general_metadata_compute_stage2`), so appending one zero row makes every slot resolve to either
-    its own row or a defined 0, and a gather writes each output element exactly once — no duplicate
-    index can reach `out`, and no lane addresses the uninitialized tail.
-
-    Sync-free: no bound is read on the host, unlike an `int(expert_frequency_offset[-1])` slice, which
-    would stall once per MoE layer per step.
-
-    Without sentinels `s_reverse_scatter_idx` is a full permutation of `[0, TK)`, the appended row is
-    unreachable, and this is exactly the scatter it replaces. Note that only the general-routing
-    metadata writes the `TK` marker; the bitmatrix path (`_bitmatrix_metadata_compute_stage2`) leaves
-    sentinel lanes at their zero-init, but it cannot see sentinels either — its histogram would
-    atomically add at `expert == E`, past the end of the `[E, n_tiles]` partial-sum buffer. Adding
-    sentinel support there means writing the `TK` marker there too.
+    The GEMM only covers the rows routed to a local expert, so under EP the tail of `ds_scattered` is
+    uninitialized. `s_reverse_scatter_idx` maps every slot either to its own row or to `TK` for a
+    sentinel, so gathering off a buffer with one appended zero row gives each slot its row or a 0: the
+    uninitialized tail is never addressed, and no slot is written twice. Without sentinels it is a
+    plain permutation. Only the general-routing metadata writes the `TK` marker; the bitmatrix path
+    never sees sentinels, so add the marker there too if that changes.
     """
     TK = s_reverse_scatter_idx.numel()
     padded = torch.zeros(TK + 1, dtype=out.dtype, device=out.device)
@@ -312,16 +296,12 @@ def _down_projection_backward_act(
         E = expert_frequency_offset.size(0) - 1
         TK = x_gather_idx.size(0)
 
-        # Same hazard as the `db2 is None` path above, same treatment. Untested: no model we run has
-        # an expert bias, so this branch is fixed for consistency rather than validated.
         old_ds_partial = torch.empty(TK, 1, device=ds_scattered.device, dtype=ds_scattered.dtype)
         _gather_valid_rows(ds_scattered, s_reverse_scatter_idx, old_ds_partial)
 
         BLOCK_H = min(triton.next_power_of_2(H), 2048)
         NUM_H_BLOCKS = triton.cdiv(H, BLOCK_H)
-        # Zero-init, unlike `old_ds_partial` above: the kernel below only walks the grouped rows each
-        # expert owns, so with sentinels the slots in `[sum_valid, TK)` are never stored to, and `ds`
-        # is copied from this buffer wholesale.
+        # Zero-init: the kernel below skips sentinel slots, and `ds` is copied from this buffer whole.
         new_ds_partial = torch.zeros(TK, NUM_H_BLOCKS, dtype=torch.float32, device=ds.device)
 
         db2_and_ds_kernel[(E, NUM_H_BLOCKS)](

--- a/sonic-moe/torch-ext/sonic_moe/functional/backward.py
+++ b/sonic-moe/torch-ext/sonic_moe/functional/backward.py
@@ -237,6 +237,33 @@ def _up_projection_backward_weight(
 _up_projection_backward_weight.compile_cache = {}
 
 
+def _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, out):
+    """Scatter `ds_scattered` back to slot order, dropping the rows no GEMM tile ever wrote.
+
+    `cu_seqlens_m` (= `expert_frequency_offset`) stops at the number of entries routed to a local
+    expert, so under expert parallelism the rows `[sum_valid, TK)` of `ds_scattered` are read straight
+    out of an uninitialized buffer — QuACK allocates `colvec_reduce_partial` with `torch.empty` and
+    only the covered tiles write it. Dropping those rows is necessary but not sufficient on its own:
+    the tail of `s_scatter_idx` is zero-filled, so a plain `out[s_scatter_idx] = ds_scattered` aliases
+    every uninitialized row onto `out[0]` with duplicate indices, leaving the surviving value
+    unspecified. Redirecting them to a scratch slot at index `TK` keeps the write pattern
+    conflict-free, and because the scratch buffer starts zeroed and is copied over `out` in full, the
+    slots that own no row end at a defined 0 rather than at whatever `out` was allocated with.
+
+    Sync-free on purpose: the bound is compared on device, because `int(expert_frequency_offset[-1])`
+    would stall the host once per MoE layer per step.
+
+    Without EP there are no sentinels, `sum_valid == TK`, every row is valid, and this reduces to the
+    scatter it replaces.
+    """
+    TK = s_scatter_idx.numel()
+    row_valid = torch.arange(TK, device=out.device) < expert_frequency_offset[-1]
+    dest = torch.where(row_valid, s_scatter_idx.long(), TK)
+    padded = torch.zeros(TK + 1, dtype=out.dtype, device=out.device)
+    padded.index_put_((dest,), ds_scattered.to(out.dtype))
+    out.view(-1).copy_(padded[:TK])
+
+
 @torch.library.custom_op(add_op_namespace_prefix("_down_projection_backward_act"), mutates_args={"dh", "ds", "db2", "a_prime"})
 def _down_projection_backward_act(
     dout: torch.Tensor,
@@ -272,21 +299,21 @@ def _down_projection_backward_act(
         A_idx=x_gather_idx,
         dynamic_scheduler=False,
     )
-    ds[s_scatter_idx] = ds_scattered
-
     if db2 is None:
-        ds[s_scatter_idx] = ds_scattered
+        _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, ds)
     else:
         H = w2.size(0)
         E = expert_frequency_offset.size(0) - 1
         TK = x_gather_idx.size(0)
 
-        old_ds_partial = torch.empty(TK, 1, device=ds_scattered.device, dtype=ds_scattered.dtype)
-        old_ds_partial[s_scatter_idx, 0] = ds_scattered
+        # Same hazard as the `db2 is None` path above, same treatment. Untested: no model we run has
+        # an expert bias, so this branch is fixed for consistency rather than validated.
+        old_ds_partial = torch.zeros(TK, 1, device=ds_scattered.device, dtype=ds_scattered.dtype)
+        _scatter_valid_rows(ds_scattered, s_scatter_idx, expert_frequency_offset, old_ds_partial)
 
         BLOCK_H = min(triton.next_power_of_2(H), 2048)
         NUM_H_BLOCKS = triton.cdiv(H, BLOCK_H)
-        new_ds_partial = torch.empty(TK, NUM_H_BLOCKS, dtype=torch.float32, device=ds.device)
+        new_ds_partial = torch.zeros(TK, NUM_H_BLOCKS, dtype=torch.float32, device=ds.device)
 
         db2_and_ds_kernel[(E, NUM_H_BLOCKS)](
             dout,


### PR DESCRIPTION
## Related issue

Discussed in internal channel  @IlyasMoutawwakil  and @NanoCode012, who independently hit and diagnosed the same bug. 

## What does this PR do?

Fixes silently corrupted router-weight gradients (`ds`) in the EP-sentinel backward path of the vendored `sonic-moe` kernel.

Under expert parallelism the router marks non-local slots with a sentinel expert id, the metadata stage drops them from the histogram, and `cu_seqlens_m` (`expert_frequency_offset`) therefore covers only the `sum_valid` entries routed to a local expert. QuACK allocates `colvec_reduce_partial` with `torch.empty` and only the covered tiles write it, so rows `[sum_valid, TK)` of `ds_scattered` are uninitialized memory. The tail of `s_scatter_idx` is zero-filled, so

```python
ds[s_scatter_idx] = ds_scattered
```
<details>
<summary><b>A worked example w/ T=3, K=2, expert 1 lives on another rank</b></summary>

Only expert 0 is local rank, so `E = 1` and the sentinel value is `1`. 
The router relabels every "expert 1" slot to the sentinel and zeroes its weight:

```
token 0 -> [ expert 0 , SENTINEL ]
token 1 -> [ SENTINEL , expert 0 ]
token 2 -> [ expert 0 , SENTINEL ]

flat slots:  0 -> e0   1 -> SENT   2 -> SENT   3 -> e0   4 -> e0   5 -> SENT
```

The histogram covers local experts only — expert 0 got slots `{0, 3, 4}`, the sentinels are dropped:

```
expert_frequency_offset = [0, 3]        # sum_valid = 3,  but TK = 6
```

So the grouped layout holds only 3 real rows (`g0, g1, g2` = slots 0, 3, 4), and the metadata leaves the tail alone:

```
s_scatter_idx = [ 0 , 3 , 4 | 0 , 0 , 0 ]
                  \_______/   \_______/
                   written     never written, zero-filled

ds_scattered  = [ real0, real1, real2 | G3, G4, G5 ]
                  \_________________/   \________/
                   rows the GEMM wrote   uninitialized colvec_reduce_partial
```

Now run the old scatter, `ds[s_scatter_idx] = ds_scattered`, one grouped row at a time:

```
g0:  ds[0] = real0
g1:  ds[3] = real1
g2:  ds[4] = real2
g3:  ds[0] = G3      <- garbage, and index 0 again
g4:  ds[0] = G4      <- garbage, and index 0 again
g5:  ds[0] = G5      <- garbage, and index 0 again
```

Two distinct defects fall out of that:

| slot | ends up holding | should hold |
| --- | --- | --- |
| `ds[0]` | one of `G3` / `G4` / `G5` — *which* one is unspecified, three writes race for the same address | `real0` |
| `ds[1]`, `ds[2]`, `ds[5]` | never written at all → whatever `torch.empty_like(topk_scores)` handed out | `0` (sentinel lanes carry no gradient) |
| `ds[3]`, `ds[4]` | `real1`, `real2` | correct, by luck of not being aliased |

`real0` is destroyed and 4 of 6 entries are freed GPU memory. 

But with this PR, we would have:

```
row_valid = [ T , T , T , F , F , F ]      # arange(6) < 3, compared on device
dest      = [ 0 , 3 , 4 , 6 , 6 , 6 ]      # invalid rows -> scratch slot TK=6
padded    = [ real0, 0, 0, real1, real2, 0 | G? ]   # zeros(TK+1), then index_put_
             \_______________________________/  \_/
              copied over ds in full             scratch: one of G3/G4/G5,
                                                 still unspecified, never read
```

Every uninit row lands on the scratch slot instead of overwriting `ds[0]`, `real0` survives.

</details>

This matters here and not only upstream: `transformers` pins this kernel at the `ep-support` revision (`src/transformers/integrations/hub_kernels.py`), so any EP training run against the current build gets randomly scaled router gradients.



## Motivation

On Qwen3-30B-A3B, EP=8, seq 16k, one fixed batch (`transformers#46269` + `kernels-community/sonic-moe @ ep-support`, build `_sonic_moe_cuda_8a730d9`), `grad_norm` came out 200–400× too large and varied randomly step to step, while the loss was identical to 6 significant digits. With `max_grad_norm=1.0,` every step was therefore clipped 200–400× too hard by a random factor, randomizing the effective learning rate. Loss-only validation cannot see any of this.

| `colvec_reduce_partial` contains | grad_norm | loss |
| --- | --- | --- |
| whatever was in that memory | 186.92 / 365.78 / 421.89 | 0.498316 |
| filled with `0.0` | 1.6722 / 1.6715 | 0.498316 |
| filled with `1e6` | 80297988.3132 (×2, identical) | 0.498316 |
| filled with `1e30` | `inf` | 0.498316 |


## Changes

- Add `_scatter_valid_rows`: rows no GEMM tile wrote are redirected to a scratch slot at index `TK` instead of colliding on slot 0, and the zero-filled scratch buffer is copied over `ds` in full, so slots owning no row end at a defined `0` rather than at whatever `ds` was allocated with.
- The `sum_valid` bound is compared on device. An `int(expert_frequency_offset[-1])` would stall the host once per MoE layer per step.
- Drop a duplicated `ds[s_scatter_idx] = ds_scattered` 
- Zero-init `old_ds_partial` / `new_ds_partial` in the expert-bias path for consistency.

Without EP there are no sentinels, `sum_valid == TK`, every row is valid, and the new path reduces to the scatter it replaces.

## Testing

Verified with QuACK left unpatched — `colvec_reduce_partial` still `torch.empty` — so this change is sufficient on its own:

| build | grad_norm | max `mlp.gate` grad |
| --- | --- | --- |
| as shipped | 384.08 / 472.37 / 446.48 | 327.54 |
| as shipped, buffer filled at `1e30` | `inf` / `inf` | `inf` |
| with this patch | 1.6718 / 1.6709 / 1.6722 | 0.08465586 |
| with this patch, buffer filled at `1e30` | 1.6718 / 1.6717 / 1.6721 | 0.08465586 |

Existing `sonic-moe/tests/test_moe.py` has no EP/sentinel coverage, so nothing there exercises this path. A regression test on `moe_general_routing_inputs` with sentinel `expert_indices`   belongs upstream on the `sentinel-experts` branch imho.

## Checklist

- [ ] This PR is linked to an issue that was discussed and approved
- [x] I have tested these changes locally
- [ ] New/changed functionality has test coverage
- LLM disclosure:
  - [ ] I did not use an LLM to create this PR.
  - [x] I used and LLM for assistance while creating this PR.
  - [ ] This PR was mostly or completely generated by an LLM.
