### PR TITLE
activation: Add XPU backend to `kernels-community/activation`

### DIFF
--- a/activation/activation_xpu/activation_kernels.cpp
+++ b/activation/activation_xpu/activation_kernels.cpp
@@ -1,0 +1,422 @@
+#include <sycl/sycl.hpp>
+
+#include <ATen/ATen.h>
+#include <ATen/DeviceGuard.h>
+#include <ATen/Dispatch.h>
+#include <c10/xpu/XPUStream.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstdint>
+
+#include "activation_xpu.hpp"
+
+namespace activation_xpu {
+
+namespace {
+
+// Aligned pack of `vec_size` elements, used to widen global memory accesses so
+// that a single work item issues one wide load/store instead of several narrow
+// ones. `sycl::vec` cannot be used here because `at::Half` and `at::BFloat16`
+// are not valid SYCL vector element types.
+template <typename scalar_t, int vec_size>
+struct alignas(sizeof(scalar_t) * vec_size) AlignedVec {
+  scalar_t val[vec_size];
+};
+
+// Widest access that is still a natural vector width on Intel GPUs (128 bit).
+template <typename scalar_t>
+constexpr int kVecSize = 16 / sizeof(scalar_t);
+
+bool is_vec_aligned(const void* ptr, int64_t bytes) {
+  return reinterpret_cast<uintptr_t>(ptr) % bytes == 0;
+}
+
+// Activation and gating kernel. Each work-group handles one token, the work
+// items in the group stride over the `d` elements of that token.
+template <typename scalar_t, typename act_fn_t, bool act_first>
+struct ActAndMulKernel {
+  ActAndMulKernel(scalar_t* out, const scalar_t* input, int64_t d,
+                  act_fn_t act_fn)
+      : out_(out), input_(input), d_(d), act_fn_(act_fn) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int64_t token_idx = item.get_group(0);
+    const int64_t local_size = item.get_local_range(0);
+    const scalar_t* input_row = input_ + token_idx * 2 * d_;
+    scalar_t* out_row = out_ + token_idx * d_;
+    for (int64_t idx = item.get_local_id(0); idx < d_; idx += local_size) {
+      const scalar_t x = input_row[idx];
+      const scalar_t y = input_row[d_ + idx];
+      out_row[idx] = act_first ? act_fn_(x) * y : x * act_fn_(y);
+    }
+  }
+
+ private:
+  scalar_t* out_;
+  const scalar_t* input_;
+  int64_t d_;
+  act_fn_t act_fn_;
+};
+
+// Vectorized variant of `ActAndMulKernel`, used when `d` is a multiple of the
+// vector width and both halves of the input row are suitably aligned.
+template <typename scalar_t, typename act_fn_t, bool act_first, int vec_size>
+struct ActAndMulVecKernel {
+  using vec_t = AlignedVec<scalar_t, vec_size>;
+
+  ActAndMulVecKernel(scalar_t* out, const scalar_t* input, int64_t d,
+                     act_fn_t act_fn)
+      : out_(out), input_(input), d_(d), act_fn_(act_fn) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int64_t token_idx = item.get_group(0);
+    const int64_t local_size = item.get_local_range(0);
+    const int64_t d_vec = d_ / vec_size;
+    const vec_t* input_row =
+        reinterpret_cast<const vec_t*>(input_ + token_idx * 2 * d_);
+    vec_t* out_row = reinterpret_cast<vec_t*>(out_ + token_idx * d_);
+    for (int64_t idx = item.get_local_id(0); idx < d_vec; idx += local_size) {
+      const vec_t x = input_row[idx];
+      const vec_t y = input_row[d_vec + idx];
+      vec_t result;
+#pragma unroll
+      for (int i = 0; i < vec_size; ++i) {
+        result.val[i] = act_first ? act_fn_(x.val[i]) * y.val[i]
+                                  : x.val[i] * act_fn_(y.val[i]);
+      }
+      out_row[idx] = result;
+    }
+  }
+
+ private:
+  scalar_t* out_;
+  const scalar_t* input_;
+  int64_t d_;
+  act_fn_t act_fn_;
+};
+
+// Element-wise activation kernel. The tensor is treated as flat, work items
+// stride over the whole element range.
+template <typename scalar_t, typename act_fn_t>
+struct ActivationKernel {
+  ActivationKernel(scalar_t* out, const scalar_t* input, int64_t numel,
+                   act_fn_t act_fn)
+      : out_(out), input_(input), numel_(numel), act_fn_(act_fn) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int64_t stride = item.get_global_range(0);
+    for (int64_t idx = item.get_global_id(0); idx < numel_; idx += stride) {
+      out_[idx] = act_fn_(input_[idx]);
+    }
+  }
+
+ private:
+  scalar_t* out_;
+  const scalar_t* input_;
+  int64_t numel_;
+  act_fn_t act_fn_;
+};
+
+// Vectorized variant of `ActivationKernel`.
+template <typename scalar_t, typename act_fn_t, int vec_size>
+struct ActivationVecKernel {
+  using vec_t = AlignedVec<scalar_t, vec_size>;
+
+  ActivationVecKernel(scalar_t* out, const scalar_t* input, int64_t num_vec,
+                      act_fn_t act_fn)
+      : out_(reinterpret_cast<vec_t*>(out)),
+        input_(reinterpret_cast<const vec_t*>(input)),
+        num_vec_(num_vec),
+        act_fn_(act_fn) {}
+
+  void operator()(sycl::nd_item<1> item) const {
+    const int64_t stride = item.get_global_range(0);
+    for (int64_t idx = item.get_global_id(0); idx < num_vec_; idx += stride) {
+      const vec_t x = input_[idx];
+      vec_t result;
+#pragma unroll
+      for (int i = 0; i < vec_size; ++i) {
+        result.val[i] = act_fn_(x.val[i]);
+      }
+      out_[idx] = result;
+    }
+  }
+
+ private:
+  vec_t* out_;
+  const vec_t* input_;
+  int64_t num_vec_;
+  act_fn_t act_fn_;
+};
+
+// Function objects are used instead of function pointers, since taking the
+// address of a function is not supported in SYCL device code.
+//
+// The functors take and return `scalar_t` so that each of them controls where
+// intermediate results are rounded. Most compute in `float` throughout, but
+// `gelu_new` and `gelu_fast` deliberately round intermediates to `scalar_t`,
+// matching the CUDA implementation so that results stay consistent across
+// backends.
+template <typename scalar_t>
+struct SiluFn {
+  scalar_t operator()(scalar_t x) const {
+    const float f = static_cast<float>(x);
+    return static_cast<scalar_t>(f / (1.0f + sycl::exp(-f)));
+  }
+};
+
+template <typename scalar_t>
+struct GeluFn {
+  // Equivalent to PyTorch GELU with 'none' approximation.
+  scalar_t operator()(scalar_t x) const {
+    constexpr float kAlpha = M_SQRT1_2;
+    const float f = static_cast<float>(x);
+    return static_cast<scalar_t>(f * 0.5f * (1.0f + sycl::erf(f * kAlpha)));
+  }
+};
+
+template <typename scalar_t>
+struct GeluTanhFn {
+  // Equivalent to PyTorch GELU with 'tanh' approximation.
+  scalar_t operator()(scalar_t x) const {
+    constexpr float kBeta = M_SQRT2 * M_2_SQRTPI * 0.5f;
+    constexpr float kKappa = 0.044715f;
+    const float f = static_cast<float>(x);
+    const float x_cube = f * f * f;
+    const float inner = kBeta * (f + kKappa * x_cube);
+    return static_cast<scalar_t>(0.5f * f * (1.0f + sycl::tanh(inner)));
+  }
+};
+
+template <typename scalar_t>
+struct GeluNewFn {
+  scalar_t operator()(scalar_t x) const {
+    const float x_cube = static_cast<float>(x * x * x);
+    const scalar_t inner = static_cast<scalar_t>(
+        0.79788456f *
+        static_cast<float>(x + static_cast<scalar_t>(0.044715f * x_cube)));
+    const scalar_t t =
+        static_cast<scalar_t>(sycl::tanh(static_cast<float>(inner)));
+    return static_cast<scalar_t>(0.5f) * x * (static_cast<scalar_t>(1.0f) + t);
+  }
+};
+
+template <typename scalar_t>
+struct GeluFastFn {
+  scalar_t operator()(scalar_t x) const {
+    const float f = static_cast<float>(x);
+    const scalar_t inner = static_cast<scalar_t>(f * 0.79788456f) *
+                           (static_cast<scalar_t>(1.0f) +
+                            static_cast<scalar_t>(0.044715f * f) * x);
+    const scalar_t t =
+        static_cast<scalar_t>(sycl::tanh(static_cast<float>(inner)));
+    return static_cast<scalar_t>(0.5f) * x * (static_cast<scalar_t>(1.0f) + t);
+  }
+};
+
+template <typename scalar_t>
+struct GeluQuickFn {
+  // x * sigmoid(1.702 * x)
+  scalar_t operator()(scalar_t x) const {
+    const float f = static_cast<float>(x);
+    return static_cast<scalar_t>(f / (1.0f + sycl::exp(-1.702f * f)));
+  }
+};
+
+template <typename scalar_t>
+struct FatreluFn {
+  explicit FatreluFn(float threshold) : threshold_(threshold) {}
+
+  scalar_t operator()(scalar_t x) const {
+    const float f = static_cast<float>(x);
+    return static_cast<scalar_t>(f > threshold_ ? f : 0.0f);
+  }
+
+ private:
+  float threshold_;
+};
+
+int64_t work_group_size(const sycl::queue& queue, int64_t d) {
+  const int64_t max_work_group_size =
+      queue.get_device().get_info<sycl::info::device::max_work_group_size>();
+  return std::max<int64_t>(1, std::min<int64_t>(d, max_work_group_size));
+}
+
+// Number of work-groups that saturates the device, used to size the grid of
+// the flat element-wise kernel.
+int64_t max_work_groups(sycl::queue& queue) {
+  const int64_t compute_units =
+      queue.get_device().get_info<sycl::info::device::max_compute_units>();
+  return std::max<int64_t>(1, compute_units * 32);
+}
+
+void check_act_and_mul_inputs(const torch::Tensor& out,
+                              const torch::Tensor& input) {
+  TORCH_CHECK(input.device().is_xpu(), "input must be an XPU tensor");
+  TORCH_CHECK(out.device() == input.device(),
+              "out and input must be on the same device");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(out.scalar_type() == input.scalar_type(),
+              "out and input must have the same dtype");
+  TORCH_CHECK(input.size(-1) % 2 == 0,
+              "the last dimension of input must be even");
+  TORCH_CHECK(out.size(-1) == input.size(-1) / 2,
+              "the last dimension of out must be half of that of input");
+}
+
+void check_activation_inputs(const torch::Tensor& out,
+                             const torch::Tensor& input) {
+  TORCH_CHECK(input.device().is_xpu(), "input must be an XPU tensor");
+  TORCH_CHECK(out.device() == input.device(),
+              "out and input must be on the same device");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+  TORCH_CHECK(out.scalar_type() == input.scalar_type(),
+              "out and input must have the same dtype");
+  TORCH_CHECK(out.sizes() == input.sizes(),
+              "out and input must have the same shape");
+}
+
+template <bool act_first, template <typename> class ActFn, typename... Args>
+void launch_act_and_mul(torch::Tensor& out, const torch::Tensor& input,
+                        Args... args) {
+  check_act_and_mul_inputs(out, input);
+
+  const int64_t d = input.size(-1) / 2;
+  const int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0 || d == 0) {
+    return;
+  }
+
+  const at::OptionalDeviceGuard device_guard(at::device_of(input));
+  sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
+                                  input.scalar_type(), "act_and_mul_kernel_xpu",
+                                  [&] {
+    using act_fn_t = ActFn<scalar_t>;
+    const act_fn_t act_fn(args...);
+    constexpr int vec_size = kVecSize<scalar_t>;
+    constexpr int64_t vec_bytes = sizeof(scalar_t) * vec_size;
+    scalar_t* out_ptr = out.data_ptr<scalar_t>();
+    const scalar_t* input_ptr = input.const_data_ptr<scalar_t>();
+
+    const bool vectorize = d % vec_size == 0 &&
+                           is_vec_aligned(out_ptr, vec_bytes) &&
+                           is_vec_aligned(input_ptr, vec_bytes);
+
+    if (vectorize) {
+      const int64_t local_size = work_group_size(queue, d / vec_size);
+      queue.parallel_for(
+          sycl::nd_range<1>(sycl::range<1>(num_tokens * local_size),
+                            sycl::range<1>(local_size)),
+          ActAndMulVecKernel<scalar_t, act_fn_t, act_first, vec_size>(
+              out_ptr, input_ptr, d, act_fn));
+    } else {
+      const int64_t local_size = work_group_size(queue, d);
+      queue.parallel_for(
+          sycl::nd_range<1>(sycl::range<1>(num_tokens * local_size),
+                            sycl::range<1>(local_size)),
+          ActAndMulKernel<scalar_t, act_fn_t, act_first>(out_ptr, input_ptr, d,
+                                                         act_fn));
+    }
+  });
+}
+
+template <template <typename> class ActFn, typename... Args>
+void launch_activation(torch::Tensor& out, const torch::Tensor& input,
+                       Args... args) {
+  check_activation_inputs(out, input);
+
+  const int64_t numel = input.numel();
+  if (numel == 0) {
+    return;
+  }
+
+  const at::OptionalDeviceGuard device_guard(at::device_of(input));
+  sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16,
+                                  input.scalar_type(), "activation_kernel_xpu",
+                                  [&] {
+    using act_fn_t = ActFn<scalar_t>;
+    const act_fn_t act_fn(args...);
+    constexpr int vec_size = kVecSize<scalar_t>;
+    constexpr int64_t vec_bytes = sizeof(scalar_t) * vec_size;
+    scalar_t* out_ptr = out.data_ptr<scalar_t>();
+    const scalar_t* input_ptr = input.const_data_ptr<scalar_t>();
+
+    const bool vectorize = numel % vec_size == 0 &&
+                           is_vec_aligned(out_ptr, vec_bytes) &&
+                           is_vec_aligned(input_ptr, vec_bytes);
+
+    const int64_t work_items = vectorize ? numel / vec_size : numel;
+    const int64_t local_size = work_group_size(queue, work_items);
+    const int64_t num_groups =
+        std::min<int64_t>((work_items + local_size - 1) / local_size,
+                          max_work_groups(queue));
+    const sycl::nd_range<1> range(sycl::range<1>(num_groups * local_size),
+                                  sycl::range<1>(local_size));
+
+    if (vectorize) {
+      queue.parallel_for(
+          range, ActivationVecKernel<scalar_t, act_fn_t, vec_size>(
+                     out_ptr, input_ptr, work_items, act_fn));
+    } else {
+      queue.parallel_for(range, ActivationKernel<scalar_t, act_fn_t>(
+                                    out_ptr, input_ptr, numel, act_fn));
+    }
+  });
+}
+
+}  // namespace
+
+void silu_and_mul(torch::Tensor& out, const torch::Tensor& input) {
+  launch_act_and_mul<true, SiluFn>(out, input);
+}
+
+void mul_and_silu(torch::Tensor& out, const torch::Tensor& input) {
+  launch_act_and_mul<false, SiluFn>(out, input);
+}
+
+void gelu_and_mul(torch::Tensor& out, const torch::Tensor& input) {
+  launch_act_and_mul<true, GeluFn>(out, input);
+}
+
+void gelu_tanh_and_mul(torch::Tensor& out, const torch::Tensor& input) {
+  launch_act_and_mul<true, GeluTanhFn>(out, input);
+}
+
+void fatrelu_and_mul(torch::Tensor& out, const torch::Tensor& input,
+                     double threshold) {
+  launch_act_and_mul<true, FatreluFn>(out, input,
+                                      static_cast<float>(threshold));
+}
+
+void gelu_new(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<GeluNewFn>(out, input);
+}
+
+void gelu_fast(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<GeluFastFn>(out, input);
+}
+
+void gelu_quick(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<GeluQuickFn>(out, input);
+}
+
+void gelu(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<GeluFn>(out, input);
+}
+
+void gelu_tanh(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<GeluTanhFn>(out, input);
+}
+
+void silu(torch::Tensor& out, const torch::Tensor& input) {
+  launch_activation<SiluFn>(out, input);
+}
+
+}  // namespace activation_xpu

--- a/activation/activation_xpu/activation_xpu.hpp
+++ b/activation/activation_xpu/activation_xpu.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace activation_xpu {
+
+void silu_and_mul(torch::Tensor& out, const torch::Tensor& input);
+
+void mul_and_silu(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu_and_mul(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu_tanh_and_mul(torch::Tensor& out, const torch::Tensor& input);
+
+void fatrelu_and_mul(torch::Tensor& out, const torch::Tensor& input,
+                     double threshold);
+
+void gelu_new(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu_fast(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu_quick(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu(torch::Tensor& out, const torch::Tensor& input);
+
+void gelu_tanh(torch::Tensor& out, const torch::Tensor& input);
+
+void silu(torch::Tensor& out, const torch::Tensor& input);
+
+}  // namespace activation_xpu

--- a/activation/activation_xpu/activation_xpu_torch.cpp
+++ b/activation/activation_xpu/activation_xpu_torch.cpp
@@ -1,0 +1,52 @@
+#include <torch/all.h>
+
+#include "activation_xpu.hpp"
+
+// Global entry points referenced by torch-ext/torch_binding.cpp for the XPU
+// backend. They forward to the SYCL implementations, which perform the shape
+// and device validation.
+
+void silu_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::silu_and_mul(out, input);
+}
+
+void mul_and_silu(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::mul_and_silu(out, input);
+}
+
+void gelu_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_and_mul(out, input);
+}
+
+void gelu_tanh_and_mul(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_tanh_and_mul(out, input);
+}
+
+void fatrelu_and_mul(torch::Tensor &out, torch::Tensor &input,
+                     double threshold) {
+  activation_xpu::fatrelu_and_mul(out, input, threshold);
+}
+
+void gelu_new(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_new(out, input);
+}
+
+void gelu_fast(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_fast(out, input);
+}
+
+void gelu_quick(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_quick(out, input);
+}
+
+void gelu_tanh(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu_tanh(out, input);
+}
+
+void silu(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::silu(out, input);
+}
+
+void gelu(torch::Tensor &out, torch::Tensor &input) {
+  activation_xpu::gelu(out, input);
+}

--- a/activation/build.toml
+++ b/activation/build.toml
@@ -8,6 +8,7 @@ backends = [
     "metal",
     "cpu",
     "rocm",
+    "xpu",
 ]
 
 [general.hub]
@@ -29,6 +30,16 @@ depends = ["torch"]
 src = [
     "activation_metal/activation.mm",
     "activation_metal/activation.metal",
+]
+
+[kernel.activation_xpu]
+backend = "xpu"
+depends = ["torch"]
+include = ["activation_xpu"]
+src = [
+    "activation_xpu/activation_kernels.cpp",
+    "activation_xpu/activation_xpu_torch.cpp",
+    "activation_xpu/activation_xpu.hpp",
 ]
 
 [kernel.activation]

--- a/activation/tests/kernels/test_activation.py
+++ b/activation/tests/kernels/test_activation.py
@@ -17,7 +17,19 @@ DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [7, 83, 2048]  # Arbitrary values for testing
 D = [512, 13824]  # Arbitrary values for testing
 SEEDS = [0]
-CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
+
+
+def _devices() -> list[str]:
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        name, count = "xpu", torch.xpu.device_count()
+    elif torch.cuda.is_available():
+        name, count = "cuda", torch.cuda.device_count()
+    else:
+        return ["cpu"]
+    return [f"{name}:{i}" for i in range(1 if count == 1 else 2)]
+
+
+DEVICES = _devices()
 
 
 def gelu_fast(x: torch.Tensor) -> torch.Tensor:
@@ -71,7 +83,7 @@ def silu(x: torch.Tensor) -> torch.Tensor:
 @pytest.mark.parametrize("d", D)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("device", DEVICES)
 @torch.inference_mode()
 def test_act_and_mul(
     activation_name: str,
@@ -177,7 +189,7 @@ def test_act_and_mul(
 @pytest.mark.parametrize("d", D)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("device", DEVICES)
 @torch.inference_mode()
 def test_activation(
     activation_fns,
@@ -204,3 +216,33 @@ def test_activation(
 
     out = torch.empty_like(x)
     opcheck(op, (out, x))
+
+
+# The shapes above are all vector-width multiples over naturally aligned
+# storage; these are neither, so a vectorized backend must take its scalar path.
+@pytest.mark.parametrize("d", [1, 13, 4097])
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_act_and_mul_unaligned(d: int, dtype: torch.dtype, device: str) -> None:
+    torch.manual_seed(0)
+    torch.set_default_device(device)
+    num_tokens = 5
+    base = torch.randn(num_tokens * 2 * d + 1, dtype=dtype)
+    x = base[1:].view(num_tokens, 2 * d)
+
+    out = torch.empty(num_tokens, d, dtype=dtype)
+    out = activation.silu_and_mul(out, x)
+
+    torch.testing.assert_close(out, silu_and_mul(x), atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("device", DEVICES)
+@torch.inference_mode()
+def test_empty_input(dtype: torch.dtype, device: str) -> None:
+    torch.set_default_device(device)
+    x = torch.empty(0, 128, dtype=dtype)
+
+    assert activation.silu_and_mul(torch.empty(0, 64, dtype=dtype), x).shape == (0, 64)
+    assert activation.silu(torch.empty(0, 128, dtype=dtype), x).shape == (0, 128)

--- a/activation/torch-ext/torch_binding.cpp
+++ b/activation/torch-ext/torch_binding.cpp
@@ -67,6 +67,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("silu_and_mul", torch::kMPS, &silu_and_mul);
+#elif defined(XPU_KERNEL)
+  ops.impl("silu_and_mul", torch::kXPU, &silu_and_mul);
 #elif defined(CPU_KERNEL)
   ops.impl("silu_and_mul", torch::kCPU, &silu_and_mul);
 #endif
@@ -74,60 +76,80 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("mul_and_silu", torch::kMPS, &mul_and_silu);
+#elif defined(XPU_KERNEL)
+  ops.impl("mul_and_silu", torch::kXPU, &mul_and_silu);
 #endif
 
   // Activation function used in GeGLU with `none` approximation.
   ops.def("gelu_and_mul(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_and_mul", torch::kMPS, &gelu_and_mul);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_and_mul", torch::kXPU, &gelu_and_mul);
 #endif
 
   // Activation function used in GeGLU with `tanh` approximation.
   ops.def("gelu_tanh_and_mul(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_tanh_and_mul", torch::kMPS, &gelu_tanh_and_mul);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_tanh_and_mul", torch::kXPU, &gelu_tanh_and_mul);
 #endif
 
   // FATReLU implementation.
   ops.def("fatrelu_and_mul(Tensor! out, Tensor input, float threshold) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("fatrelu_and_mul", torch::kMPS, &fatrelu_and_mul);
+#elif defined(XPU_KERNEL)
+  ops.impl("fatrelu_and_mul", torch::kXPU, &fatrelu_and_mul);
 #endif
 
   // GELU implementation used in GPT-2.
   ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_new", torch::kMPS, &gelu_new);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_new", torch::kXPU, &gelu_new);
 #endif
 
   // Approximate GELU implementation.
   ops.def("gelu_fast(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_fast", torch::kMPS, &gelu_fast);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_fast", torch::kXPU, &gelu_fast);
 #endif
 
   // Quick GELU implementation.
   ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_quick", torch::kMPS, &gelu_quick);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_quick", torch::kXPU, &gelu_quick);
 #endif
 
   // GELU with `tanh` approximation.
   ops.def("gelu_tanh(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu_tanh", torch::kMPS, &gelu_tanh);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu_tanh", torch::kXPU, &gelu_tanh);
 #endif
 
   // SiLU implementation.
   ops.def("silu(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("silu", torch::kMPS, &silu);
+#elif defined(XPU_KERNEL)
+  ops.impl("silu", torch::kXPU, &silu);
 #endif
 
   // GELU with none approximation.
   ops.def("gelu(Tensor! out, Tensor input) -> ()");
 #if defined(METAL_KERNEL)
   ops.impl("gelu", torch::kMPS, &gelu);
+#elif defined(XPU_KERNEL)
+  ops.impl("gelu", torch::kXPU, &gelu);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Adds a SYCL implementation of the `activation` kernels so the component can be
used on Intel GPUs. All eleven operators exposed by the CUDA backend are
implemented and registered under the `XPU` dispatch key, so existing callers
work unchanged on XPU devices.

Previously `activation` declared only `cuda`, `rocm`, `metal` and `cpu`. On XPU
the kernel could not be loaded at all, forcing every consumer to carry a
separate eager fallback path.

Operators: `silu_and_mul`, `mul_and_silu`, `gelu_and_mul`, `gelu_tanh_and_mul`,
`fatrelu_and_mul`, `gelu_new`, `gelu_fast`, `gelu_quick`, `silu`, `gelu`,
`gelu_tanh`. Supported dtypes: `float32`, `float16`, `bfloat16`.

New sources live in `activation_xpu/`, following the layout of the existing CPU
backend. `tests/kernels/test_activation.py` is parameterized over the available
accelerator instead of hard-coding CUDA, so the existing suite runs unmodified
on XPU.

Depends on huggingface/kernels#752, which makes `kernel-builder` request IEEE
correctly rounded fp32 division for SYCL kernels.

## Correctness

Validated on Intel Arc Pro B60 with `torch 2.13.0+xpu` and oneAPI 2026.0.

The existing `tests/kernels/test_activation.py` passes in full on XPU (420
cases), including the gated operators that are compared against eager PyTorch
bit-for-bit with zero tolerance. Two cases were added to that file, covering
shapes and alignments that force a vectorized backend onto its scalar path, and
empty inputs. Both are device-parameterized like the rest of the suite.

## Performance

Measured on one Intel Arc Pro B60. Speedup is eager time divided by kernel time;
values above 1.00 favour the kernel. Gated operators use a `16384 x 16384`
input, element-wise operators `16384 x 8192`; the `4096` columns are the same
measurement at `4096 x 8192` and `4096 x 4096`.

| Operator | fp16 | bf16 | fp32 | fp16 (4096) | bf16 (4096) | fp32 (4096) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `silu_and_mul` | 1.66x | 1.66x | 1.68x | 1.80x | 1.67x | 1.67x |
| `mul_and_silu` | 1.66x | 1.66x | 1.68x | 1.66x | 1.67x | 1.67x |
| `gelu_and_mul` | 1.66x | 1.66x | 1.67x | 1.68x | 1.67x | 1.67x |
| `gelu_tanh_and_mul` | 1.87x | 1.64x | 1.71x | 1.97x | 1.69x | 1.72x |
| `fatrelu_and_mul` | 3.37x | 3.55x | 2.23x | 3.40x | 3.62x | 2.23x |
| `gelu_new` | 5.40x | 3.86x | 9.05x | 5.19x | 3.73x | 8.53x |
| `gelu_fast` | 6.20x | 4.48x | 10.51x | 6.01x | 4.35x | 10.00x |
| `gelu_quick` | 3.44x | 3.47x | 3.42x | 3.54x | 3.52x | 3.49x |
| `silu` | 0.98x | 0.99x | 0.98x | 1.02x | 1.00x | 1.00x |
| `gelu` | 0.98x | 0.99x | 0.97x | 1.01x | 1.01x | 1.00x |
| `gelu_tanh` | 1.18x | 1.05x | 1.02x | 1.15x | 1.01x | 0.95x |

Three regimes are visible:

* **Gated operators** avoid two `[n, d]` intermediates and cut memory traffic
  from `6nd` to `3nd`. `fatrelu_and_mul` gains more because its eager form
  additionally materializes a boolean mask.
* **Composite activations** have no native PyTorch operator and expand into
  eight or more element-wise launches in eager mode, so fusing them gives the
  largest speedups.
* **Single-operator activations** read and write the same amount of data as the
  corresponding PyTorch operator and are therefore on par with it. They exist
  for interface completeness, so callers need no device-dependent branch.

### Memory

Peak memory allocated while producing the result, via
`torch.xpu.max_memory_allocated`. The output tensor is included and the input
excluded, so both paths are charged for what they produce. The ratio is
independent of dtype and shape; absolute figures are `float16` at
`16384 x 16384` (gated) and `16384 x 8192` (element-wise).

| Operator | eager | kernel | reduction |
| --- | ---: | ---: | ---: |
| `silu_and_mul`, `mul_and_silu`, `gelu_and_mul`, `gelu_tanh_and_mul`, `fatrelu_and_mul` | 512 MiB | 256 MiB | 2.00x |
| `gelu_quick` | 512 MiB | 256 MiB | 2.00x |
| `gelu_new` | 768 MiB | 256 MiB | 3.00x |
| `gelu_fast` | 1024 MiB | 256 MiB | 4.00x |
| `silu`, `gelu`, `gelu_tanh` | 256 MiB | 256 MiB | 1.00x |

The fused kernels never allocate beyond the output tensor. Eager `gelu_fast`
peaks at four times that because three intermediates are live simultaneously.

## Build

Both XPU variants offered by `kernel-builder` build cleanly and pass the
`manylinux_2_28` and Python `abi3` compatibility checks:

```
nix build '.#redistributable.torch213-cxx11-xpu20260-x86_64-linux'
nix build '.#redistributable.torch212-cxx11-xpu20253-x86_64-linux'
```

## Limitations

* Inputs must be contiguous, matching the CUDA backend.
