### PR TITLE
aiter-flash-attn: support sliding-window attention (fixes #1055)

### DIFF
--- a/aiter-flash-attn/README.md
+++ b/aiter-flash-attn/README.md
@@ -61,10 +61,29 @@ out = flash_attn.flash_attn_func(q, k, v, causal=True)
 ## Origin
 
 Code is taken from `aiter/ops/triton/attention/mha.py` and its transitive
-imports, with the `dao_ai` impl path stripped (it depended on a separate
-`flash_attn_triton_amd` subpackage we don't need here). All `from aiter.*`
-absolute imports have been rewritten to package-relative form per the
-[Hub kernel requirements](https://huggingface.co/docs/kernels/kernel-requirements).
+imports (including the `flash_attn_triton_amd` / `dao_ai` backend), vendored at
+[`ROCm/aiter@8a9186d`](https://github.com/ROCm/aiter/commit/8a9186d983ed34ece2f68fe039e07f1b0abe147b).
+All `from aiter.*` absolute imports have been rewritten to package-relative form
+per the [Hub kernel requirements](https://huggingface.co/docs/kernels/kernel-requirements).
+
+Two intentional local deviations from upstream:
+
+- `utils/_triton/arch_info.py` detects the GPU arch lazily (on first `get_arch()`
+  call) so the module imports in the kernel-builder Nix sandbox, which has no
+  active GPU driver.
+- `mha.py` resolves sliding-window attention per call so it works through the
+  plain `flash_attn_func` / `flash_attn_varlen_func` entry points without an
+  explicit `mha_set_impl`:
+    - Under `causal=True` a right window (`window_size[1] >= 0`) is a no-op — the
+      causal edge already bounds the right side — so it is normalized to `-1` and
+      the call stays on the default kernel, which supports a left window together
+      with attention sinks. This keeps causal sliding-window models on the tuned
+      default path, **including sink models such as gpt-oss** (Gemma3, Mistral,
+      Qwen2 SWA also land here).
+    - A non-causal right window (which the default kernel cannot express) auto-
+      selects the `dao_ai` backend, but only when the workload is compatible with
+      it (no attention sink, no positional-encoding head split, not FP8).
+      Sink/PE/FP8 workloads stay on the default kernel.
 
 ## License
 

--- a/aiter-flash-attn/flake.lock
+++ b/aiter-flash-attn/flake.lock
@@ -41,11 +41,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783417137,
-        "narHash": "sha256-/iWe/m5ZACdb/DcXTrvXmbHS2QrzgGcGa7hPKi460tE=",
+        "lastModified": 1785743322,
+        "narHash": "sha256-6iiCDJZ1KJd+QdS9LOln2ZleEyFMK94/Q24Gsbb0bEI=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "81580bb92577f2f7228661ca2a221fc052375709",
+        "rev": "ebfa584ed4d64c90885efc83437f7dd7ba9fe8ac",
         "type": "github"
       },
       "original": {
@@ -56,17 +56,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776927958,
-        "narHash": "sha256-XOzEtft7E0P6TgQViLUOQeGHlEYiQ0+FY24BPEksj6s=",
+        "lastModified": 1783284758,
+        "narHash": "sha256-tiQ8/qi8I45OOaBBYlVbXoAVkeQzvvTQOv5I45rMw5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
         "type": "github"
       }
     },
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776914043,
-        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
+        "lastModified": 1783320166,
+        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
+        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
         "type": "github"
       },
       "original": {

--- a/aiter-flash-attn/tests/test_flash_attn.py
+++ b/aiter-flash-attn/tests/test_flash_attn.py
@@ -8,8 +8,17 @@ import pytest
 import torch
 
 
-def _sdpa_reference(q, k, v, causal=False, scale=None):
-    """Eager-attention reference matching the FA2 (B, S, H, D) layout."""
+def _sdpa_reference(q, k, v, causal=False, scale=None, window_size=(-1, -1), sink=None):
+    """Eager-attention reference matching the FA2 (B, S, H, D) layout.
+
+    ``window_size=(left, right)`` mirrors the flash-attn sliding-window
+    convention: query i attends to keys in
+    [i + Sk - Sq - left, i + Sk - Sq + right] inclusive (a value of -1 removes
+    that side's bound).
+
+    ``sink`` (shape ``(H,)``) adds a per-head attention-sink logit that joins the
+    softmax denominator but contributes no value (gpt-oss style).
+    """
     B, Sq, H, D = q.shape
     Sk = k.shape[1]
     scale = scale or (1.0 / math.sqrt(D))
@@ -18,10 +27,25 @@ def _sdpa_reference(q, k, v, causal=False, scale=None):
     k_ = k.transpose(1, 2).float()
     v_ = v.transpose(1, 2).float()
     attn = (q_ @ k_.transpose(-1, -2)) * scale  # (B, H, Sq, Sk)
+
+    i = torch.arange(Sq, device=q.device)[:, None]
+    j = torch.arange(Sk, device=q.device)[None, :]
+    shift = Sk - Sq
+    keep = torch.ones((Sq, Sk), dtype=torch.bool, device=q.device)
     if causal:
-        mask = torch.full((Sq, Sk), float("-inf"), device=q.device).triu(diagonal=1 + Sk - Sq)
-        attn = attn + mask
-    probs = attn.softmax(dim=-1)
+        keep &= j <= i + shift
+    left, right = int(window_size[0]), int(window_size[1])
+    if left != -1:
+        keep &= j >= i + shift - left
+    if right != -1:
+        keep &= j <= i + shift + right
+    attn = attn.masked_fill(~keep, float("-inf"))
+
+    if sink is not None:
+        sink_col = sink.float().view(1, H, 1, 1).expand(B, H, Sq, 1)
+        probs = torch.cat([attn, sink_col], dim=-1).softmax(dim=-1)[..., :Sk]
+    else:
+        probs = attn.softmax(dim=-1)
     out = probs @ v_  # (B, H, Sq, D)
     return out.transpose(1, 2).to(q.dtype)
 
@@ -69,5 +93,128 @@ def test_flash_attn_varlen_matches_sdpa():
         parts.append(_sdpa_reference(qi, ki, vi, causal=True).squeeze(0))
         offset += s
     ref = torch.cat(parts, dim=0)
+
+    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA/ROCm device")
+@pytest.mark.parametrize(
+    "causal,window_size",
+    [
+        (False, (16, 16)),   # symmetric local window
+        (False, (32, 0)),    # left-only history + current
+        (True, (16, 0)),     # causal sliding window (Gemma3/Mistral/Qwen2 SWA style)
+        (True, (8, 0)),
+    ],
+)
+def test_flash_attn_sliding_window_matches_sdpa(causal, window_size):
+    # Non-causal right windows are unsupported by the default kernel and must be
+    # auto-routed to the dao_ai backend; causal right windows are normalized away
+    # (causal subsumes them) and stay on the default kernel. Both must be correct
+    # without the caller ever setting mha_set_impl.
+    from aiter_flash_attn import flash_attn_func
+    from aiter_flash_attn import mha
+
+    assert mha._MHA_IMPL == "default", "impl must stay default (no explicit override)"
+
+    torch.manual_seed(0)
+    B, S, H, D = 2, 128, 4, 64
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+
+    out = flash_attn_func(q, k, v, causal=causal, window_size=window_size)
+    ref = _sdpa_reference(q, k, v, causal=causal, window_size=window_size)
+
+    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA/ROCm device")
+@pytest.mark.parametrize("causal,window_size", [(False, (16, 16)), (True, (16, 0))])
+def test_flash_attn_sliding_window_backward_matches_sdpa(causal, window_size):
+    # Exercises the re-vendored dao_ai sliding-window backward (ROCm/aiter #3742).
+    from aiter_flash_attn import flash_attn_func
+
+    torch.manual_seed(0)
+    B, S, H, D = 2, 128, 4, 64
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16, requires_grad=True)
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16, requires_grad=True)
+    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16, requires_grad=True)
+    g = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+
+    out = flash_attn_func(q, k, v, causal=causal, window_size=window_size)
+    out.backward(g)
+
+    qr = q.detach().clone().requires_grad_(True)
+    kr = k.detach().clone().requires_grad_(True)
+    vr = v.detach().clone().requires_grad_(True)
+    ref = _sdpa_reference(qr, kr, vr, causal=causal, window_size=window_size)
+    ref.backward(g)
+
+    torch.testing.assert_close(q.grad, qr.grad, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(k.grad, kr.grad, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(v.grad, vr.grad, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA/ROCm device")
+def test_flash_attn_varlen_sliding_window_matches_sdpa():
+    from aiter_flash_attn import flash_attn_varlen_func
+
+    torch.manual_seed(0)
+    H, D = 4, 64
+    window_size = (16, 0)
+    seqlens = [32, 48, 24]
+    total = sum(seqlens)
+    q = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+    k = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+    v = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+    cu = torch.tensor([0, *torch.tensor(seqlens).cumsum(0).tolist()], device="cuda", dtype=torch.int32)
+    max_s = max(seqlens)
+
+    out = flash_attn_varlen_func(
+        q, k, v, cu, cu, max_s, max_s, causal=True, window_size=window_size
+    )
+
+    parts = []
+    offset = 0
+    for s in seqlens:
+        qi = q[offset:offset + s].unsqueeze(0)
+        ki = k[offset:offset + s].unsqueeze(0)
+        vi = v[offset:offset + s].unsqueeze(0)
+        parts.append(
+            _sdpa_reference(qi, ki, vi, causal=True, window_size=window_size).squeeze(0)
+        )
+        offset += s
+    ref = torch.cat(parts, dim=0)
+
+    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA/ROCm device")
+@pytest.mark.parametrize("window_right", [0, -1])
+def test_flash_attn_causal_sliding_window_with_sink(window_right):
+    # gpt-oss style: causal sliding window + attention sinks. Under causal
+    # masking a right window of 0 is a no-op, so it must be accepted and stay on
+    # the default kernel (which supports a left window together with sinks) --
+    # dao_ai has no sink support, so this must NOT route there.
+    from aiter_flash_attn import flash_attn_func
+    from aiter_flash_attn import mha
+
+    assert mha._MHA_IMPL == "default"
+
+    torch.manual_seed(0)
+    B, S, H, D = 2, 128, 4, 64
+    left = 32
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    sink = torch.randn(H, device="cuda", dtype=torch.float16)
+
+    out = flash_attn_func(
+        q, k, v, causal=True, window_size=(left, window_right), sink=sink
+    )
+    ref = _sdpa_reference(
+        q, k, v, causal=True, window_size=(left, -1), sink=sink
+    )
 
     torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/bwd.py
@@ -1,14 +1,16 @@
+import warnings
+from typing import Literal
+
 import torch
 import triton
 import triton.language as tl
-import warnings
-from typing import Literal, Optional
+
 from .utils import (
-    DEBUG,
     AUTOTUNE,
+    DEBUG,
     AutotuneMode,
-    is_fp8,
     get_arch,
+    is_fp8,
     remap_xcd,
 )
 
@@ -489,6 +491,19 @@ def get_bwd_configs(mode: AutotuneMode):
                     num_stages=2,
                     num_warps=8,
                 ),
+                # mid-tile, 2-stage variant
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 128,
+                        "BLOCK_M2": 128,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
+                    num_warps=4,
+                ),
             ]
             causal_configs = [
                 triton.Config(
@@ -537,6 +552,32 @@ def get_bwd_configs(mode: AutotuneMode):
                         "waves_per_eu": 2,
                     },
                     num_stages=2,
+                    num_warps=4,
+                ),
+                # larger-tile variant (helps long-seq throughput; noncausal-proven)
+                triton.Config(
+                    {
+                        "BLOCK_M1": 32,
+                        "BLOCK_N1": 256,
+                        "BLOCK_M2": 256,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=2,
+                    num_warps=8,
+                ),
+                # small-tile variant (helps short seqlen / wide-window cases)
+                triton.Config(
+                    {
+                        "BLOCK_M1": 16,
+                        "BLOCK_N1": 64,
+                        "BLOCK_M2": 64,
+                        "BLOCK_N2": 64,
+                        "BLK_SLICE_FACTOR": 2,
+                        "waves_per_eu": 2,
+                    },
+                    num_stages=1,
                     num_warps=4,
                 ),
             ]
@@ -827,7 +868,8 @@ def _bwd_dq_inner_split(
             dp = tl.dot(do, vT)
 
         if ENABLE_DROPOUT:
-            dp = tl.where(dropout_mask, dp, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(dp.dtype) * dropout_scale
+            dp = dp * scaled_mask
 
         # ds
         delta_i = Di[:, None]
@@ -967,7 +1009,8 @@ def _bwd_dkdv_inner_split(
 
         # dV
         if ENABLE_DROPOUT:
-            pT_dropout = tl.where(dropout_mask, pT, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(pT.dtype) * dropout_scale
+            pT_dropout = pT * scaled_mask
             dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
             dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
@@ -982,7 +1025,8 @@ def _bwd_dkdv_inner_split(
             dpT = tl.dot(v, tl.trans(do))
 
         if ENABLE_DROPOUT:
-            dpT = tl.where(dropout_mask, dpT, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(dpT.dtype) * dropout_scale
+            dpT = dpT * scaled_mask
 
         delta_i = Di[None, :]
         dsT = pT * (dpT - delta_i)
@@ -1149,7 +1193,8 @@ def _bwd_dkdvdq_inner_atomic(
 
         # dV
         if ENABLE_DROPOUT:
-            pT_dropout = tl.where(dropout_mask, pT, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(pT.dtype) * dropout_scale
+            pT_dropout = pT * scaled_mask
             dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
             dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
@@ -1164,7 +1209,8 @@ def _bwd_dkdvdq_inner_atomic(
             dpT = tl.dot(v, tl.trans(do))
 
         if ENABLE_DROPOUT:
-            dpT = tl.where(dropout_mask, dpT, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(dpT.dtype) * dropout_scale
+            dpT = dpT * scaled_mask
 
         delta_i = Di[None, :]
         dsT = pT * (dpT - delta_i)
@@ -1443,7 +1489,7 @@ def _bwd_kernel_fused_atomic_causal(
             dropout_p,
             philox_seed,
             batch_philox_offset,
-            dropout_offset,  #
+            dropout_offset,
             seqlen_q,
             seqlen_k,  # max sequence length for q and k
             start_n,
@@ -1490,7 +1536,7 @@ def _bwd_kernel_fused_atomic_causal(
             dropout_p,
             philox_seed,
             batch_philox_offset,
-            dropout_offset,  #
+            dropout_offset,
             seqlen_q,
             seqlen_k,  # max sequence length for q and k
             start_n,
@@ -1751,7 +1797,7 @@ def _bwd_kernel_split_dkdv_causal(
             dropout_p,
             philox_seed,
             batch_philox_offset,
-            dropout_offset,  #
+            dropout_offset,
             seqlen_q,
             seqlen_k,  # max sequence length for q and k
             start_n,
@@ -1793,7 +1839,7 @@ def _bwd_kernel_split_dkdv_causal(
             dropout_p,
             philox_seed,
             batch_philox_offset,
-            dropout_offset,  #
+            dropout_offset,
             seqlen_q,
             seqlen_k,  # max sequence length for q and k
             start_n,
@@ -2703,7 +2749,7 @@ def _bwd_kernel_split_dq_noncausal(
 @triton.jit
 def _bwd_preprocess(
     Out,
-    DO,  # noqa: E741
+    DO,
     Delta,
     stride_ob,
     stride_oh,
@@ -2746,7 +2792,7 @@ def _bwd_preprocess(
         + q_start * stride_om
         + offs_m[:, None] * stride_om
         + offs_d[None, :] * stride_od
-    )  # noqa: E741
+    )
     off_do = (
         bid * stride_dob
         + hid * stride_doh
@@ -2798,10 +2844,10 @@ def _bwd_dkdv_inner(
     stride_delta_m,
     BLOCK_M: tl.constexpr,  # 16
     BLOCK_N: tl.constexpr,  # 128
-    HEAD_DIM_QK: tl.constexpr,  #
-    HEAD_DIM_V: tl.constexpr,  #
-    ACTUAL_HEAD_DIM_QK: tl.constexpr,  #
-    ACTUAL_HEAD_DIM_V: tl.constexpr,  #
+    HEAD_DIM_QK: tl.constexpr,
+    HEAD_DIM_V: tl.constexpr,
+    ACTUAL_HEAD_DIM_QK: tl.constexpr,
+    ACTUAL_HEAD_DIM_V: tl.constexpr,
     dropout_p,
     philox_seed,
     batch_philox_offset,
@@ -2816,7 +2862,10 @@ def _bwd_dkdv_inner(
     descale_q,
     descale_k,
     descale_v,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     MASK: tl.constexpr,  # causal masking, only apply to tiles on mask diagonal
+    USE_SLIDING_WINDOW: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,  # activate dropout
     USE_ALIBI: tl.constexpr,
     USE_EXP2: tl.constexpr,  # activate exp2
@@ -2847,9 +2896,9 @@ def _bwd_dkdv_inner(
     curr_philox_offset = batch_philox_offset
     RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
 
-    for blk_idx in range(num_steps):
+    for blk_idx in tl.range(num_steps, num_stages=1):
         if DEBUG_TRITON:
-            print(f"iter {blk_idx}: curr_m = {curr_m}")  # noqa: E701
+            print(f"iter {blk_idx}: curr_m = {curr_m}")
         offs_m = curr_m + tl.arange(0, BLOCK_M)
         # update the mask because offs_m advanced
         mask_m = offs_m < seqlen_q
@@ -2885,11 +2934,10 @@ def _bwd_dkdv_inner(
             alibi_block = -1 * alibi_slope * tl.abs(relative_pos_block)
             qkT_scaled += alibi_block
 
-        if DEBUG_TRITON_DETAIL:
-            if start_n == 256:
-                print(f"qT: {qT.shape}\n", qT)
-                print(f"k: {k.shape}\n", k)
-                print(f"qkT scaled: {qkT.shape}\n", qkT_scaled)
+        if DEBUG_TRITON_DETAIL and start_n == 256:
+            print(f"qT: {qT.shape}\n", qT)
+            print(f"k: {k.shape}\n", k)
+            print(f"qkT scaled: {qkT.shape}\n", qkT_scaled)
 
         # Compute probabilities - handle invalid rows where m is -inf
         # For rows where m is -inf, no keys were valid, so pT should be 0
@@ -2903,31 +2951,49 @@ def _bwd_dkdv_inner(
         else:
             pT = tl.math.exp(qkT_shifted)
 
-        # Autoregressive masking.
-        if MASK:
-            # offset offs_m with delta_qk since the causal mask starts at
-            # bottom right of the (seqlen_q, seqlen_k) matrix
-            causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
-            mask = causal_mask & mask_nm
-            if DEBUG_TRITON_DETAIL:
-                if start_n == 256:
-                    print(f"causal_mask: {causal_mask.shape}\n", causal_mask)
-                    print(
-                        f"qkT after causal: {qkT.shape}\n",
-                        tl.where(causal_mask, qkT * sm_scale, 0.0),
+        # Causal and sliding-window masking.
+        if MASK or USE_SLIDING_WINDOW:
+            mask = mask_nm
+            if MASK:
+                # offset offs_m with delta_qk since the causal mask starts at
+                # bottom right of the (seqlen_q, seqlen_k) matrix
+                causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
+                mask = causal_mask & mask
+            if USE_SLIDING_WINDOW:
+                # Per-element form of the band a query m attends:
+                #   m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R.
+                # _sliding_window_q_bounds() is the block-range inversion of this same
+                # inequality (it bounds m for a fixed K block); keep the two in sync.
+                causal_offset = seqlen_k - seqlen_q
+                if WINDOW_SIZE_LEFT < 0:
+                    window_mask = offs_n[:, None] <= (
+                        offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
                     )
+                else:
+                    left_bound = offs_m[None, :] + causal_offset - WINDOW_SIZE_LEFT
+                    right_bound = offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
+                    window_mask = (offs_n[:, None] >= left_bound) & (
+                        offs_n[:, None] <= right_bound
+                    )
+                mask = window_mask & mask
+            if DEBUG_TRITON_DETAIL and start_n == 256:
+                print(f"mask: {mask.shape}\n", mask)
+                print(
+                    f"pT after mask: {pT.shape}\n",
+                    tl.where(mask, pT, 0.0),
+                )
             pT = tl.where(mask, pT, 0.0)
         do = tl.load(do_ptrs, mask=mask_do, other=0.0)
         # Compute dV.
         if ENABLE_DROPOUT:
-            pT_dropout = pT * dropout_mask.to(pT.dtype) * dropout_scale
+            scaled_mask = dropout_mask.to(pT.dtype) * dropout_scale
+            pT_dropout = pT * scaled_mask
             dv = tl.dot(pT_dropout.to(do.type.element_ty), do, acc=dv)
         else:
             dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
-        if DEBUG_TRITON_DETAIL:
-            if start_n == 256:
-                print(f"pT: {pT.shape}\n", pT)
+        if DEBUG_TRITON_DETAIL and start_n == 256:
+            print(f"pT: {pT.shape}\n", pT)
         # D (= delta) is pre-divided by ds_scale.
         Di = tl.load(D + offs_m * stride_delta_m, mask=mask_m)
         # Compute dP and dS.
@@ -2936,7 +3002,8 @@ def _bwd_dkdv_inner(
         else:
             dpT = tl.dot(v, tl.trans(do))
         if ENABLE_DROPOUT:
-            dpT = tl.where(dropout_mask, dpT, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(dpT.dtype) * dropout_scale
+            dpT = dpT * scaled_mask
         delta_i = Di[None, :]
         dsT = pT * (dpT - delta_i)
         if IS_FP8:
@@ -2977,13 +3044,13 @@ def _bwd_dq_inner(
     stride_lse_m,
     stride_delta_m,
     seqlen_q,
-    seqlen_k,  #
-    BLOCK_M2: tl.constexpr,  #
-    BLOCK_N2: tl.constexpr,  #
+    seqlen_k,
+    BLOCK_M2: tl.constexpr,
+    BLOCK_N2: tl.constexpr,
     HEAD_DIM_QK: tl.constexpr,
     HEAD_DIM_V: tl.constexpr,
     ACTUAL_HEAD_DIM_QK: tl.constexpr,
-    ACTUAL_HEAD_DIM_V: tl.constexpr,  #
+    ACTUAL_HEAD_DIM_V: tl.constexpr,
     dropout_p,
     philox_seed,
     batch_philox_offset,
@@ -2993,11 +3060,14 @@ def _bwd_dq_inner(
     start_m,
     start_n,
     end_n,
-    num_steps,  #
+    num_steps,
     descale_q,
     descale_k,
     descale_v,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     MASK: tl.constexpr,
+    USE_SLIDING_WINDOW: tl.constexpr,
     ENABLE_DROPOUT: tl.constexpr,
     USE_ALIBI: tl.constexpr,
     USE_EXP2: tl.constexpr,
@@ -3028,9 +3098,9 @@ def _bwd_dq_inner(
     step_n = BLOCK_N2
     curr_philox_offset = batch_philox_offset
     RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
-    for blk_idx in range(num_steps):
+    for blk_idx in tl.range(num_steps, num_stages=1):
         if DEBUG_TRITON:
-            print(f"iter {blk_idx}: curr_n = {curr_n}")  # noqa: E701
+            print(f"iter {blk_idx}: curr_n = {curr_n}")
         offs_n = curr_n + tl.arange(0, BLOCK_N2)
         # end_n is needed because the end of causal True might not be perfectly
         # aligned with the end of the block
@@ -3038,9 +3108,9 @@ def _bwd_dq_inner(
         if DEBUG_TRITON_DETAIL:
             print(
                 f"start_n = {start_n}, end_n = {end_n}, offs_n: {offs_n.shape}\n{offs_n}"
-            )  # noqa: E701
+            )
         if DEBUG_TRITON_DETAIL:
-            print(f"mask_n: {mask_n.shape}\n{mask_n}")  # noqa: E701
+            print(f"mask_n: {mask_n.shape}\n{mask_n}")
         mask_kT = mask_n[None, :]
         mask_vT = mask_n[None, :]
         mask_mn = mask_m[:, None] & (offs_n[None, :] < end_n)
@@ -3075,7 +3145,7 @@ def _bwd_dq_inner(
             qk_scaled += alibi_block
 
         if DEBUG_TRITON_DETAIL:
-            print(f"qk scaled: {qk.shape}\n", qk_scaled)  # noqa: E701
+            print(f"qk scaled: {qk.shape}\n", qk_scaled)
 
         # Compute probabilities - handle invalid rows where m is -inf
         # For rows where m is -inf, no keys were valid, so p should be 0
@@ -3087,10 +3157,29 @@ def _bwd_dq_inner(
         else:
             p = tl.math.exp(qk_shifted)
 
-        # Autoregressive masking.
-        if MASK:
-            causal_mask = (offs_m[:, None] - delta_qk) >= offs_n[None, :]
-            mask = causal_mask & mask_mn
+        # Causal and sliding-window masking.
+        if MASK or USE_SLIDING_WINDOW:
+            mask = mask_mn
+            if MASK:
+                causal_mask = (offs_m[:, None] - delta_qk) >= offs_n[None, :]
+                mask = causal_mask & mask
+            if USE_SLIDING_WINDOW:
+                # Per-element form of the band a query m attends:
+                #   m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R.
+                # _sliding_window_k_bounds() is the block-range inversion of this same
+                # inequality (it bounds n for a fixed Q block); keep the two in sync.
+                causal_offset = seqlen_k - seqlen_q
+                if WINDOW_SIZE_LEFT < 0:
+                    window_mask = offs_n[None, :] <= (
+                        offs_m[:, None] + causal_offset + WINDOW_SIZE_RIGHT
+                    )
+                else:
+                    left_bound = offs_m[:, None] + causal_offset - WINDOW_SIZE_LEFT
+                    right_bound = offs_m[:, None] + causal_offset + WINDOW_SIZE_RIGHT
+                    window_mask = (offs_n[None, :] >= left_bound) & (
+                        offs_n[None, :] <= right_bound
+                    )
+                mask = window_mask & mask
             p = tl.where(mask, p, 0.0)
         # Compute dP and dS.
         if IS_FP8:
@@ -3098,7 +3187,8 @@ def _bwd_dq_inner(
         else:
             dp = tl.dot(do, vT)
         if ENABLE_DROPOUT:
-            dp = tl.where(dropout_mask, dp, 0.0) * dropout_scale
+            scaled_mask = dropout_mask.to(dp.dtype) * dropout_scale
+            dp = dp * scaled_mask
         delta_i = Di[:, None]
         ds = p * (dp - delta_i)
         # Compute dQ.
@@ -3116,6 +3206,75 @@ def _bwd_dq_inner(
         kT_ptrs += step_n * stride_kn
         vT_ptrs += step_n * stride_vn
     return dq
+
+
+@triton.jit
+def _sliding_window_q_bounds(
+    start_n,
+    seqlen_q,
+    seqlen_k,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """Query-block range that overlaps the sliding window for a fixed K block.
+
+    dKdV sweeps query blocks for the fixed key block [start_n, start_n+BLOCK_N).
+    A query m attends key n iff
+        m + (seqlen_k - seqlen_q) - L <= n <= m + (seqlen_k - seqlen_q) + R,
+    so the queries that touch any key in this block span
+        [start_n - R - off, (start_n + BLOCK_N - 1) + L - off]   (off = seqlen_k - seqlen_q).
+    Returns (start_m, num_steps) aligned to BLOCK_M; num_steps == 0 means the
+    block is entirely outside the window and can be skipped.
+    """
+    causal_offset = seqlen_k - seqlen_q
+    m_lo = start_n - WINDOW_SIZE_RIGHT - causal_offset
+    if WINDOW_SIZE_LEFT < 0:  # unbounded left -> no upper limit on contributing queries
+        m_hi = seqlen_q - 1
+    else:
+        m_hi = (start_n + BLOCK_N - 1) + WINDOW_SIZE_LEFT - causal_offset
+    m_lo = tl.maximum(m_lo, 0)
+    m_hi = tl.minimum(m_hi, seqlen_q - 1)
+    start_m = (m_lo // BLOCK_M) * BLOCK_M
+    if m_hi < m_lo:
+        num_steps = 0
+    else:
+        num_steps = tl.cdiv(m_hi + 1 - start_m, BLOCK_M)
+    return start_m, num_steps
+
+
+@triton.jit
+def _sliding_window_k_bounds(
+    start_m,
+    seqlen_q,
+    seqlen_k,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Key-block range that overlaps the sliding window for a fixed Q block.
+
+    dQ sweeps key blocks for the fixed query block [start_m, start_m+BLOCK_M).
+    The keys query m attends are [m + off - L, m + off + R] (off = seqlen_k - seqlen_q),
+    so across the block they span [start_m + off - L, (start_m + BLOCK_M - 1) + off + R].
+    Returns (start_n, num_steps) aligned to BLOCK_N; num_steps == 0 means skip.
+    """
+    causal_offset = seqlen_k - seqlen_q
+    if WINDOW_SIZE_LEFT < 0:  # unbounded left -> keys reach back to 0
+        n_lo = 0
+    else:
+        n_lo = start_m + causal_offset - WINDOW_SIZE_LEFT
+    n_hi = (start_m + BLOCK_M - 1) + causal_offset + WINDOW_SIZE_RIGHT
+    n_lo = tl.maximum(n_lo, 0)
+    n_hi = tl.minimum(n_hi, seqlen_k - 1)
+    start_n = (n_lo // BLOCK_N) * BLOCK_N
+    if n_hi < n_lo:
+        num_steps = 0
+    else:
+        num_steps = tl.cdiv(n_hi + 1 - start_n, BLOCK_N)
+    return start_n, num_steps
 
 
 @triton.autotune(
@@ -3210,6 +3369,9 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     IS_FP8: tl.constexpr,
     FP8_MAX: tl.constexpr,
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
+    USE_SLIDING_WINDOW: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     NUM_XCD: tl.constexpr = 1,
@@ -3223,7 +3385,7 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
     hkid = remap_xcd(hkid, HK, NUM_XCD)
 
     if DEBUG_TRITON:
-        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
+        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")
     # figure out varlen start and end
     q_start = 0
     k_start = 0
@@ -3252,7 +3414,7 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
 
     delta_qk = seqlen_q - seqlen_k
     if DEBUG_TRITON:
-        print(f"delta_qk = {delta_qk}")  # noqa: E701
+        print(f"delta_qk = {delta_qk}")
     PADDED_HEAD_QK: tl.constexpr = ACTUAL_HEAD_DIM_QK != HEAD_DIM_QK
     PADDED_HEAD_V: tl.constexpr = ACTUAL_HEAD_DIM_V != HEAD_DIM_V
     offs_d_qk = tl.arange(0, HEAD_DIM_QK)
@@ -3279,13 +3441,13 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
             if DEBUG_TRITON:
                 print(
                     f"q >= k: start_delta = delta_qk aligned to BLOCK_M = {start_delta_q_gt_k}"
-                )  # noqa: E701
+                )
         else:
             start_delta = start_delta_q_lt_k
             if DEBUG_TRITON:
                 print(
                     f"q < k: start_delta = residue btw multiple BLOCK_N and delta_qk = {delta_aligned} = aligned to BLOCK_M = {start_delta_q_lt_k}"
-                )  # noqa: E701
+                )
 
         offs_n = start_n + tl.arange(0, BLOCK_N1)
         # Mask for loading K and V
@@ -3331,7 +3493,7 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 residue_m = max(start_n + delta_qk - start_m, 0)
                 len_m = BLOCK_N1 + residue_m
                 if DEBUG_TRITON:
-                    print(f"residue_m = {residue_m}")  # noqa: E701
+                    print(f"residue_m = {residue_m}")
 
             # offset input and output tensor by batch and Q/K heads
             adj_q = bid * stride_qb + hqid * stride_qh + q_start * stride_qm
@@ -3385,7 +3547,7 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
             if DEBUG_TRITON:
                 print(
                     f"Masked: start_n: {start_n}; start_m: {start_m}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             dk, dv = _bwd_dkdv_inner(
                 dk,
                 dv,  # output tensors
@@ -3423,7 +3585,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=True,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3433,19 +3598,29 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
             )
             start_m += num_steps * MASK_BLOCK_M1
-            num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M1)
+            # The unmasked region runs from the diagonal to seqlen_q. With a
+            # finite left window, queries more than WINDOW_SIZE_LEFT past this
+            # K block attend nothing in it, so cap the sweep at that upper bound.
+            if USE_SLIDING_WINDOW and WINDOW_SIZE_LEFT >= 0:
+                # m_hi = (n_hi + WINDOW_SIZE_LEFT) - (seqlen_k - seqlen_q)
+                m_hi = (start_n + BLOCK_N1 - 1) + WINDOW_SIZE_LEFT + delta_qk
+                m_hi = tl.minimum(m_hi, seqlen_q - 1)
+                if m_hi < start_m:
+                    num_steps = 0
+                else:
+                    num_steps = tl.cdiv(m_hi + 1 - start_m, BLOCK_M1)
+            else:
+                num_steps = tl.cdiv(seqlen_q - start_m, BLOCK_M1)
             end_m = start_m + num_steps * BLOCK_M1
 
             if DEBUG_TRITON:
-                print(
-                    f"start_m after Masked step: {start_m}; num_steps: {num_steps}"
-                )  # noqa: E701
+                print(f"start_m after Masked step: {start_m}; num_steps: {num_steps}")
             if DEBUG_TRITON:
                 print(
                     f"unMasked: start_n: {start_n}, start_m: {start_m}, end_m: {end_m}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             if DEBUG_TRITON:
-                print("unMasked")  # noqa: E701
+                print("unMasked")
             dk, dv = _bwd_dkdv_inner(
                 dk,
                 dv,  # output tensors
@@ -3483,7 +3658,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3510,12 +3688,12 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
         if DEBUG_TRITON:
             print(
                 f"end_n = start_m + BLOCK_M = {start_m} + {BLOCK_M2} = {start_m + BLOCK_M2}"
-            )  # noqa: E701
+            )
         if start_m + BLOCK_M2 < delta_qk:
             if DEBUG_TRITON:
                 print(
                     f"start_m + BLOCK_M2 = {start_m} + {BLOCK_M2} = {start_m + BLOCK_M2} < delta_qk of {delta_qk}"
-                )  # noqa: E701
+                )
             return
 
         offs_m = start_m + tl.arange(0, BLOCK_M2)
@@ -3542,7 +3720,7 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
             # clamp end_n at [0, seqlen_k]
             end_n = max(min(end_n, seqlen_k), 0)
             if DEBUG_TRITON:
-                print(f"delta_qk: {delta_qk}; end_n: {end_n}")  # noqa: E701
+                print(f"delta_qk: {delta_qk}; end_n: {end_n}")
             # offset input and output tensor by batch and Q/K heads
             adj_q = bid * stride_qb + hqid * stride_qh + q_start * stride_qm
             adj_do = bid * stride_dob + hqid * stride_doh + q_start * stride_dom
@@ -3629,7 +3807,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
-                MASK=True,  #
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
+                MASK=True,
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3639,12 +3820,26 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
             )
             end_n -= num_steps * MASK_BLOCK_N2
-            num_steps = tl.cdiv(end_n, BLOCK_N2)
-            start_n = max(end_n - num_steps * BLOCK_N2, 0)
+            # The unmasked region runs from 0 up to the diagonal (end_n). With a
+            # finite left window, keys more than WINDOW_SIZE_LEFT before this Q
+            # block fall outside the band, so raise the lower bound.
+            if USE_SLIDING_WINDOW and WINDOW_SIZE_LEFT >= 0:
+                # n_lo = start_m - (seqlen_q - seqlen_k) - WINDOW_SIZE_LEFT
+                n_lo = start_m - delta_qk - WINDOW_SIZE_LEFT
+                n_lo = tl.maximum(n_lo, 0)
+                n_lo = (n_lo // BLOCK_N2) * BLOCK_N2
+                if n_lo >= end_n:
+                    num_steps = 0
+                else:
+                    num_steps = tl.cdiv(end_n - n_lo, BLOCK_N2)
+                start_n = n_lo
+            else:
+                num_steps = tl.cdiv(end_n, BLOCK_N2)
+                start_n = max(end_n - num_steps * BLOCK_N2, 0)
             if DEBUG_TRITON:
                 print(
                     f"unMasked: start_m: {start_m}, start_n: {start_n}, end_n: {end_n}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             dq = _bwd_dq_inner(
                 dq,
                 q,
@@ -3684,7 +3879,10 @@ def bwd_kernel_fused_causal(  # grid = (nheads_k, tl.cdiv(max_seqlen_q // BLOCK_
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -3793,6 +3991,9 @@ def bwd_kernel_fused_noncausal(
     IS_FP8: tl.constexpr,
     FP8_MAX: tl.constexpr,
     USE_SEQUSED: tl.constexpr,  # Add flag for seqused
+    USE_SLIDING_WINDOW: tl.constexpr,
+    WINDOW_SIZE_LEFT: tl.constexpr,
+    WINDOW_SIZE_RIGHT: tl.constexpr,
     DEBUG_TRITON: tl.constexpr,
     DEBUG_TRITON_DETAIL: tl.constexpr,
     NUM_XCD: tl.constexpr = 1,
@@ -3806,7 +4007,7 @@ def bwd_kernel_fused_noncausal(
     hkid = remap_xcd(hkid, HK, NUM_XCD)
 
     if DEBUG_TRITON:
-        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
+        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")
     # figure out varlen start and end
     q_start = 0
     k_start = 0
@@ -3914,9 +4115,21 @@ def bwd_kernel_fused_noncausal(
             else:
                 descale_q, descale_k, descale_v = 1.0, 1.0, 1.0
 
-            # because there is no causal, we always start from the beginning
-            start_m = 0
-            num_steps = tl.cdiv(seqlen_q, BLOCK_M1)
+            # because there is no causal, we sweep all query blocks -- unless a
+            # sliding window lets us skip query blocks entirely outside the band.
+            if USE_SLIDING_WINDOW:
+                start_m, num_steps = _sliding_window_q_bounds(
+                    start_n,
+                    seqlen_q,
+                    seqlen_k,
+                    WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT,
+                    BLOCK_N1,
+                    BLOCK_M1,
+                )
+            else:
+                start_m = 0
+                num_steps = tl.cdiv(seqlen_q, BLOCK_M1)
             dk, dv = _bwd_dkdv_inner(
                 dk,
                 dv,  # output tensors
@@ -3944,7 +4157,7 @@ def bwd_kernel_fused_noncausal(
                 dropout_p,
                 philox_seed,
                 batch_philox_offset,
-                dropout_offset,  #
+                dropout_offset,
                 alibi_slope,
                 seqlen_q,
                 seqlen_k,  # max sequence length for q and k
@@ -3954,7 +4167,10 @@ def bwd_kernel_fused_noncausal(
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,  # causal masking
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,  # activate dropout
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -4036,9 +4252,20 @@ def bwd_kernel_fused_noncausal(
                 descale_q, descale_k, descale_v = 1.0, 1.0, 1.0
 
             # start can only be 0 at minimum
-            start_n = 0
             end_n = seqlen_k
-            num_steps = tl.cdiv(seqlen_k, BLOCK_N2)
+            if USE_SLIDING_WINDOW:
+                start_n, num_steps = _sliding_window_k_bounds(
+                    start_m,
+                    seqlen_q,
+                    seqlen_k,
+                    WINDOW_SIZE_LEFT,
+                    WINDOW_SIZE_RIGHT,
+                    BLOCK_M2,
+                    BLOCK_N2,
+                )
+            else:
+                start_n = 0
+                num_steps = tl.cdiv(seqlen_k, BLOCK_N2)
 
             dq = tl.zeros([BLOCK_M2, HEAD_DIM_QK], dtype=tl.float32)
             dq = _bwd_dq_inner(
@@ -4080,7 +4307,10 @@ def bwd_kernel_fused_noncausal(
                 descale_q,
                 descale_k,
                 descale_v,
+                WINDOW_SIZE_LEFT,
+                WINDOW_SIZE_RIGHT,
                 MASK=False,
+                USE_SLIDING_WINDOW=USE_SLIDING_WINDOW,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -4125,23 +4355,25 @@ def attention_backward_triton_impl(
     dv: torch.Tensor,
     delta: torch.Tensor,
     sm_scale: float,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     causal: bool,
     layout: Literal["bshd", "bhsd", "thd"],
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
-    max_seqlen_q: Optional[int],
-    max_seqlen_k: Optional[int],
-    seqused_q: Optional[torch.Tensor] = None,
-    seqused_k: Optional[torch.Tensor] = None,
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
+    seqused_q: torch.Tensor | None = None,
+    seqused_k: torch.Tensor | None = None,
     dropout_p: float = 0.0,
-    philox_seed: Optional[int] = None,
-    philox_offset: Optional[int] = None,
+    philox_seed: int | None = None,
+    philox_offset: int | None = None,
     use_exp2: bool = True,
     mode: Literal["fused", "fused_atomic", "split"] = "fused",
-    q_descale: Optional[torch.Tensor] = None,
-    k_descale: Optional[torch.Tensor] = None,
-    v_descale: Optional[torch.Tensor] = None,
+    q_descale: torch.Tensor | None = None,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+    window_size_left: int = -1,
+    window_size_right: int = -1,
 ):
     # get params, strides and shape
     IS_VARLEN = layout == "thd"
@@ -4165,7 +4397,7 @@ def attention_backward_triton_impl(
         # shape
         total_seqlen_q, nheads_q, head_size_q = q.shape
         total_seqlen_k, nheads_k, head_size_k = k.shape
-        total_seqlen_v, nheads_v, head_size_v = v.shape
+        _total_seqlen_v, nheads_v, head_size_v = v.shape
         nheads_lse, total_seqlen_lse = softmax_lse.shape
 
         # assert shapes
@@ -4289,7 +4521,7 @@ def attention_backward_triton_impl(
         batch_q, seqlen_q, nheads_q, head_size_q = q.shape
         batch_k, seqlen_k, nheads_k, head_size_k = k.shape
         batch_v, seqlen_v, nheads_v, head_size_v = v.shape
-        batch_lse, nheads_lse, seqlen_lse = softmax_lse.shape
+        _batch_lse, nheads_lse, _seqlen_lse = softmax_lse.shape
 
         # assert batch dimensions
         assert (
@@ -4397,6 +4629,28 @@ def attention_backward_triton_impl(
     use_alibi, (stride_az, stride_ah) = (
         (True, alibi_slopes.stride()) if alibi_slopes is not None else (False, (0, 0))
     )
+
+    # "Active" iff either edge differs from the -1 "off" sentinel. This mirrors
+    # the forward kernels (fwd_prefill.py / fwd_decode.py both test `!= -1`); the
+    # interface guards removed in this change used `>= 0`, which is equivalent for
+    # every valid input (-1 is the only negative either edge ever takes).
+    use_sliding_window = window_size_left != -1 or window_size_right != -1
+    if use_sliding_window and mode != "fused":
+        raise NotImplementedError(
+            "Sliding-window backward is currently implemented for fused mode only."
+        )
+    # The kernels only special-case an infinite *left* edge (WINDOW_SIZE_LEFT < 0).
+    # There is no infinite-right code path, so a negative right bound would collapse
+    # right_bound to (anchor - 1) and silently mask out almost everything. When the
+    # window is active, window_size_right must therefore be >= 0. (window_size_right
+    # == -1 is only valid as the "off" sentinel, i.e. together with
+    # window_size_left == -1, which leaves use_sliding_window False.)
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window backward requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An infinite right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
 
     # get closest power of 2 over or equal to 32.
     padded_d_model_qk = 1 << (head_size_qk - 1).bit_length()
@@ -4506,7 +4760,7 @@ def attention_backward_triton_impl(
         if causal:
 
             if DEBUG_TRITON:
-                print(f"bwd_kernel: grid = {grid}")  # noqa: E701
+                print(f"bwd_kernel: grid = {grid}")
             bwd_kernel_fused_causal[grid](
                 q,
                 k,
@@ -4590,6 +4844,9 @@ def attention_backward_triton_impl(
                 USE_SEQUSED=(
                     seqused_q is not None or seqused_k is not None
                 ),  # Add flag for seqused
+                USE_SLIDING_WINDOW=use_sliding_window,
+                WINDOW_SIZE_LEFT=window_size_left,
+                WINDOW_SIZE_RIGHT=window_size_right,
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 NUM_XCD=num_xcd,
@@ -4678,6 +4935,9 @@ def attention_backward_triton_impl(
                 USE_SEQUSED=(
                     seqused_q is not None or seqused_k is not None
                 ),  # Add flag for seqused
+                USE_SLIDING_WINDOW=use_sliding_window,
+                WINDOW_SIZE_LEFT=window_size_left,
+                WINDOW_SIZE_RIGHT=window_size_right,
                 DEBUG_TRITON=DEBUG_TRITON,
                 DEBUG_TRITON_DETAIL=DEBUG_TRITON_DETAIL,
                 NUM_XCD=num_xcd,

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/common.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/common.py
@@ -6,7 +6,7 @@ the main attention kernels (fwd_prefill, fwd_decode, bwd). These are kept
 separate from utils.py to allow stricter type checking on pure Python utilities.
 """
 
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal
 
 import torch
 import triton
@@ -89,7 +89,7 @@ def _cast_varlen_to_fp8_kernel_2d(
 
     # STEP 1: Find max absolute value across the entire sequence
     num_of_blocks = tl.cdiv(seqlen, BLOCK_SIZE)
-    for blk_idx in range(0, num_of_blocks):
+    for blk_idx in range(num_of_blocks):
         offs_seq = blk_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         offs_dim = tl.arange(0, HEAD_DIM)
 
@@ -121,7 +121,7 @@ def _cast_varlen_to_fp8_kernel_2d(
     tl.store(desc_ptr, descale)
 
     # STEP 2: Apply scaling and convert to FP8
-    for blk_idx in range(0, num_of_blocks):
+    for blk_idx in range(num_of_blocks):
         offs_seq = blk_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         offs_dim = tl.arange(0, HEAD_DIM)
 
@@ -271,8 +271,8 @@ def cast_to_fp8(
     fp8_dtype: torch.dtype,
     layout: Literal["bshd", "thd"],
     clamp_val: float = 1e-9,
-    cu_seqlens: Optional[torch.Tensor] = None,
-    max_seqlen: Optional[int] = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Cast tensor to FP8 with per-(batch, head) scaling factors."""
     if DEBUG > 0:
@@ -347,9 +347,9 @@ def _apply_rotary_kernel(
     x: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
-    seqlen_offsets: Union[int, torch.Tensor] = 0,
-    cu_seqlens: Optional[torch.Tensor] = None,
-    max_seqlen: Optional[int] = None,
+    seqlen_offsets: int | torch.Tensor = 0,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: int | None = None,
     interleaved: bool = False,
     inplace: bool = False,
     conjugate: bool = False,
@@ -362,7 +362,7 @@ def _apply_rotary_kernel(
         assert (
             max_seqlen is not None
         ), "If cu_seqlens is passed, max_seqlen must also be provided"
-        total_seqlen, nheads, headdim = x.shape
+        _total_seqlen, nheads, headdim = x.shape
         assert cu_seqlens is not None
         batch_p_1 = cu_seqlens.shape[0]
         batch = batch_p_1 - 1
@@ -432,9 +432,9 @@ class _ApplyRotary(torch.autograd.Function):
         sin: torch.Tensor,
         interleaved: bool,
         inplace: bool,
-        seqlen_offsets: Union[int, torch.Tensor],
-        cu_seqlens: Optional[torch.Tensor],
-        max_seqlen: Optional[int],
+        seqlen_offsets: int | torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        max_seqlen: int | None,
     ) -> torch.Tensor:
         out = _apply_rotary_kernel(
             x,
@@ -487,9 +487,9 @@ def apply_rotary_emb(
     sin: torch.Tensor,
     interleaved: bool = False,
     inplace: bool = False,
-    seqlen_offsets: Union[int, torch.Tensor] = 0,
-    cu_seqlens: Optional[torch.Tensor] = None,
-    max_seqlen: Optional[int] = None,
+    seqlen_offsets: int | torch.Tensor = 0,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: int | None = None,
 ) -> torch.Tensor:
     """Apply rotary embeddings to tensor x.
 
@@ -535,15 +535,15 @@ def apply_rotary_emb(
 
 def apply_rotary(
     q: torch.Tensor,
-    k_new: Optional[torch.Tensor],
+    k_new: torch.Tensor | None,
     cos: torch.Tensor,
     sin: torch.Tensor,
     *,
     causal: bool,
     local: bool,
     interleaved: bool = False,
-    seqlen_offsets: Union[int, torch.Tensor] = 0,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    seqlen_offsets: int | torch.Tensor = 0,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     """Apply rotary embeddings to q and optionally k_new.
 
     Policy:

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/fwd_decode.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/fwd_decode.py
@@ -1,12 +1,14 @@
 import warnings
+from typing import Literal
+
 import torch
 import triton
 import triton.language as tl
-from typing import Literal, Optional
+
 from .common import apply_rotary
 from .utils import (
-    DEBUG,
     AUTOTUNE,
+    DEBUG,
     AutotuneMode,
     get_arch,
     get_padded_headsize,
@@ -37,43 +39,7 @@ def get_fwd_decode_configs(mode: AutotuneMode):
         (splitk_configs, reduce_config): Tuple of config lists for each kernel
     """
 
-    if mode == "off":
-        arch = get_arch()
-        if arch.is_rdna:
-            return (
-                [
-                    triton.Config(
-                        {"BLOCK_M": 32, "BLOCK_N": 32},
-                        num_stages=1,
-                        num_warps=4,
-                    ),
-                ],
-                [triton.Config({}, num_stages=1, num_warps=4)],
-            )
-        elif arch.is_cdna:
-            return (
-                [
-                    triton.Config(
-                        {"BLOCK_M": 64, "BLOCK_N": 64, "waves_per_eu": 1},
-                        num_stages=1,
-                        num_warps=4,
-                    ),
-                ],
-                [triton.Config({}, num_stages=1, num_warps=4)],
-            )
-        else:
-            return (
-                [
-                    triton.Config(
-                        {"BLOCK_M": 64, "BLOCK_N": 64, "waves_per_eu": 1},
-                        num_stages=1,
-                        num_warps=4,
-                    ),
-                ],
-                [triton.Config({}, num_stages=1, num_warps=4)],
-            )
-
-    elif mode == "on":
+    if mode == "off" or mode == "on":
         arch = get_arch()
         if arch.is_rdna:
             return (
@@ -186,7 +152,7 @@ def _attn_fwd_inner(
     if IS_FP8:
         qk += tl.dot(q, kT) * q_descale * k_descale  # Apply FP8 scaling
     else:
-        qk = tl.dot(q, kT, acc=qk)  # noqa: F821
+        qk = tl.dot(q, kT, acc=qk)
 
     if USE_ALIBI:
         row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -332,6 +298,8 @@ def _fwd_kernel_splitK(
     stride_vn_d,
     stride_bt_b,
     stride_bt_s,
+    stride_kb,  # paged K block stride (k_cache.stride(0)); supports non-contiguous cache
+    stride_vb,  # paged V block stride (v_cache.stride(0))
     stride_az,
     stride_ah,
     stride_q_descale_z,  # FP8 descale strides
@@ -377,6 +345,8 @@ def _fwd_kernel_splitK(
     stride_qd_i64 = tl.cast(stride_qd, tl.int64)
     stride_kz_i64 = tl.cast(stride_kz, tl.int64)
     stride_kn_i64 = tl.cast(stride_kn, tl.int64)
+    stride_kb_i64 = tl.cast(stride_kb, tl.int64)
+    stride_vb_i64 = tl.cast(stride_vb, tl.int64)
     stride_kg_i64 = tl.cast(stride_kg, tl.int64)
     stride_kh_i64 = tl.cast(stride_kh, tl.int64)
     stride_kd_i64 = tl.cast(stride_kd, tl.int64)
@@ -512,7 +482,7 @@ def _fwd_kernel_splitK(
     # initialize pointer to m and l
     m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
-    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)  # noqa: F821
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
 
     # loop over k, v and update accumulator
     if USE_BLOCK_TABLE:
@@ -556,13 +526,13 @@ def _fwd_kernel_splitK(
                     # Calculate base addresses for K and V in this physical block
                     k_base = (
                         K
-                        + physical_block * BLOCK_SIZE_K * stride_kn_i64
+                        + physical_block * stride_kb_i64
                         + hk_id * stride_kh_i64
                         + g_id * stride_kg_i64
                     )
                     v_base = (
                         V
-                        + physical_block * BLOCK_SIZE_K * stride_vn_i64
+                        + physical_block * stride_vb_i64
                         + hv_id * stride_vh_i64
                         + g_id * stride_vg_i64
                     )
@@ -945,27 +915,27 @@ def attention_forward_decode_triton_impl(
     q: torch.Tensor,
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
-    k_new: Optional[torch.Tensor],
-    v_new: Optional[torch.Tensor],
+    k_new: torch.Tensor | None,
+    v_new: torch.Tensor | None,
     out: torch.Tensor,
     softmax_lse: torch.Tensor,
     sm_scale: float,
     causal: bool,
     window_size_left: int,
     window_size_right: int,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     layout: Literal["bshd"],
-    cache_seqlens: Optional[torch.Tensor],
-    cache_batch_idx: Optional[torch.Tensor],
-    block_table: Optional[torch.Tensor] = None,
-    q_descale: Optional[torch.Tensor] = None,
-    k_descale: Optional[torch.Tensor] = None,
-    v_descale: Optional[torch.Tensor] = None,
+    cache_seqlens: torch.Tensor | None,
+    cache_batch_idx: torch.Tensor | None,
+    block_table: torch.Tensor | None = None,
+    q_descale: torch.Tensor | None = None,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
     # rotary (optional)
-    rotary_cos: Optional[torch.Tensor] = None,
-    rotary_sin: Optional[torch.Tensor] = None,
+    rotary_cos: torch.Tensor | None = None,
+    rotary_sin: torch.Tensor | None = None,
     rotary_interleaved: bool = False,
-    seqlens_rotary: Optional[torch.Tensor] = None,
+    seqlens_rotary: torch.Tensor | None = None,
 ):
     # Validate layout at entry
     if layout != "bshd":
@@ -1050,11 +1020,21 @@ def attention_forward_decode_triton_impl(
 
     # kernel_configs
     is_new_kv = False  # Cache has been updated, so no new KV in kernel
-    use_alibi, (stride_az, stride_ah) = True if alibi_slopes is not None else False, (
+    use_alibi, (stride_az, stride_ah) = alibi_slopes is not None, (
         alibi_slopes.stride() if alibi_slopes is not None else (None, None)
     )
     use_cache_seqlens = cache_seqlens is not None
     use_sliding_window = window_size_left != -1 or window_size_right != -1
+    # As in the prefill kernel, WINDOW_SIZE_RIGHT is used as a literal finite
+    # offset (no infinite-right branch), so a negative right collapses the band
+    # and silently over-masks. Reject it instead. (right == -1 is only valid as
+    # the off sentinel, paired with left == -1, which leaves this flag False.)
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window attention requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An unbounded right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
     use_block_table = block_table is not None
 
     # get shapes and strides
@@ -1064,17 +1044,14 @@ def attention_forward_decode_triton_impl(
     # Handle paged KV cache layout
     if use_block_table:
         # For paged attention, k_cache and v_cache have shape [num_blocks, block_size, nheads, head_dim]
-        num_blocks_kc, block_size_k, nheads_kc, dim_kc = k_cache.shape
-        num_blocks_vc, block_size_v, nheads_vc, dim_vc = v_cache.shape
-        # Get the actual sequence length from cache_seqlens or block_table
-        if cache_seqlens is not None:
-            seqlen_kc = int(cache_seqlens.max().item())
-        else:
-            # Infer from block_table shape [batch_size, num_blocks_per_seq]
-            assert block_table is not None
-            num_blocks_per_seq = block_table.shape[1]
-            seqlen_kc = num_blocks_per_seq * block_size_k
-        seqlen_vc = seqlen_kc
+        _num_blocks_kc, block_size_k, nheads_kc, dim_kc = k_cache.shape
+        _num_blocks_vc, _block_size_v, nheads_vc, dim_vc = v_cache.shape
+        # Get the actual sequence length from the block_table upper bound.
+        # Avoid cache_seqlens.max().item(): GPU-to-CPU sync is illegal during
+        # CUDA graph capture, and the block-table bound is always safe.
+        assert block_table is not None
+        num_blocks_per_seq = block_table.shape[1]
+        seqlen_kc = num_blocks_per_seq * block_size_k
 
         # Strides for paged layout
         stride_kc_z = 0  # No batch dimension in paged cache
@@ -1091,17 +1068,17 @@ def attention_forward_decode_triton_impl(
         stride_kc_z, stride_kc_h, stride_kc_n, stride_kc_d = get_stride_from_layout(
             k_cache, layout
         )
-        _, seqlen_vc, nheads_vc, dim_vc = get_shape_from_layout(v_cache, layout)
+        _, _seqlen_vc, nheads_vc, dim_vc = get_shape_from_layout(v_cache, layout)
         stride_vc_z, stride_vc_h, stride_vc_n, stride_vc_d = get_stride_from_layout(
             v_cache, layout
         )
         block_size_k = 0  # Not used
     if is_new_kv:
-        _, seqlen_kn, nheads_kn, dim_kn = get_shape_from_layout(k_new, layout)
+        _, _seqlen_kn, nheads_kn, _dim_kn = get_shape_from_layout(k_new, layout)
         stride_kn_z, stride_kn_h, stride_kn_n, stride_kn_d = get_stride_from_layout(
             k_new, layout
         )
-        _, seqlen_vn, nheads_vn, dim_vn = get_shape_from_layout(v_new, layout)
+        _, _seqlen_vn, nheads_vn, _dim_vn = get_shape_from_layout(v_new, layout)
         stride_vn_z, stride_vn_h, stride_vn_n, stride_vn_d = get_stride_from_layout(
             v_new, layout
         )
@@ -1110,7 +1087,7 @@ def attention_forward_decode_triton_impl(
         stride_kn_z, stride_kn_h, stride_kn_n, stride_kn_d = None, None, None, None
         _, _seqlen_vn, nheads_vn, _dim_vn = None, None, None, None
         stride_vn_z, stride_vn_h, stride_vn_n, stride_vn_d = None, None, None, None
-    _, seqlen_o, nheads_o, dim_o = get_shape_from_layout(out, layout)
+    _, _seqlen_o, nheads_o, _dim_o = get_shape_from_layout(out, layout)
     stride_oz, stride_oh, stride_om, stride_od = get_stride_from_layout(out, layout)
     assert (
         dim_q == dim_kc == dim_vc
@@ -1141,13 +1118,8 @@ def attention_forward_decode_triton_impl(
 
     # Use heuristics for split_k
     if use_block_table:
-        # For paged attention, use the actual sequence length from cache_seqlens
-        max_seqlen = (
-            int(cache_seqlens.max().item())
-            if cache_seqlens is not None
-            else block_size_k
-        )
-        split_k = get_split_k(batch_size, n_group_q, heads_per_group_q, max_seqlen)
+        # Reuse seqlen_kc (already computed above without GPU-to-CPU sync)
+        split_k = get_split_k(batch_size, n_group_q, heads_per_group_q, seqlen_kc)
     else:
         split_k = get_split_k(batch_size, n_group_q, heads_per_group_q, seqlen_kc)
     split_size = (seqlen_kc + split_k - 1) // split_k
@@ -1379,6 +1351,11 @@ def attention_forward_decode_triton_impl(
         # block table strides
         stride_bt_b=stride_bt_b,
         stride_bt_s=stride_bt_s,
+        # paged KV block strides (real k/v_cache.stride(0)); lets the kernel
+        # index a non-contiguous paged cache instead of assuming the block
+        # stride equals BLOCK_SIZE_K * stride_kn (contiguous-only).
+        stride_kb=(k_cache.stride(0) if use_block_table else 0),
+        stride_vb=(v_cache.stride(0) if use_block_table else 0),
         # alibi strides
         stride_az=stride_az,
         stride_ah=stride_ah,

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/fwd_prefill.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/fwd_prefill.py
@@ -1,14 +1,16 @@
 import warnings
+from typing import Literal
+
 import torch
 import triton
 import triton.language as tl
-from typing import Literal, Optional
-from .common import compute_alibi_block, compute_fp8_scaling_factors, apply_rotary
+
+from .common import apply_rotary, compute_alibi_block, compute_fp8_scaling_factors
 from .utils import (
     AUTOTUNE,
-    AutotuneMode,
     DEBUG,
     FWD_CONF_OVERRIDE,
+    AutotuneMode,
     get_arch,
     is_fp8,
     remap_xcd,
@@ -37,20 +39,7 @@ def get_fwd_prefill_configs(mode: AutotuneMode):
         if FWD_CONF_OVERRIDE:
             return [FWD_CONF_OVERRIDE]
         arch = get_arch()
-        if arch.name == "gfx950":
-            return [
-                triton.Config(
-                    {
-                        "BLOCK_M": 128,
-                        "BLOCK_N": 64,
-                        "waves_per_eu": 2,
-                        "PRE_LOAD_V": False,
-                    },
-                    num_stages=1,
-                    num_warps=4,
-                ),
-            ]
-        elif arch.name == "gfx942":
+        if arch.name == "gfx950" or arch.name == "gfx942":
             return [
                 triton.Config(
                     {
@@ -64,6 +53,21 @@ def get_fwd_prefill_configs(mode: AutotuneMode):
                 ),
             ]
         elif arch.is_rdna:
+            # gfx1151 (Strix Halo / RDNA3.5): tuned for the Qwen3-Omni
+            # ViT prefill shape (B=1, S=3200, H=16, head_dim=72, fp16).
+            if arch.name == "gfx1151":
+                return [
+                    triton.Config(
+                        {
+                            "BLOCK_M": 128,
+                            "BLOCK_N": 64,
+                            "PRE_LOAD_V": False,
+                            "waves_per_eu": 2,
+                        },
+                        num_stages=1,
+                        num_warps=8,
+                    ),
+                ]
             BLOCK_N = 64 if arch.name == "gfx1100" else 32
             return [
                 triton.Config(
@@ -166,6 +170,21 @@ def get_fwd_prefill_configs(mode: AutotuneMode):
                     )
                 ]
         elif arch.is_rdna:
+            # gfx1151 (Strix Halo / RDNA3.5): tuned for the Qwen3-Omni
+            # ViT prefill shape (B=1, S=3200, H=16, head_dim=72, fp16).
+            if arch.name == "gfx1151":
+                return [
+                    triton.Config(
+                        {
+                            "BLOCK_M": 128,
+                            "BLOCK_N": 64,
+                            "PRE_LOAD_V": False,
+                            "waves_per_eu": 2,
+                        },
+                        num_stages=1,
+                        num_warps=8,
+                    ),
+                ]
             BLOCK_N = 64 if arch.name == "gfx1100" else 32
             return [
                 triton.Config(
@@ -299,7 +318,7 @@ def _attn_fwd_inner(
     seqlen_delta_qk = seqlen_k - seqlen_q
 
     # loop over k, v, and update accumulator
-    for start_n in range(block_min, block_max, BLOCK_N):
+    for start_n in tl.range(block_min, block_max, BLOCK_N, num_stages=1):
         # get ptrs
         k_ptrs = k_base_ptrs + start_n * stride_kn
         v_ptrs = v_base_ptrs + start_n * stride_vk
@@ -336,12 +355,11 @@ def _attn_fwd_inner(
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=ACCUMULATOR_TYPE)
 
         # Apply extra token masking for partial blocks (only when APPLY_MASK=True)
-        if APPLY_MASK:
-            if (n_extra_tokens != 0) and (start_n + BLOCK_N == block_max):
-                boundary_m = tl.full([BLOCK_M], seqlen_k, dtype=tl.int32)
-                size_n = start_n + offs_n[None, :]
-                mask = size_n < boundary_m[:, None]
-                qk = tl.where(mask, qk, float("-inf"))
+        if APPLY_MASK and ((n_extra_tokens != 0) and (start_n + BLOCK_N == block_max)):
+            boundary_m = tl.full([BLOCK_M], seqlen_k, dtype=tl.int32)
+            size_n = start_n + offs_n[None, :]
+            mask = size_n < boundary_m[:, None]
+            qk = tl.where(mask, qk, float("-inf"))
 
         # -- compute qk ----
         if IS_FP8:
@@ -941,6 +959,7 @@ def attn_fwd(
     USE_SEQUSED: tl.constexpr,
     FORCE_MASKING: tl.constexpr,
     NUM_XCD: tl.constexpr = 1,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr = False,
 ):
     # set params
     ACCUMULATOR_TYPE = tl.float32
@@ -1091,17 +1110,29 @@ def attn_fwd(
 
     # Initialize for processing
     # Compute pointers for all the tensors used in this kernel.
-    q_offset = (
-        Q + off_z * stride_qz + off_h_q * stride_qh + cu_seqlens_q_start * stride_qm
-    )
+    # When the caller guarantees that the head-axis strides of Q/K/V are
+    # multiples of 8 elements (set via HEAD_STRIDE_ALIGNED_8), the head-axis
+    # offset is a multiple of 8 *elements*. The resulting byte alignment is
+    # element-size dependent: 16 bytes for 16-bit types (fp16/bf16), 8 bytes
+    # for fp8, 32 bytes for fp32. The 16-byte case is the one that lets
+    # AxisInfo widen the K/V global load to a 128-bit (buffer_load_b128)
+    # access; for the other dtypes the hint is still sound but yields a
+    # different (smaller or larger) vector width. Auto-specialization only
+    # fires at the 16-element threshold, so hint the smaller multiple
+    # explicitly.
+    qh_off = off_h_q * stride_qh
+    kh_off = off_h_k * stride_kh
+    vh_off = off_h_k * stride_vh
+    if HEAD_STRIDE_ALIGNED_8:
+        qh_off = tl.multiple_of(qh_off, 8)
+        kh_off = tl.multiple_of(kh_off, 8)
+        vh_off = tl.multiple_of(vh_off, 8)
+
+    q_offset = Q + off_z * stride_qz + qh_off + cu_seqlens_q_start * stride_qm
     q_ptrs = q_offset + offs_m[:, None] * stride_qm + offs_d_qk[None, :] * stride_qk
-    k_offset = (
-        K + off_z * stride_kz + off_h_k * stride_kh + cu_seqlens_k_start * stride_kn
-    )
+    k_offset = K + off_z * stride_kz + kh_off + cu_seqlens_k_start * stride_kn
     k_ptrs = k_offset + offs_d_qk[:, None] * stride_kk + offs_n[None, :] * stride_kn
-    v_offset = (
-        V + off_z * stride_vz + off_h_k * stride_vh + cu_seqlens_k_start * stride_vk
-    )
+    v_offset = V + off_z * stride_vz + vh_off + cu_seqlens_k_start * stride_vk
     v_ptrs = v_offset + offs_n[:, None] * stride_vk + offs_d_v[None, :] * stride_vn
     if USE_BIAS:
         # Note: this might get large enough to overflow on some configs
@@ -1404,38 +1435,38 @@ def attention_forward_prefill_triton_impl(
     v: torch.Tensor,
     o: torch.Tensor,
     softmax_lse: torch.Tensor,
-    sd_mask: Optional[torch.Tensor],
+    sd_mask: torch.Tensor | None,
     sm_scale: float,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     causal: bool,
     window_size_left: int,
     window_size_right: int,
-    bias: Optional[torch.Tensor],
+    bias: torch.Tensor | None,
     layout: Literal["bshd", "bhsd", "thd"],
     # varlen
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
     max_seqlens_q: int,
     max_seqlens_k: int,
     # dropout
     dropout_p: float,
-    philox_seed: Optional[int],
-    philox_offset: Optional[int],
+    philox_seed: int | None,
+    philox_offset: int | None,
     # misc
     return_scores: bool,
     use_exp2: bool,
     # fp8
-    q_descale: Optional[torch.Tensor],
-    k_descale: Optional[torch.Tensor],
-    v_descale: Optional[torch.Tensor],
+    q_descale: torch.Tensor | None,
+    k_descale: torch.Tensor | None,
+    v_descale: torch.Tensor | None,
     # seqused for FA v3
-    seqused_q: Optional[torch.Tensor] = None,
-    seqused_k: Optional[torch.Tensor] = None,
+    seqused_q: torch.Tensor | None = None,
+    seqused_k: torch.Tensor | None = None,
     # rotary (optional)
-    rotary_cos: Optional[torch.Tensor] = None,
-    rotary_sin: Optional[torch.Tensor] = None,
+    rotary_cos: torch.Tensor | None = None,
+    rotary_sin: torch.Tensor | None = None,
     rotary_interleaved: bool = False,
-    seqlens_rotary: Optional[torch.Tensor] = None,
+    seqlens_rotary: torch.Tensor | None = None,
 ):
     # get params, strides and shape
     IS_VARLEN = layout == "thd"
@@ -1457,8 +1488,8 @@ def attention_forward_prefill_triton_impl(
     if IS_VARLEN:
         # shape
         total_seqlen_q, nheads_q, head_size_q = q.shape
-        total_seqlen_k, nheads_k, head_size_k = k.shape
-        total_seqlen_v, nheads_v, head_size_v = v.shape
+        _total_seqlen_k, nheads_k, head_size_k = k.shape
+        _total_seqlen_v, nheads_v, head_size_v = v.shape
 
         # assert shapes
         assert (
@@ -1499,14 +1530,6 @@ def attention_forward_prefill_triton_impl(
         assert (
             cu_seqlens_k.dtype == torch.int32
         ), f"cu_seqlens_k must be int32, got {cu_seqlens_k.dtype}"
-        assert cu_seqlens_q[0] == 0, "cu_seqlens_q must start with 0"
-        assert cu_seqlens_k[0] == 0, "cu_seqlens_k must start with 0"
-        assert (
-            cu_seqlens_q[-1] == total_seqlen_q
-        ), f"cu_seqlens_q[-1] {cu_seqlens_q[-1]} != total_seqlen_q {total_seqlen_q}"
-        assert (
-            cu_seqlens_k[-1] == total_seqlen_k
-        ), f"cu_seqlens_k[-1] {cu_seqlens_k[-1]} != total_seqlen_k {total_seqlen_k}"
 
         # set vars
         batch = len(cu_seqlens_q) - 1
@@ -1731,6 +1754,20 @@ def attention_forward_prefill_triton_impl(
 
     # check features
     use_sliding_window = window_size_left != -1 or window_size_right != -1
+    # The kernel only special-cases an infinite *left* edge (WINDOW_SIZE_LEFT < 0).
+    # WINDOW_SIZE_RIGHT is consumed as a literal finite offset everywhere (the
+    # per-element right_bound and the block-classification bounds), so a negative
+    # right does not mean "unbounded" -- it collapses right_bound to (anchor - 1)
+    # and silently over-masks. Reject it rather than return a wrong result.
+    # (window_size_right == -1 is only valid as the "off" sentinel, i.e. together
+    # with window_size_left == -1, which leaves use_sliding_window False.) This
+    # matches the backward guard in attention_backward_triton_impl.
+    if use_sliding_window and window_size_right < 0:
+        raise NotImplementedError(
+            "Sliding-window attention requires window_size_right >= 0 "
+            f"(got window_size_right={window_size_right}). An unbounded right edge "
+            "is not supported; use window_size_right=0 for a causal window."
+        )
     use_alibi, (stride_az, stride_ah) = (
         (True, alibi_slopes.stride()) if alibi_slopes is not None else (False, (0, 0))
     )
@@ -1791,6 +1828,15 @@ def attention_forward_prefill_triton_impl(
     force_masking = arch.is_rdna
 
     num_xcd = 1 if arch.is_rdna else 8
+
+    # Soundness precondition for the `tl.multiple_of` head-stride hint inside
+    # `attn_fwd`: only enable it when every Q/K/V head-axis stride is a
+    # multiple of 8 elements. With a non-contiguous input (e.g. a transposed
+    # view) stride_*h need not equal head_dim, so the head_dim constexpr
+    # alone is not enough.
+    head_stride_aligned_8 = (
+        stride_qh % 8 == 0 and stride_kh % 8 == 0 and stride_vh % 8 == 0
+    )
 
     # launch kernel
     def grid(META):
@@ -1861,7 +1907,7 @@ def attention_forward_prefill_triton_impl(
         IS_VARLEN=IS_VARLEN,
         BLOCK_DMODEL_QK=padded_d_model_qk,
         BLOCK_DMODEL_V=padded_d_model_v,
-        USE_BIAS=False if bias is None else True,
+        USE_BIAS=not bias is None,
         USE_ALIBI=use_alibi,
         ENABLE_DROPOUT=dropout_p > 0.0,
         USE_EXP2=use_exp2,
@@ -1872,4 +1918,5 @@ def attention_forward_prefill_triton_impl(
         USE_SEQUSED=(seqused_q is not None or seqused_k is not None),
         FORCE_MASKING=force_masking,
         NUM_XCD=num_xcd,
+        HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
     )

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/interface_v2.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/interface_v2.py
@@ -1,25 +1,31 @@
+from typing import Literal
+
 import torch
-from typing import Literal, Optional, Union
-from .fwd_prefill import attention_forward_prefill_triton_impl
-from .fwd_decode import attention_forward_decode_triton_impl
+
 from .bwd import attention_backward_triton_impl
+from .fwd_decode import attention_forward_decode_triton_impl
+from .fwd_prefill import attention_forward_prefill_triton_impl
 from .utils import (
-    DEBUG,
-    USE_EXP2,
     BWD_MODE,
-    PHILOX_SEED,
+    DEBUG,
     PHILOX_OFFSET,
+    PHILOX_SEED,
     SHAPE_EXPECTATIONS,
+    USE_EXP2,
     round_multiple,
 )
+
+# Built once at import, not per call: a per-call alloc inherits the default
+# device and does an illegal H2D under CUDA graph capture.
+_RNG_STATE = torch.tensor([PHILOX_SEED, PHILOX_OFFSET])
 
 
 def fwd(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    out: Optional[torch.Tensor],
-    alibi_slopes: Optional[torch.Tensor],
+    out: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
     dropout_p: float,
     softmax_scale: float,
     causal: bool,
@@ -27,8 +33,8 @@ def fwd(
     window_size_right: int,
     softcap: float,
     return_softmax: bool,
-    gen_: Optional[torch.Tensor] = None,
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    gen_: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
 
     # Reject FP8 tensors (FA2 AMD path does not support FP8)
     if str(q.dtype).startswith("torch.float8"):
@@ -78,7 +84,7 @@ def fwd(
 
     # Dropout + RNG seed
     philox_seed, philox_offset = PHILOX_SEED, PHILOX_OFFSET
-    rng_state = torch.as_tensor([philox_seed, philox_offset])
+    rng_state = _RNG_STATE
 
     # argument checks
     assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4
@@ -212,10 +218,10 @@ def bwd(
     v: torch.Tensor,
     out: torch.Tensor,
     softmax_lse: torch.Tensor,
-    dq: Optional[torch.Tensor],
-    dk: Optional[torch.Tensor],
-    dv: Optional[torch.Tensor],
-    alibi_slopes: Optional[torch.Tensor],
+    dq: torch.Tensor | None,
+    dk: torch.Tensor | None,
+    dv: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
     dropout_p: float,
     softmax_scale: float,
     causal: bool,
@@ -223,21 +229,12 @@ def bwd(
     window_size_right: int,
     softcap: float,
     deterministic: bool,
-    gen_: Optional[torch.Tensor] = None,
-    rng_state: Optional[torch.Tensor] = None,
+    gen_: torch.Tensor | None = None,
+    rng_state: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     if softcap != 0.0:
         raise NotImplementedError(
             "softcap is not supported in the AMD Triton FA2 interface (expected 0.0)."
-        )
-
-    # Check for sliding window - backward doesn't support it yet
-    is_sliding_window = (window_size_left >= 0) or (window_size_right >= 0)
-    if is_sliding_window:
-        raise NotImplementedError(
-            f"Sliding window attention is not yet supported in the AMD Triton backward pass "
-            f"(window_size_left={window_size_left}, window_size_right={window_size_right}). "
-            f"Use window_size=(-1, -1) for full attention."
         )
 
     if DEBUG:
@@ -324,6 +321,8 @@ def bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
     )
 
     if DEBUG:
@@ -350,13 +349,13 @@ def varlen_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    out: Optional[torch.Tensor],
+    out: torch.Tensor | None,
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_k: torch.Tensor,
-    seqused_k: Optional[torch.Tensor],
-    leftpad_k: Optional[torch.Tensor],
-    block_table_: Optional[torch.Tensor],
-    alibi_slopes: Optional[torch.Tensor],
+    seqused_k: torch.Tensor | None,
+    leftpad_k: torch.Tensor | None,
+    block_table_: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
     max_seqlen_q: int,
     max_seqlen_k: int,
     dropout_p: float,
@@ -367,9 +366,9 @@ def varlen_fwd(
     window_size_right: int,
     softcap: float,
     return_softmax: bool,
-    gen_: Optional[torch.Tensor] = None,
+    gen_: torch.Tensor | None = None,
     num_splits: int = 0,
-) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
 
     if str(q.dtype).startswith("torch.float8"):
         raise NotImplementedError(
@@ -454,7 +453,7 @@ def varlen_fwd(
         assert alibi_slopes.shape == (batch, nheads_q)
 
     philox_seed, philox_offset = PHILOX_SEED, PHILOX_OFFSET
-    rng_state = torch.as_tensor([philox_seed, philox_offset])
+    rng_state = _RNG_STATE
 
     # Inline checks (subset appropriate for varlen)
     assert q.dim() == 3 and k.dim() == 3 and v.dim() == 3
@@ -550,12 +549,12 @@ def varlen_bwd(
     v: torch.Tensor,
     out: torch.Tensor,
     softmax_lse: torch.Tensor,
-    dq: Optional[torch.Tensor],
-    dk: Optional[torch.Tensor],
-    dv: Optional[torch.Tensor],
+    dq: torch.Tensor | None,
+    dk: torch.Tensor | None,
+    dv: torch.Tensor | None,
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_k: torch.Tensor,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     max_seqlen_q: int,
     max_seqlen_k: int,
     dropout_p: float,
@@ -566,8 +565,8 @@ def varlen_bwd(
     window_size_right: int,
     softcap: float,
     deterministic: bool,
-    gen_: Optional[torch.Tensor] = None,
-    rng_state: Optional[torch.Tensor] = None,
+    gen_: torch.Tensor | None = None,
+    rng_state: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     if str(q.dtype).startswith("torch.float8"):
         raise NotImplementedError(
@@ -664,6 +663,8 @@ def varlen_bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
     )
 
     if DEBUG:
@@ -691,16 +692,16 @@ def fwd_kvcache(
     q: torch.Tensor,
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
-    k: Optional[torch.Tensor],
-    v: Optional[torch.Tensor],
-    cache_seqlens: Optional[Union[int, torch.Tensor]],
-    rotary_cos: Optional[torch.Tensor],
-    rotary_sin: Optional[torch.Tensor],
-    cache_batch_idx: Optional[torch.Tensor],
-    cache_leftpad: Optional[torch.Tensor],
-    block_table: Optional[torch.Tensor],
-    alibi_slopes: Optional[torch.Tensor],
-    out: Optional[torch.Tensor],
+    k: torch.Tensor | None,
+    v: torch.Tensor | None,
+    cache_seqlens: int | torch.Tensor | None,
+    rotary_cos: torch.Tensor | None,
+    rotary_sin: torch.Tensor | None,
+    cache_batch_idx: torch.Tensor | None,
+    cache_leftpad: torch.Tensor | None,
+    block_table: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
+    out: torch.Tensor | None,
     softmax_scale: float,
     causal: bool,
     window_size_left: int,

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/interface_v3.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/interface_v3.py
@@ -1,14 +1,16 @@
+from typing import Literal
+
 import torch
-from typing import Literal, Optional, Tuple
-from .fwd_prefill import attention_forward_prefill_triton_impl
-from .fwd_decode import attention_forward_decode_triton_impl
+
 from .bwd import attention_backward_triton_impl
+from .fwd_decode import attention_forward_decode_triton_impl
+from .fwd_prefill import attention_forward_prefill_triton_impl
 from .utils import (
-    DEBUG,
-    USE_EXP2,
     BWD_MODE,
-    PHILOX_SEED,
+    DEBUG,
     PHILOX_OFFSET,
+    PHILOX_SEED,
+    USE_EXP2,
     is_fp8,
 )
 
@@ -17,26 +19,26 @@ def fwd(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    k_new: Optional[torch.Tensor],
-    v_new: Optional[torch.Tensor],
-    qv: Optional[torch.Tensor],
-    out: Optional[torch.Tensor],
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
-    cu_seqlens_k_new: Optional[torch.Tensor],
-    seqused_q: Optional[torch.Tensor],
-    seqused_k: Optional[torch.Tensor],
-    max_seqlen_q: Optional[int],
-    max_seqlen_k: Optional[int],
-    page_table: Optional[torch.Tensor],
-    kv_batch_idx: Optional[torch.Tensor],
-    leftpad_k: Optional[torch.Tensor],
-    rotary_cos: Optional[torch.Tensor],
-    rotary_sin: Optional[torch.Tensor],
-    seqlens_rotary: Optional[torch.Tensor],
-    q_descale: Optional[torch.Tensor],
-    k_descale: Optional[torch.Tensor],
-    v_descale: Optional[torch.Tensor],
+    k_new: torch.Tensor | None,
+    v_new: torch.Tensor | None,
+    qv: torch.Tensor | None,
+    out: torch.Tensor | None,
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
+    cu_seqlens_k_new: torch.Tensor | None,
+    seqused_q: torch.Tensor | None,
+    seqused_k: torch.Tensor | None,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
+    page_table: torch.Tensor | None,
+    kv_batch_idx: torch.Tensor | None,
+    leftpad_k: torch.Tensor | None,
+    rotary_cos: torch.Tensor | None,
+    rotary_sin: torch.Tensor | None,
+    seqlens_rotary: torch.Tensor | None,
+    q_descale: torch.Tensor | None,
+    k_descale: torch.Tensor | None,
+    v_descale: torch.Tensor | None,
     softmax_scale: float,
     causal: bool,
     window_size_left: int,
@@ -44,11 +46,11 @@ def fwd(
     attention_chunk: int,
     softcap: float,
     rotary_interleaved: bool,
-    scheduler_metadata: Optional[torch.Tensor] = None,
+    scheduler_metadata: torch.Tensor | None = None,
     num_splits: int = 1,
-    pack_gqa: Optional[bool] = None,
+    pack_gqa: bool | None = None,
     sm_margin: int = 0,
-) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
     """
     Flash Attention v3 forward pass compatible interface for AMD Triton implementation.
 
@@ -408,15 +410,15 @@ def bwd(
     v: torch.Tensor,
     out: torch.Tensor,
     softmax_lse: torch.Tensor,
-    dq: Optional[torch.Tensor],
-    dk: Optional[torch.Tensor],
-    dv: Optional[torch.Tensor],
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
-    seqused_q: Optional[torch.Tensor],
-    seqused_k: Optional[torch.Tensor],
-    max_seqlen_q: Optional[int],
-    max_seqlen_k: Optional[int],
+    dq: torch.Tensor | None,
+    dk: torch.Tensor | None,
+    dv: torch.Tensor | None,
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
+    seqused_q: torch.Tensor | None,
+    seqused_k: torch.Tensor | None,
+    max_seqlen_q: int | None,
+    max_seqlen_k: int | None,
     softmax_scale: float,
     causal: bool,
     window_size_left: int,
@@ -425,10 +427,10 @@ def bwd(
     deterministic: bool,
     sm_margin: int = 0,
     *,
-    q_descale: Optional[torch.Tensor] = None,
-    k_descale: Optional[torch.Tensor] = None,
-    v_descale: Optional[torch.Tensor] = None,
-) -> Tuple[torch.Tensor]:
+    q_descale: torch.Tensor | None = None,
+    k_descale: torch.Tensor | None = None,
+    v_descale: torch.Tensor | None = None,
+) -> tuple[torch.Tensor]:
     """
     Flash Attention v3 backward pass compatible interface for AMD Triton implementation.
 
@@ -469,15 +471,6 @@ def bwd(
         print("sm_margin:", sm_margin)
 
     # Check for unsupported features in backward pass
-
-    # Handle sliding window - backward doesn't support it yet
-    is_sliding_window = (window_size_left >= 0) or (window_size_right >= 0)
-    if is_sliding_window:
-        raise NotImplementedError(
-            f"Sliding window attention is not yet supported in the AMD Triton backward pass "
-            f"(window_size_left={window_size_left}, window_size_right={window_size_right}). "
-            f"Use window_size=(-1, -1) for full attention."
-        )
 
     # Handle softcap
     if softcap != 0.0:
@@ -554,6 +547,8 @@ def bwd(
         philox_offset=philox_offset,
         use_exp2=USE_EXP2,
         mode=BWD_MODE,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
         q_descale=q_descale,
         k_descale=k_descale,
         v_descale=v_descale,
@@ -594,8 +589,8 @@ def bwd(
 def fwd_combine(
     out_partial: torch.Tensor,
     lse_partial: torch.Tensor,
-    out: Optional[torch.Tensor] = None,
-    out_dtype: Optional[torch.dtype] = None,
+    out: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     """
     Combine partial outputs from split attention computation.
@@ -626,12 +621,12 @@ def get_scheduler_metadata(
     headdim_v: int,
     qkv_dtype: torch.dtype,
     cache_seqlens: torch.Tensor,
-    cu_seqlens_q: Optional[torch.Tensor] = None,
-    cu_seqlens_k: Optional[torch.Tensor] = None,
-    cu_seqlens_k_new: Optional[torch.Tensor] = None,
-    seqused_q: Optional[torch.Tensor] = None,
-    cache_leftpad: Optional[torch.Tensor] = None,
-    page_size: Optional[int] = None,
+    cu_seqlens_q: torch.Tensor | None = None,
+    cu_seqlens_k: torch.Tensor | None = None,
+    cu_seqlens_k_new: torch.Tensor | None = None,
+    seqused_q: torch.Tensor | None = None,
+    cache_leftpad: torch.Tensor | None = None,
+    page_size: int | None = None,
     max_seqlen_k_new: int = 0,
     causal: bool = False,
     window_size_left: int = -1,
@@ -639,7 +634,7 @@ def get_scheduler_metadata(
     attention_chunk: int = 0,
     has_softcap: bool = False,
     num_splits: int = 0,
-    pack_gqa: Optional[bool] = None,
+    pack_gqa: bool | None = None,
     sm_margin: int = 0,
 ) -> None:
     """

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/flash_attn_triton_amd/utils.py
@@ -9,40 +9,40 @@ This module contains essential runtime utilities:
 """
 
 import functools
-import os
 import json
 import logging
+import os
 from dataclasses import dataclass
-from typing import Literal, Optional, Union
-import triton.language as tl
+from typing import Literal
 
 import torch
 import triton
+import triton.language as tl
 
 logger = logging.getLogger(__name__)
 
 AutotuneMode = Literal["off", "on", "sweep"]
 
 __all__ = [
-    # Runtime info
-    "get_arch",
-    "is_hip",
+    "AUTOTUNE",
+    "BWD_MODE",
+    "DEBUG",
+    "PHILOX_OFFSET",
+    "PHILOX_SEED",
+    "SHAPE_EXPECTATIONS",
+    "USE_EXP2",
+    "USE_TRITON_ROCM",
     # Global config
     "AutotuneMode",
-    "AUTOTUNE",
-    "DEBUG",
-    "USE_TRITON_ROCM",
-    "BWD_MODE",
-    "USE_EXP2",
-    "PHILOX_SEED",
-    "PHILOX_OFFSET",
-    "SHAPE_EXPECTATIONS",
-    # FP8
-    "is_fp8",
+    # Runtime info
+    "get_arch",
+    "get_padded_headsize",
     # Shape/stride helpers
     "get_shape_from_layout",
     "get_stride_from_layout",
-    "get_padded_headsize",
+    # FP8
+    "is_fp8",
+    "is_hip",
     # Misc helpers
     "round_multiple",
 ]
@@ -81,7 +81,7 @@ class GpuArch:
     """GPU architecture information."""
 
     name: str  # e.g., "gfx942", "gfx1100"
-    family: Optional[ArchFamily] = None
+    family: ArchFamily | None = None
 
     @property
     def is_cdna(self) -> bool:
@@ -139,7 +139,7 @@ try:
             num_stages=conf.pop("num_stages", 1),
             num_warps=conf.pop("num_warps", 4),
         )
-except Exception as e:
+except Exception as e:  # noqa: BLE001
     logger.warning(f"FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON parse error: {e}")
 
 # Unified debug level:
@@ -174,7 +174,7 @@ _FP8_DTYPES = frozenset(
 
 
 def is_fp8(
-    x: Union[torch.dtype, torch.Tensor, list[torch.Tensor], tuple[torch.Tensor, ...]],
+    x: torch.dtype | torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
 ) -> bool:
     """Check if dtype/tensor(s) are FP8.
 
@@ -224,8 +224,8 @@ def is_fp8(
 def get_shape_from_layout(
     x: torch.Tensor,
     layout: Literal["bshd", "bhsd", "thd"],
-    cu_seqlens: Optional[torch.Tensor] = None,
-    max_seqlen: Optional[int] = None,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: int | None = None,
 ) -> tuple[int, int, int, int]:
     """Extract (batch, max_seqlen, num_heads, head_dim) from tensor based on layout."""
     if layout == "bhsd":
@@ -233,13 +233,13 @@ def get_shape_from_layout(
     elif layout == "bshd":
         batch, max_seqlen_final, num_heads, head_dim = x.shape
     elif layout == "thd":
-        total_seqlen, num_heads, head_dim = x.shape
+        _total_seqlen, num_heads, head_dim = x.shape
         if cu_seqlens is None:
             raise ValueError("cu_seqlens must be provided for varlen (thd) layout")
         if max_seqlen is None:
             raise ValueError("max_seqlen must be provided for varlen (thd) layout")
 
-        batch, max_seqlen_final, num_heads, head_dim = (
+        batch, max_seqlen_final, num_heads, head_dim = (  # noqa: PLW0127
             len(cu_seqlens) - 1,
             max_seqlen,
             num_heads,

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha.py
@@ -3,15 +3,16 @@
 
 import functools
 import json
+
 import torch
 import triton
 import triton.language as tl
 
 from ..utils._triton import arch_info
-from ..utils.core import AITER_TRITON_CONFIGS_PATH
-from ..utils._triton.pid_preprocessing import remap_xcd
-from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
 from ..utils._triton.kernel_repr import make_kernel_repr
+from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
+from ..utils._triton.pid_preprocessing import remap_xcd
+from ..utils.core import AITER_TRITON_CONFIGS_PATH
 
 
 @triton.jit
@@ -362,6 +363,7 @@ def _attn_fwd(
     USE_INT64_STRIDES: tl.constexpr,
     ENABLE_SINK: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr = False,
 ):
     NUM_BLOCKS = (SEQLEN_Q + BLOCK_M - 1) // BLOCK_M
     # calculate offsets
@@ -564,9 +566,22 @@ def _attn_fwd(
         off_k_head = off_q_head
 
     # q,k,v offsets
+    # When the caller guarantees that the head-axis strides of Q/K/V are
+    # multiples of 8 elements (set via HEAD_STRIDE_ALIGNED_8), the head-axis
+    # byte offset is 16-byte aligned. Auto-specialization only fires at the
+    # 16-element threshold, so hint the smaller multiple explicitly to let
+    # AxisInfo widen the global load.
+    qh_off = off_q_head * stride_qh
+    kh_off = off_k_head * stride_kh
+    vh_off = off_k_head * stride_vh
+    if HEAD_STRIDE_ALIGNED_8:
+        qh_off = tl.multiple_of(qh_off, 8)
+        kh_off = tl.multiple_of(kh_off, 8)
+        vh_off = tl.multiple_of(vh_off, 8)
+
     q_offs = (
         off_z * stride_qz
-        + off_q_head * stride_qh
+        + qh_off
         + cu_seqlens_q_start * stride_qm
         + offs_m[:, None] * stride_qm
         + offs_d[None, :] * stride_qk
@@ -575,7 +590,7 @@ def _attn_fwd(
     if HAS_PE:
         q_pe_offs = (
             off_z * stride_qz
-            + off_q_head * stride_qh
+            + qh_off
             + cu_seqlens_q_start * stride_qm
             + offs_m[:, None] * stride_qm
             + offs_pe[None, :] * stride_qk
@@ -586,7 +601,7 @@ def _attn_fwd(
 
     k_offs = (
         off_z * stride_kz
-        + off_k_head * stride_kh
+        + kh_off
         + cu_seqlens_k_start * stride_kn
         + offs_d[:, None] * stride_kk
         + offs_n[None, :] * stride_kn
@@ -595,7 +610,7 @@ def _attn_fwd(
     if HAS_PE:
         k_pe_offs = (
             off_z * stride_kz
-            + off_k_head * stride_kh
+            + kh_off
             + cu_seqlens_k_start * stride_kn
             + offs_pe[:, None] * stride_kk
             + offs_n[None, :] * stride_kn
@@ -606,7 +621,7 @@ def _attn_fwd(
 
     v_offs = (
         off_z * stride_vz
-        + off_k_head * stride_vh
+        + vh_off
         + cu_seqlens_k_start * stride_vn
         + offs_n[:, None] * stride_vn
         + offs_d[None, :] * stride_vk
@@ -856,15 +871,14 @@ def _attn_fwd(
     end_m_idx = (start_m + 1) * BLOCK_M
     start_m_idx = start_m * BLOCK_M
     causal_start_idx = seqlen_q - seqlen_k
-    if IS_CAUSAL:
-        if causal_start_idx > start_m_idx and causal_start_idx < end_m_idx:
-            out_mask_boundary = tl.full(
-                (BLOCK_DMODEL_POW2,), causal_start_idx, dtype=tl.int32
-            )
-            mask_m_offsets = start_m_idx + tl.arange(0, BLOCK_M)
-            out_ptrs_mask = mask_m_offsets[:, None] >= out_mask_boundary[None, :]
-            z = 0.0
-            acc = tl.where(out_ptrs_mask, acc, z.to(acc.type.element_ty))
+    if IS_CAUSAL and (causal_start_idx > start_m_idx and causal_start_idx < end_m_idx):
+        out_mask_boundary = tl.full(
+            (BLOCK_DMODEL_POW2,), causal_start_idx, dtype=tl.int32
+        )
+        mask_m_offsets = start_m_idx + tl.arange(0, BLOCK_M)
+        out_ptrs_mask = mask_m_offsets[:, None] >= out_mask_boundary[None, :]
+        z = 0.0
+        acc = tl.where(out_ptrs_mask, acc, z.to(acc.type.element_ty))
 
     # write back LSE(Log Sum Exponents), the log of the normalization constant
     overflow_size = end_m_idx - seqlen_q

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha_fused_bwd.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha_fused_bwd.py
@@ -3,15 +3,15 @@
 
 import functools
 import json
+
 import triton
 import triton.language as tl
 
-
 from ..utils._triton import arch_info
-from ..utils.core import AITER_TRITON_CONFIGS_PATH
-from ..utils._triton.pid_preprocessing import remap_xcd
-from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
 from ..utils._triton.kernel_repr import make_kernel_repr
+from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
+from ..utils._triton.pid_preprocessing import remap_xcd
+from ..utils.core import AITER_TRITON_CONFIGS_PATH
 
 # This function computes delta given output Out and gradient DO
 # Here is the I/O shape:
@@ -32,7 +32,7 @@ _bwd_preprocess_repr = make_kernel_repr(
 @triton.jit(repr=_bwd_preprocess_repr)
 def _bwd_preprocess(
     o_ptr,
-    do_ptr,  # noqa: E741
+    do_ptr,
     delta_ptr,
     stride_o_b,
     stride_o_h,
@@ -671,7 +671,7 @@ def _bwd_kernel_dkdvdq_causal(
         dropout_p,
         philox_seed,
         batch_philox_offset,
-        dropout_offset,  #
+        dropout_offset,
         seqlen_q,
         seqlen_k,  # max sequence length for q and k
         start_n,
@@ -718,7 +718,7 @@ def _bwd_kernel_dkdvdq_causal(
         dropout_p,
         philox_seed,
         batch_philox_offset,
-        dropout_offset,  #
+        dropout_offset,
         seqlen_q,
         seqlen_k,  # max sequence length for q and k
         start_n,

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha_onekernel_bwd.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/_kernels/mha_onekernel_bwd.py
@@ -3,12 +3,14 @@
 
 import functools
 import json
+
 import triton  # type: ignore
 import triton.language as tl  # type: ignore
+
 from ..utils._triton import arch_info
-from ..utils.core import AITER_TRITON_CONFIGS_PATH
-from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
 from ..utils._triton.kernel_repr import make_kernel_repr
+from ..utils._triton.mha_kernel_utils import _compute_fp8_scaling_factors
+from ..utils.core import AITER_TRITON_CONFIGS_PATH
 
 # NOTE: triton fails to import tl.constexprs so create them here for the file
 DROPOUT_USE_PYTORCH = False
@@ -37,7 +39,7 @@ _bwd_preprocess_repr = make_kernel_repr(
 @triton.jit(repr=_bwd_preprocess_repr)
 def _bwd_preprocess(
     o_ptr,
-    do_ptr,  # noqa: E741
+    do_ptr,
     delta_ptr,
     stride_o_b,
     stride_o_h,
@@ -148,8 +150,8 @@ def _bwd_dkdv_inner(
     stride_deltam,
     BLOCK_M: tl.constexpr,  # 16
     BLOCK_N: tl.constexpr,  # 128
-    HEAD_DIM: tl.constexpr,  #
-    ACTUAL_HEAD_DIM: tl.constexpr,  #
+    HEAD_DIM: tl.constexpr,
+    ACTUAL_HEAD_DIM: tl.constexpr,
     PE_HEAD_DIM: tl.constexpr,
     dropout_p,
     philox_seed,
@@ -204,7 +206,7 @@ def _bwd_dkdv_inner(
 
     for blk_idx in range(num_steps):
         if DEBUG_TRITON:
-            print(f"iter {blk_idx}: curr_m = {curr_m}")  # noqa: E701
+            print(f"iter {blk_idx}: curr_m = {curr_m}")
         offs_m = curr_m + tl.arange(0, BLOCK_M)
         # update the mask because offs_m advanced
         mask_m = offs_m < seqlen_q
@@ -250,11 +252,10 @@ def _bwd_dkdv_inner(
             alibi_block = -1 * alibi_slope * tl.abs(relative_pos_block)
             qkT_scaled += alibi_block
 
-        if DEBUG_TRITON_DETAIL:
-            if start_n == 256:
-                print(f"qT: {qT.shape}\n", qT)
-                print(f"k: {k.shape}\n", k)
-                print(f"qkT scaled: {qkT.shape}\n", qkT_scaled)
+        if DEBUG_TRITON_DETAIL and start_n == 256:
+            print(f"qT: {qT.shape}\n", qT)
+            print(f"k: {k.shape}\n", k)
+            print(f"qkT scaled: {qkT.shape}\n", qkT_scaled)
         # TODO: remove the scaling of m later when we removed re-scaling in fwd
         if USE_EXP2:
             pT = tl.math.exp2(qkT_scaled * RCP_LN2 - m[None, :] * RCP_LN2)
@@ -267,13 +268,12 @@ def _bwd_dkdv_inner(
             # bottom right of the (seqlen_q, seqlen_k) matrix
             causal_mask = (offs_m[None, :] - delta_qk) >= offs_n[:, None]
             mask = causal_mask & mask_nm
-            if DEBUG_TRITON_DETAIL:
-                if start_n == 256:
-                    print(f"causal_mask: {causal_mask.shape}\n", causal_mask)
-                    print(
-                        f"qkT after causal: {qkT.shape}\n",
-                        tl.where(causal_mask, qkT * sm_scale, 0.0),
-                    )
+            if DEBUG_TRITON_DETAIL and start_n == 256:
+                print(f"causal_mask: {causal_mask.shape}\n", causal_mask)
+                print(
+                    f"qkT after causal: {qkT.shape}\n",
+                    tl.where(causal_mask, qkT * sm_scale, 0.0),
+                )
             pT = tl.where(mask, pT, 0.0)
         if SLIDING_WINDOW > 0:
             window_mask = offs_n[:, None] >= (
@@ -306,9 +306,8 @@ def _bwd_dkdv_inner(
             else:
                 dv = tl.dot(pT.to(do.type.element_ty), do, acc=dv)
 
-        if DEBUG_TRITON_DETAIL:
-            if start_n == 256:
-                print(f"pT: {pT.shape}\n", pT)
+        if DEBUG_TRITON_DETAIL and start_n == 256:
+            print(f"pT: {pT.shape}\n", pT)
         # D (= delta) is pre-divided by ds_scale.
         Di = tl.load(D + offs_m * stride_deltam, mask=mask_m)
         # Compute dP and dS.
@@ -365,11 +364,11 @@ def _bwd_dq_inner(
     stride_dropoutm,
     stride_dropoutn,  # stride for dropout
     seqlen_q,
-    seqlen_k,  #
-    BLOCK_M2: tl.constexpr,  #
-    BLOCK_N2: tl.constexpr,  #
+    seqlen_k,
+    BLOCK_M2: tl.constexpr,
+    BLOCK_N2: tl.constexpr,
     HEAD_DIM: tl.constexpr,
-    ACTUAL_HEAD_DIM: tl.constexpr,  #
+    ACTUAL_HEAD_DIM: tl.constexpr,
     PE_HEAD_DIM: tl.constexpr,
     dropout_p,
     philox_seed,
@@ -380,7 +379,7 @@ def _bwd_dq_inner(
     start_m,
     start_n,
     end_n,
-    num_steps,  #
+    num_steps,
     descale_q,
     descale_k,
     descale_v,
@@ -423,7 +422,7 @@ def _bwd_dq_inner(
     delta_recomp = tl.zeros([BLOCK_M2], dtype=tl.float32)
     for blk_idx in range(num_steps):
         if DEBUG_TRITON:
-            print(f"iter {blk_idx}: curr_n = {curr_n}")  # noqa: E701
+            print(f"iter {blk_idx}: curr_n = {curr_n}")
         offs_n = curr_n + tl.arange(0, BLOCK_N2)
         # end_n is needed because the end of causal True might not be perfectly
         # aligned with the end of the block
@@ -431,9 +430,9 @@ def _bwd_dq_inner(
         if DEBUG_TRITON_DETAIL:
             print(
                 f"start_n = {start_n}, end_n = {end_n}, offs_n: {offs_n.shape}\n{offs_n}"
-            )  # noqa: E701
+            )
         if DEBUG_TRITON_DETAIL:
-            print(f"mask_n: {mask_n.shape}\n{mask_n}")  # noqa: E701
+            print(f"mask_n: {mask_n.shape}\n{mask_n}")
         mask_kT = mask_n[None, :]
         mask_mn = mask_m[:, None] & (offs_n[None, :] < end_n)
         if PADDED_HEAD:
@@ -476,7 +475,7 @@ def _bwd_dq_inner(
             qk_scaled += alibi_block
 
         if DEBUG_TRITON_DETAIL:
-            print(f"qk scaled: {qk.shape}\n", qk_scaled)  # noqa: E701
+            print(f"qk scaled: {qk.shape}\n", qk_scaled)
         if USE_EXP2:
             p = tl.math.exp2(qk_scaled * RCP_LN2 - m * RCP_LN2)
         else:
@@ -730,7 +729,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
     pid = tl.program_id(1)
     bid = tl.program_id(2)
     if DEBUG_TRITON:
-        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
+        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")
     # figure out varlen start and end
     q_start = 0
     k_start = 0
@@ -747,7 +746,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
 
     delta_qk = seqlen_q - seqlen_k
     if DEBUG_TRITON:
-        print(f"delta_qk = {delta_qk}")  # noqa: E701
+        print(f"delta_qk = {delta_qk}")
     PADDED_HEAD: tl.constexpr = ACTUAL_HEAD_DIM != HEAD_DIM
     HAS_PE: tl.constexpr = PE_HEAD_DIM > 0
     offs_d = tl.arange(0, HEAD_DIM)
@@ -781,13 +780,13 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             if DEBUG_TRITON:
                 print(
                     f"q >= k: start_delta = delta_qk aligned to BLOCK_M = {start_delta_q_gt_k}"
-                )  # noqa: E701
+                )
         else:
             start_delta = start_delta_q_lt_k
             if DEBUG_TRITON:
                 print(
                     f"q < k: start_delta = residue btw multiple BLOCK_N and delta_qk = {delta_aligned} = aligned to BLOCK_M = {start_delta_q_lt_k}"
-                )  # noqa: E701
+                )
 
         offs_n = start_n + tl.arange(0, BLOCK_N1)
         # Mask for loading K and V
@@ -841,7 +840,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 residue_m = max(start_n + delta_qk - start_m, 0)
                 len_m = BLOCK_N1 + residue_m
                 if DEBUG_TRITON:
-                    print(f"residue_m = {residue_m}")  # noqa: E701
+                    print(f"residue_m = {residue_m}")
 
             # offset input and output tensor by batch and Q/K heads
             adj_q = bid * stride_qb + hqid * stride_qh + q_start * stride_qm
@@ -893,7 +892,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             if DEBUG_TRITON:
                 print(
                     f"Masked: start_n: {start_n}; start_m: {start_m}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             dk, dk_pe, dv = _bwd_dkdv_inner(
                 dk,  # output tensor
                 dk_pe,  # optional output tensor
@@ -950,15 +949,13 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             end_m = start_m + num_steps * BLOCK_M1
 
             if DEBUG_TRITON:
-                print(
-                    f"start_m after Masked step: {start_m}; num_steps: {num_steps}"
-                )  # noqa: E701
+                print(f"start_m after Masked step: {start_m}; num_steps: {num_steps}")
             if DEBUG_TRITON:
                 print(
                     f"unMasked: start_n: {start_n}, start_m: {start_m}, end_m: {end_m}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             if DEBUG_TRITON:
-                print("unMasked")  # noqa: E701
+                print("unMasked")
             dk, dk_pe, dv = _bwd_dkdv_inner(
                 dk,  # output tensor
                 dk_pe,  # optional output tensor
@@ -1029,12 +1026,12 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
         if DEBUG_TRITON:
             print(
                 f"end_n = start_m + BLOCK_M = {start_m} + {BLOCK_M2} = {start_m + BLOCK_M2}"
-            )  # noqa: E701
+            )
         if start_m + BLOCK_M2 < delta_qk:
             if DEBUG_TRITON:
                 print(
                     f"start_m + BLOCK_M2 = {start_m} + {BLOCK_M2} = {start_m + BLOCK_M2} < delta_qk of {delta_qk}"
-                )  # noqa: E701
+                )
             return
 
         offs_m = start_m + tl.arange(0, BLOCK_M2)
@@ -1059,7 +1056,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             # clamp end_n at [0, seqlen_k]
             end_n = max(min(end_n, seqlen_k), 0)
             if DEBUG_TRITON:
-                print(f"delta_qk: {delta_qk}; end_n: {end_n}")  # noqa: E701
+                print(f"delta_qk: {delta_qk}; end_n: {end_n}")
             # offset input and output tensor by batch and Q/K heads
             adj_q = bid * stride_qb + hqid * stride_qh + q_start * stride_qm
             adj_do = bid * stride_dob + hqid * stride_doh + q_start * stride_dom
@@ -1153,7 +1150,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
                 descale_k,
                 descale_v,
                 descale_do,
-                MASK=True,  #
+                MASK=True,
                 ENABLE_DROPOUT=ENABLE_DROPOUT,
                 USE_ALIBI=USE_ALIBI,
                 USE_EXP2=USE_EXP2,
@@ -1173,7 +1170,7 @@ def bwd_kernel_causal(  # grid = (tl.cdiv(max_seqlen_q // BLOCK_M2), batch, nhea
             if DEBUG_TRITON:
                 print(
                     f"unMasked: start_m: {start_m}, start_n: {start_n}, end_n: {end_n}, num_steps: {num_steps}"
-                )  # noqa: E701
+                )
             dq, dq_pe, delta_recomp_unmasked = _bwd_dq_inner(
                 dq,  # output tensor
                 dq_pe,  # optional output tensor
@@ -1452,7 +1449,7 @@ def bwd_kernel_noncausal(
     pid = tl.program_id(1)
     bid = tl.program_id(2)
     if DEBUG_TRITON:
-        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")  # noqa: E701
+        print(f"\npid: {pid}, bid: {bid}, hkid: {hkid}")
     # figure out varlen start and end
     q_start = 0
     k_start = 0
@@ -1590,7 +1587,7 @@ def bwd_kernel_noncausal(
                 dropout_p,
                 philox_seed,
                 batch_philox_offset,
-                dropout_offset,  #
+                dropout_offset,
                 alibi_slope,
                 seqlen_q,
                 seqlen_k,  # max sequence length for q and k

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/mha.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/mha.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal
+
 import torch
 import triton
 import triton.language as tl
 
-from .utils import types
-from .mha_onekernel_bwd import flash_attn_onekernel_backward
-from .mha_fused_bwd import flash_attn_fused_backward
-from .utils.logger import AiterTritonLogger
-from .utils.device_info import get_num_xcds
 from ._kernels.mha import _attn_fwd, _get_config
 from ._kernels.flash_attn_triton_amd import flash_attn_2
+from .mha_fused_bwd import flash_attn_fused_backward
+from .mha_onekernel_bwd import flash_attn_onekernel_backward
+from .utils import types
+from .utils.device_info import get_num_xcds
+from .utils.logger import AiterTritonLogger
 
 _LOGGER = AiterTritonLogger()
 
-global _USE_FUSED_BWD_KERNEL
 _USE_FUSED_BWD_KERNEL = False
 
 
@@ -47,8 +47,44 @@ def mha_set_use_int64_strides(value: bool):
     _USE_INT64_STRIDES = value
 
 
-def _get_sliding_window_size(window_size: Tuple[int, int]) -> int:
-    return int(window_size[0]) if int(window_size[0]) >= 0 else 0
+def _get_sliding_window_size(window_size: tuple[int, int]) -> int:
+    return max(int(window_size[0]), 0)
+
+
+def _resolve_mha_impl(
+    window_size_right: int,
+    sink: torch.Tensor | None,
+    pe_head_dim: int,
+    is_fp8: bool,
+) -> Literal["default", "dao_ai"]:
+    """Pick the effective MHA implementation for a single call.
+
+    The default kernel (_attn_fwd) does not implement a right-side sliding
+    window, but the dao_ai backend (flash_attn_triton_amd) does. When the
+    caller leaves the impl on "default" and requests a right window
+    (window_size_right != -1), auto-select dao_ai so sliding-window models work
+    through the plain flash_attn_func / flash_attn_varlen_func entry points that
+    transformers uses, without an explicit mha_set_impl("dao_ai").
+
+    dao_ai does not support attention sinks, positional-encoding head splits or
+    FP8, so those workloads stay on the default kernel (and hit the
+    window_size_right guard if they also ask for a right window). An explicit
+    mha_set_impl choice is always respected.
+
+    NOTE: this is a deliberate deviation from upstream aiter, which never
+    auto-switches impl. Keep the decision inputs in sync between the forward and
+    backward passes so both use the same backend for a given call.
+    """
+    impl = _MHA_IMPL
+    if (
+        impl == "default"
+        and window_size_right != -1
+        and sink is None
+        and pe_head_dim == 0
+        and not is_fp8
+    ):
+        impl = "dao_ai"
+    return impl
 
 
 def _flash_attn_forward(
@@ -60,35 +96,54 @@ def _flash_attn_forward(
     causal: bool,
     window_size_left: int,
     window_size_right: int,
-    bias: Optional[torch.Tensor],
-    alibi_slopes: Optional[torch.Tensor],
+    bias: torch.Tensor | None,
+    alibi_slopes: torch.Tensor | None,
     return_lse: bool,  # Not used
     return_softmax: bool,
     max_seqlen_q: int,
     max_seqlen_k: int,
-    cu_seqlens_q: Optional[torch.Tensor] = None,
-    cu_seqlens_k: Optional[torch.Tensor] = None,
-    descale_q: Optional[torch.Tensor] = None,
-    descale_k: Optional[torch.Tensor] = None,
-    descale_v: Optional[torch.Tensor] = None,
-    sink: Optional[torch.Tensor] = None,
-    config: Optional[dict[str, any]] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], int, int]:
+    cu_seqlens_q: torch.Tensor | None = None,
+    cu_seqlens_k: torch.Tensor | None = None,
+    descale_q: torch.Tensor | None = None,
+    descale_k: torch.Tensor | None = None,
+    descale_v: torch.Tensor | None = None,
+    sink: torch.Tensor | None = None,
+    config: dict[str, any] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, int, int]:
 
     if bias is not None:
         raise ValueError("Bias is not supported yet in the Triton Backend")
-    if window_size_right != -1:
+
+    # Under causal masking a right-side window is a no-op: the causal edge
+    # (key <= query) is always at or inside the window's right edge when
+    # window_size_right >= 0. Normalize it away so causal sliding-window models
+    # stay on the default kernel, which supports a left window together with
+    # attention sinks (e.g. gpt-oss). Without this, the guard below would reject
+    # them, and dao_ai (which the guard would otherwise require) has no sink
+    # support.
+    if causal and window_size_right >= 0:
+        window_size_right = -1
+
+    # Resolve the effective implementation before the feature guards below. The
+    # default kernel has no right-side sliding window, but the dao_ai backend
+    # does, so a (non-causal) right window auto-selects dao_ai for compatible
+    # workloads (see _resolve_mha_impl). IS_FP8 / pe_head_dim are needed for that
+    # decision and reused further down.
+    IS_FP8 = types._is_fp8(q)
+    pe_head_dim = q.shape[-1] - v.shape[-1]
+    impl = _resolve_mha_impl(window_size_right, sink, pe_head_dim, IS_FP8)
+
+    if impl != "dao_ai" and window_size_right != -1:
         raise ValueError("window_size_right is not supported yet in the Triton Backend")
-    sliding_window = window_size_left if window_size_left >= 0 else 0
+    sliding_window = max(window_size_left, 0)
 
     # Triton cannot specialize on numpy scalar types; ensure native Python int
     max_seqlen_q = int(max_seqlen_q)
     max_seqlen_k = int(max_seqlen_k)
 
     # FP8
-    IS_FP8 = types._is_fp8(q)
     FP8_MAX: tl.constexpr = torch.finfo(q.dtype).max
-    is_varlen = True if cu_seqlens_q is not None else False
+    is_varlen = cu_seqlens_q is not None
 
     if IS_FP8:
         o = torch.zeros(
@@ -121,9 +176,7 @@ def _flash_attn_forward(
         v_strides = (v.stride(0), v.stride(2), v.stride(1), v.stride(3))
         o_strides = (o.stride(0), o.stride(2), o.stride(1), o.stride(3))
 
-    qk_head_dim = q.shape[-1]
     v_head_dim = v.shape[-1]
-    pe_head_dim = qk_head_dim - v_head_dim
     # padding for head_dim. Power of 2 or 16
     BLOCK_DMODEL_POW2 = max(triton.next_power_of_2(v_head_dim), 16)
     BLOCK_DMODEL_PE_POW2 = (
@@ -183,7 +236,7 @@ def _flash_attn_forward(
         s_dmask = None
         dropout_mask = None
 
-    if _MHA_IMPL == "dao_ai":
+    if impl == "dao_ai":
         assert sink is None, "dao_ai impl does not support attention sink."
         assert (
             pe_head_dim == 0
@@ -191,9 +244,6 @@ def _flash_attn_forward(
         assert (
             not IS_FP8
         ), "dao_ai impl does not support FP8. Use the default impl or FA3 path."
-        assert (
-            window_size_left == -1 and window_size_right == -1
-        ), "dao_ai impl does not support sliding window attention."
         if is_varlen:
             o, softmax_lse, s_dmask, _ = flash_attn_2.varlen_fwd(
                 q,
@@ -212,8 +262,8 @@ def _flash_attn_forward(
                 softmax_scale=softmax_scale,
                 zero_tensors=False,
                 causal=causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
                 softcap=0.0,
                 return_softmax=return_softmax,
             )
@@ -227,8 +277,8 @@ def _flash_attn_forward(
                 dropout_p,
                 softmax_scale,
                 causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
                 softcap=0.0,
                 return_softmax=return_softmax,
             )
@@ -248,7 +298,7 @@ def _flash_attn_forward(
         if config is None:
             config = _get_config(enable_dropout, q.dtype, has_pe=pe_head_dim > 0)
 
-        grid = lambda META: (  # noqa: E731
+        grid = lambda META: (
             batch * num_q_heads * triton.cdiv(seqlen_q, META["BLOCK_M"]),
         )
 
@@ -305,6 +355,15 @@ def _flash_attn_forward(
             USE_INT64_STRIDES=_USE_INT64_STRIDES,
             ENABLE_SINK=sink is not None,
             SLIDING_WINDOW=sliding_window,
+            # Soundness precondition: only set when every Q/K/V head-axis
+            # stride is a multiple of 8 elements. q_strides[1]/k_strides[1]/
+            # v_strides[1] are the head-axis strides in both thd and bshd
+            # layouts (see q_strides assembly above).
+            HEAD_STRIDE_ALIGNED_8=(
+                q_strides[1] % 8 == 0
+                and k_strides[1] % 8 == 0
+                and v_strides[1] % 8 == 0
+            ),
             **config,
         )
 
@@ -397,8 +456,16 @@ class _FlashAttnFunc(torch.autograd.Function):
         if head_size_v_og % 8 != 0:
             do_padded = torch.nn.functional.pad(do, [0, 8 - head_size_v_og % 8])
         sliding_window = _get_sliding_window_size(ctx.window_size)
+        # Mirror the forward impl decision (including the causal right-window
+        # normalization) so the backward runs on the same backend as the forward.
+        window_size_right = int(ctx.window_size[1])
+        if ctx.causal and window_size_right >= 0:
+            window_size_right = -1
+        impl = _resolve_mha_impl(
+            window_size_right, sink, q.shape[-1] - v.shape[-1], types._is_fp8(q)
+        )
 
-        if _MHA_IMPL == "dao_ai":
+        if impl == "dao_ai":
             assert sink is None, "dao_ai impl does not support attention sink."
             flash_attn_2.bwd(
                 do_padded,
@@ -414,8 +481,8 @@ class _FlashAttnFunc(torch.autograd.Function):
                 ctx.dropout_p,
                 ctx.softmax_scale,
                 ctx.causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=ctx.window_size[0],
+                window_size_right=window_size_right,
                 softcap=0.0,
                 deterministic=ctx.deterministic,
             )
@@ -516,7 +583,7 @@ def flash_attn_func(
     return_lse=False,
     return_attn_probs=False,
     sink=None,
-    config: Optional[dict[str, any]] = None,
+    config: dict[str, any] | None = None,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
@@ -686,8 +753,16 @@ class _FlashAttnVarlenFunc(torch.autograd.Function):
         if head_size_og % 8 != 0:
             do_padded = torch.nn.functional.pad(do, [0, 8 - head_size_og % 8])
         sliding_window = _get_sliding_window_size(ctx.window_size)
+        # Mirror the forward impl decision (including the causal right-window
+        # normalization) so the backward runs on the same backend as the forward.
+        window_size_right = int(ctx.window_size[1])
+        if ctx.causal and window_size_right >= 0:
+            window_size_right = -1
+        impl = _resolve_mha_impl(
+            window_size_right, sink, q.shape[-1] - v.shape[-1], types._is_fp8(q)
+        )
 
-        if _MHA_IMPL == "dao_ai":
+        if impl == "dao_ai":
             assert sink is None, "dao_ai impl does not support attention sink."
             flash_attn_2.varlen_bwd(
                 do_padded,
@@ -708,8 +783,8 @@ class _FlashAttnVarlenFunc(torch.autograd.Function):
                 softmax_scale=ctx.softmax_scale,
                 zero_tensors=False,
                 causal=ctx.causal,
-                window_size_left=-1,
-                window_size_right=-1,
+                window_size_left=ctx.window_size[0],
+                window_size_right=window_size_right,
                 softcap=0.0,
                 deterministic=False,
             )
@@ -822,7 +897,7 @@ def flash_attn_varlen_func(
     block_table=None,
     out=None,
     sink=None,
-    config: Optional[dict[str, any]] = None,
+    config: dict[str, any] | None = None,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in K, V with fewer heads
@@ -913,20 +988,20 @@ def flash_attn_with_kvcache(
     q: torch.Tensor,
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
-    k: Optional[torch.Tensor] = None,
-    v: Optional[torch.Tensor] = None,
-    cache_seqlens: Optional[Union[torch.Tensor, int]] = None,
-    softmax_scale: Optional[float] = None,
+    k: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
+    cache_seqlens: torch.Tensor | int | None = None,
+    softmax_scale: float | None = None,
     causal: bool = True,
     window_size: tuple[int, int] = (-1, -1),
     softcap: float = 0.0,
     num_splits: int = 0,
-    rotary_cos: Optional[torch.Tensor] = None,
-    rotary_sin: Optional[torch.Tensor] = None,
-    cache_batch_idx: Optional[torch.Tensor] = None,
-    cache_leftpad: Optional[torch.Tensor] = None,
-    block_table: Optional[torch.Tensor] = None,
-    alibi_slopes: Optional[torch.Tensor] = None,
+    rotary_cos: torch.Tensor | None = None,
+    rotary_sin: torch.Tensor | None = None,
+    cache_batch_idx: torch.Tensor | None = None,
+    cache_leftpad: torch.Tensor | None = None,
+    block_table: torch.Tensor | None = None,
+    alibi_slopes: torch.Tensor | None = None,
     rotary_interleaved: bool = True,
     return_softmax_lse: bool = False,
 ):

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/mha_fused_bwd.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/mha_fused_bwd.py
@@ -1,19 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-from typing import Optional, Dict
 import torch
 import triton
 
-from .utils.types import _is_fp8
-from .utils.logger import AiterTritonLogger
 from ._kernels.mha_fused_bwd import (
-    _bwd_preprocess,
     _bwd_kernel_dkdvdq_causal,
     _bwd_kernel_dkdvdq_noncausal,
+    _bwd_preprocess,
     _get_config,
 )
 from .utils.device_info import get_num_xcds
+from .utils.logger import AiterTritonLogger
+from .utils.types import _is_fp8
 
 _LOGGER = AiterTritonLogger()
 
@@ -30,21 +29,21 @@ def flash_attn_fused_backward(
     dv: torch.Tensor,
     dbias: torch.Tensor,
     sm_scale: float,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     causal: bool,
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
     max_seqlen_q: int,
     max_seqlen_k: int,
     dropout_p: float,
-    philox_seed: Optional[int] = 0,
-    philox_offset: Optional[int] = 0,
-    descale_q: Optional[torch.Tensor] = None,
-    descale_k: Optional[torch.Tensor] = None,
-    descale_v: Optional[torch.Tensor] = None,
-    descale_do: Optional[torch.Tensor] = None,
-    USE_INT64_STRIDES: Optional[bool] = False,
-    config: Optional[Dict[str, any]] = None,
+    philox_seed: int | None = 0,
+    philox_offset: int | None = 0,
+    descale_q: torch.Tensor | None = None,
+    descale_k: torch.Tensor | None = None,
+    descale_v: torch.Tensor | None = None,
+    descale_do: torch.Tensor | None = None,
+    USE_INT64_STRIDES: bool | None = False,
+    config: dict[str, any] | None = None,
 ):
     """
     Flash Attention fused backward pass computing dQ, dK, dV in a single kernel using atomics.
@@ -119,12 +118,12 @@ def flash_attn_fused_backward(
             stride_descale_do_z,
         )
 
-    IS_VARLEN = True if cu_seqlens_q is not None else False
+    IS_VARLEN = cu_seqlens_q is not None
 
     # get strides and shape
     if IS_VARLEN:
         # Layout for q,k,v is thd ie [total tokens, num_head, head_dim]
-        batch, seqlen_q, num_q_heads, head_sz = (
+        batch, _seqlen_q, num_q_heads, head_sz = (
             len(cu_seqlens_q) - 1,
             max_seqlen_q,
             q.shape[1],
@@ -141,7 +140,7 @@ def flash_attn_fused_backward(
         do_strides = (0, do.stride(1), do.stride(0), do.stride(2))
     else:
         # Layout for q,k,v is bshd ie [batch, seq_len, num_head, head_dim]
-        batch, seqlen_q, num_q_heads, head_sz = q.shape
+        batch, _seqlen_q, num_q_heads, head_sz = q.shape
         _, num_k_heads = k.shape[1], k.shape[2]
         q_strides = (q.stride(0), q.stride(2), q.stride(1), q.stride(3))
         k_strides = (k.stride(0), k.stride(2), k.stride(1), k.stride(3))

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/mha_onekernel_bwd.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/mha_onekernel_bwd.py
@@ -1,19 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-from typing import Optional, Dict
 import torch
 import triton  # type: ignore
 import triton.language as tl  # type: ignore
-from .utils.types import _is_fp8
-from .utils.logger import AiterTritonLogger
 
 from ._kernels.mha_onekernel_bwd import (
     _bwd_preprocess,
+    _get_config,
     bwd_kernel_causal,
     bwd_kernel_noncausal,
-    _get_config,
 )
+from .utils.logger import AiterTritonLogger
+from .utils.types import _is_fp8
 
 _LOGGER = AiterTritonLogger()
 
@@ -38,23 +37,23 @@ def flash_attn_onekernel_backward(
     dv: torch.Tensor,
     dbias: torch.Tensor,
     sm_scale: float,
-    alibi_slopes: Optional[torch.Tensor],
+    alibi_slopes: torch.Tensor | None,
     causal: bool,
-    cu_seqlens_q: Optional[torch.Tensor],
-    cu_seqlens_k: Optional[torch.Tensor],
+    cu_seqlens_q: torch.Tensor | None,
+    cu_seqlens_k: torch.Tensor | None,
     max_seqlen_q: int,
     max_seqlen_k: int,
     dropout_p: float,
-    philox_seed: Optional[int] = 0,
-    philox_offset: Optional[int] = 0,
-    descale_q: Optional[torch.Tensor] = None,
-    descale_k: Optional[torch.Tensor] = None,
-    descale_v: Optional[torch.Tensor] = None,
-    descale_do: Optional[torch.Tensor] = None,
-    USE_INT64_STRIDES: Optional[bool] = False,
-    sink: Optional[torch.Tensor] = None,
-    dsink: Optional[torch.Tensor] = None,
-    config: Optional[Dict[str, any]] = None,
+    philox_seed: int | None = 0,
+    philox_offset: int | None = 0,
+    descale_q: torch.Tensor | None = None,
+    descale_k: torch.Tensor | None = None,
+    descale_v: torch.Tensor | None = None,
+    descale_do: torch.Tensor | None = None,
+    USE_INT64_STRIDES: bool | None = False,
+    sink: torch.Tensor | None = None,
+    dsink: torch.Tensor | None = None,
+    config: dict[str, any] | None = None,
     sliding_window: int = 0,
 ):
     """
@@ -133,14 +132,14 @@ def flash_attn_onekernel_backward(
             stride_descale_do_z,
         )
 
-    IS_VARLEN = True if cu_seqlens_q is not None else False
+    IS_VARLEN = cu_seqlens_q is not None
 
     # get strides and shape
     if IS_VARLEN:
         # Layout is thd.
         # q and k are [total_tokens, num_head, head_dim_qk].
         # v is [total_tokens, num_head, head_dim_v].
-        batch, seqlen_q, num_q_heads = (
+        batch, _seqlen_q, num_q_heads = (
             len(cu_seqlens_q) - 1,
             max_seqlen_q,
             q.shape[1],
@@ -159,7 +158,7 @@ def flash_attn_onekernel_backward(
         # Layout is bshd.
         # q and k are [batch, seq_len, num_head, head_dim_qk].
         # v is [batch, seq_len, num_head, head_dim_v]
-        batch, seqlen_q, num_q_heads = q.shape[:-1]
+        batch, _seqlen_q, num_q_heads = q.shape[:-1]
         _, num_k_heads = k.shape[1], k.shape[2]
         q_strides = (q.stride(0), q.stride(2), q.stride(1), q.stride(3))
         k_strides = (k.stride(0), k.stride(2), k.stride(1), k.stride(3))

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/_triton/arch_info.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/_triton/arch_info.py
@@ -40,3 +40,6 @@ def is_mx_scale_preshuffling_avail():
 
 def is_tdm_avail():
     return get_arch() in ("gfx1250",)
+
+
+_LDS_CAP_BYTES = {"gfx1250": 327680, "gfx950": 163840, "gfx942": 65536}

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/_triton/pid_preprocessing.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/_triton/pid_preprocessing.py
@@ -34,7 +34,8 @@ def remap_xcd(pid, GRID_MN, NUM_XCDS: tl.constexpr = 8):
     # We calculate the number of xcds that have pids_per_xcd pids as
     # tall_xcds
     tall_xcds = GRID_MN % NUM_XCDS
-    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    if tall_xcds == 0:
+        tall_xcds = tl.cast(NUM_XCDS, tall_xcds.type)
     # Compute current XCD and local pid within the XCD
     xcd = pid % NUM_XCDS
     local_pid = pid // NUM_XCDS

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/logger.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/logger.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 
 # AITER Triton Logger which is singleton object around python logging.
@@ -15,12 +15,12 @@ import logging
 #   ERROR
 #   CRITICAL
 #
-class AiterTritonLogger(object):
+class AiterTritonLogger:
     _instance = None
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(AiterTritonLogger, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
             log_level_str = os.getenv("AITER_TRITON_LOG_LEVEL", "WARNING").upper()
             numeric_level = getattr(logging, log_level_str, logging.WARNING)
             cls._instance._logger = logging.getLogger("AITER_TRITON")

--- a/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/types.py
+++ b/aiter-flash-attn/torch-ext/aiter_flash_attn/utils/types.py
@@ -1,5 +1,6 @@
 import torch
 import triton.language as tl
+
 from ._triton import arch_info
 
 


### PR DESCRIPTION
## What

Enables sliding-window attention on ROCm so SWA models ( Gemma3, Mistral, Qwen2 SWA, and
**gpt-oss** (SWA + attention sinks) ) work through the plain `flash_attn_func` / `flash_attn_varlen_func` paths `transformers` uses. Previously `window_size_right != -1` raised `ValueError: window_size_right is not supported yet`. fixes #1055.

## How

- **Re-vendored** `torch-ext/aiter_flash_attn/` from `ROCm/aiter@8a9186d`, bringing real SWA support incl. the sliding-window **backward** (aiter #3742) the old snapshot predated.
- **Per-call routing** in `mha.py` (forward + both backwards): under `causal` a right window is a no-op, so it's normalized to `-1` and stays on the default kernel (which supports left window **+ sinks**, so gpt-oss works); a *non-causal* right window auto-selects the `dao_ai` backend when compatible (no sink/PE/FP8).

## Testing

Real AMD **gfx942** (MI300-class): 12/12 pass; SWA forward, causal, varlen, **backward** vs SDPA, and gpt-oss-style causal SWA **+ sinks**. Numerics verified on gfx942 only.