### PR TITLE
triton-kernels: make matmul_ogs_torch usable off CUDA and with default round_x

### DIFF
--- a/triton-kernels/torch-ext/triton_kernels/matmul_ogs.py
+++ b/triton-kernels/torch-ext/triton_kernels/matmul_ogs.py
@@ -602,18 +602,20 @@ def matmul_ogs_torch(x, w, bias,
                  betas = None,
                  gammas = None,
                  round_x = None, round_y = None,
-                 device: str = "cuda",
+                 device: str | torch.device | None = None,
                  ):
     is_input_batched = x.ndim == 3
     assert x.dtype.itemsize > 1
     assert w.dtype.itemsize > 1
+    if device is None:
+        device = x.device
     if is_input_batched:
         assert gather_indx is None, "gather not supported in batched mode"
         assert scatter_indx is None, "scatter not supported in batched mode"
         assert routing_data is None, "routing not supported in batched mode"
         assert w.ndim == 3 and w.shape[0] == x.shape[0]
     if round_x is None:
-        round_x = lambda x: x
+        round_x = lambda x, idx: x
     if round_y is None:
         round_y = lambda x: x
     if bias.ndim == 1:


### PR DESCRIPTION
## Summary

Two bugs in the reference implementation, both hit with the documented defaults:

- `device` defaulted to the string `"cuda"`, so the internal
  `torch.arange(lo, hi, device=device)` raised "Torch not compiled with CUDA
  enabled" on a build without CUDA. Default to `x.device`, which is the same
  device on CUDA and therefore a no-op there. The annotation is widened to
  match what the parameter now accepts.

- the fallback `round_x = lambda x: x` takes one argument, but the call site
  passes two (`round_x(x[batch, idx, :], torch.arange(lo, hi))`), so any caller
  that does not supply `round_x` got a `TypeError` regardless of backend.

## Validation

`matmul_ogs_torch` now runs with defaults and is usable as a reference to check
`matmul_ogs` against. Checked on Intel Arc Pro B60, `torch 2.13.0+xpu`; the
`round_x` arity bug is backend independent.
