### PR TITLE
megablocks: run native MXFP4 experts through the XPU grouped GEMM

### DIFF
--- a/megablocks/torch-ext/megablocks/xpu_fused_moe.py
+++ b/megablocks/torch-ext/megablocks/xpu_fused_moe.py
@@ -529,6 +529,30 @@ def _get_device_mesh(model):
         return None
 
 
+def _mxfp4_expert_tensors(experts, dtype):
+    """View transformers' MXFP4 experts as the tensors the SYCL grouped GEMM expects.
+
+    Weights and scales arrive wrapped in triton tensors. On XPU both use StridedLayout,
+    whose swizzle is the identity, so `storage.data` is still the checkpoint tensor - just
+    transposed to [E, K/2, N]. Transposing back therefore restores the original contiguous
+    [E, N, K/2] weights and [E, N, K/32] E8M0 scales as plain views: `contiguous()` finds
+    them already contiguous and returns them untouched, so this costs no copy and no extra
+    memory. The experts module is left alone, which keeps the triton tensors and the
+    PrecisionConfig that `save_pretrained` needs to re-serialize the checkpoint.
+    """
+    tensors = []
+    for proj in ("gate_up_proj", "down_proj"):
+        config = getattr(experts, f"{proj}_precision_config")
+        tensors.append(getattr(experts, proj).storage.data.transpose(-1, -2).contiguous())
+        tensors.append(config.weight_scale.storage.data.transpose(-1, -2).contiguous())
+
+        # The GEMM reads the bias as ElementA; `to` is a no-op when it already matches.
+        bias = getattr(experts, f"{proj}_bias", None)
+        tensors.append(None if bias is None else bias.data.to(dtype))
+
+    return tensors
+
+
 class MegaBlocksMoeMLP(torch.nn.Module):
     can_torch_compile: bool = True
         
@@ -612,7 +636,18 @@ class MegaBlocksMoeMLP(torch.nn.Module):
         
         w13_scales = getattr(self.experts, "gate_up_proj_scales", None)
         w2_scales = getattr(self.experts, "down_proj_scales", None)
-        
+
+        # Native MXFP4 checkpoint: derive the GEMM's view of the experts once and cache it.
+        mxfp4 = getattr(self, "_mxfp4_tensors", None)
+        if (mxfp4 is None or mxfp4[0] is not x.dtype) and getattr(
+            self.experts, "gate_up_proj_precision_config", None
+        ) is not None:
+            mxfp4 = (x.dtype, *_mxfp4_expert_tensors(self.experts, x.dtype))
+            self._mxfp4_tensors = mxfp4
+        if mxfp4 is not None:
+            _, w13, w13_scales, w13_bias, w2, w2_scales, w2_bias = mxfp4
+            is_mxfp4 = True
+
         # Store original shape
         in_shape = x.size()
         


### PR DESCRIPTION
## Summary

The XPU grouped GEMM already has an MXFP4 path, but it was unreachable from
transformers: a GPT-OSS checkpoint loaded with `Mxfp4Config(dequantize=False)`
hands the experts over as triton wrapper tensors plus a `PrecisionConfig`, which
`MegaBlocksMoeMLP` did not recognise. This teaches the layer to read that
representation.

## Why the conversion is free

On XPU, `make_default_matmul_mxfp4_w_layout` falls through to `StridedLayout`,
whose `swizzle_data` is the identity, and `Storage` only holds a reference. The
tensor transformers swizzles is `blocks.contiguous().transpose(-2, -1)`, so
`storage.data` is still the checkpoint tensor, merely viewed transposed.

Transposing it back therefore yields the original contiguous `[E, N, K/2]`
weights and `[E, N, K/32]` E8M0 scales — exactly what the GEMM expects — as
plain views. No data is copied or reordered.

## Why it does not rewrite the module

The CPU path repacks the experts in place because `brgemm` needs a private
layout. XPU does not, so this leaves the module alone: `gate_up_proj` stays a
triton tensor and `<proj>_precision_config` stays alive, which keeps
`Mxfp4ReverseDeserialize` working and lets a model still be saved after a
forward pass.

The one allocation is the bias, which the GEMM reads as `ElementA` while the
checkpoint stores it in fp32. Casting it in place would be cheaper but would
silently downgrade the precision of any subsequently saved checkpoint.

## Validation

GPT-OSS on Intel Arc Pro B60, `torch 2.13.0+xpu`, against the triton
`matmul_ogs` path on the same card and checkpoint:

| | speedup |
| --- | ---: |
| MoE prefill | ~9x |
| end to end, 128 in / 32 out | ~2x |

Output matches the dequantized bf16 path. Weight and scale storage pointers are
identical to the ones transformers set up on every layer; memory growth across
the first forward accounts for the bias cast and nothing else, and a second
forward grows by zero.

## Dependencies

Pairs with a transformers change that stops forcing dequantization on XPU when
`use_kernels` is set. That change needs a `megablocks` build carrying this
commit published on the Hub before it takes effect.
