### PR TITLE
Accumulate tiled MLP weight grads once per backward

### DIFF
--- a/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
+++ b/liger-kernels/torch-ext/liger_kernels/tiled_mlp.py
@@ -10,6 +10,27 @@ import torch.distributed as dist
 from .utils import ensure_contiguous
 
 
+def _autograd_input_params(
+    compute_params: Optional[List[torch.nn.Parameter]],
+) -> List[torch.nn.Parameter]:
+    """The weights to pass to the autograd Function as explicit inputs.
+
+    Doing so makes autograd accumulate each weight once, at the end of the backward, instead of once
+    per shard. DDP registers one hook per parameter and marks it ready on every firing, so the
+    per-shard accumulation would trip "Expected to mark a variable ready only once".
+
+    Returns an empty list under ZeRO-3: partitioned weights are 0-sized placeholders outside their
+    owning module's forward, so autograd would record ``(0,)`` as the expected gradient shape and the
+    recompute would fail. Those stay on the accumulate-into-``.grad`` path, where the reduction is
+    deferred to the last shard via ``ds_grad_is_ready``.
+    """
+    if not compute_params:
+        return []
+    if any(hasattr(p, "ds_id") for p in compute_params):
+        return []
+    return [p for p in compute_params if p.requires_grad]
+
+
 class LigerTiledMLPFunction(torch.autograd.Function):
     """
     Based on DeepSpeed's TiledMLP:
@@ -41,11 +62,15 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         x: torch.Tensor,
         shards: int,
         compute_params: Optional[List[torch.nn.Parameter]] = None,
+        *params: torch.Tensor,
     ) -> torch.Tensor:
         ctx.fn = fn
         ctx.mlp_module = mlp_module
         ctx.shards = shards
         ctx.compute_params = compute_params
+        # `params` arrives via ensure_contiguous, which may hand us copies; resolve the originals so
+        # torch.autograd.grad differentiates the tensors the recompute actually uses.
+        ctx.grad_params = _autograd_input_params(compute_params)
         ctx.save_for_backward(x)
 
         # x.shape could be [bs, seqlen, hidden_size] or [seqlen, hidden_size] (moe experts)
@@ -64,6 +89,7 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         mlp_module = ctx.mlp_module
         shards = ctx.shards
         compute_params = ctx.compute_params
+        grad_params = ctx.grad_params
 
         grad_output = grads[0]
 
@@ -91,6 +117,10 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         # flips the ready flag. Parameters on other backends have no ds_id and are left untouched.
         ds_params = [p for p in compute_params if hasattr(p, "ds_id")] if compute_params else []
 
+        # Summed over shards and returned as this Function's gradients, so autograd accumulates each
+        # weight exactly once. Empty under ZeRO-3, which keeps the per-shard accumulation below.
+        param_grads = [None] * len(grad_params)
+
         for i, x_shard in enumerate(x_shards):
             x_shard.requires_grad_(x_requires_grad)
 
@@ -98,22 +128,44 @@ class LigerTiledMLPFunction(torch.autograd.Function):
             shard_step = x_shards[i].shape[0]
             shard_offset = i * x_shards[0].shape[0]
 
-            x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
             incoming_grad_shard = incoming_grad_shards[i]
 
-            # Defer DeepSpeed's reduction until the last shard has accumulated into param.grad; the flag
-            # is read by ZeRO's hook during each shard's backward, so it must be set per shard.
-            for param in ds_params:
-                param.ds_grad_is_ready = i + 1 == len(x_shards)
+            if grad_params:
+                with torch.enable_grad():
+                    output = fn(mlp_module, x_shard)
+                inputs = ([x_shard] if x_requires_grad else []) + grad_params
+                # torch.autograd.grad returns the gradients instead of accumulating into .grad, so no
+                # AccumulateGrad node fires here and DDP's per-parameter hook stays untouched
+                shard_grads = torch.autograd.grad(
+                    outputs=output,
+                    inputs=inputs,
+                    grad_outputs=incoming_grad_shard,
+                    allow_unused=True,
+                )
+                if x_requires_grad:
+                    x_grad.narrow(0, shard_offset, shard_step).copy_(shard_grads[0])
+                    shard_grads = shard_grads[1:]
+                for j, shard_grad in enumerate(shard_grads):
+                    if shard_grad is None:
+                        continue
+                    # the first shard's gradient is freshly allocated, so accumulate into it in place
+                    param_grads[j] = shard_grad if param_grads[j] is None else param_grads[j].add_(shard_grad)
+            else:
+                x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
 
-            with torch.enable_grad():
-                output = fn(mlp_module, x_shard)
-            torch.autograd.backward(output, incoming_grad_shard)
+                # Defer DeepSpeed's reduction until the last shard has accumulated into param.grad; the flag
+                # is read by ZeRO's hook during each shard's backward, so it must be set per shard.
+                for param in ds_params:
+                    param.ds_grad_is_ready = i + 1 == len(x_shards)
+
+                with torch.enable_grad():
+                    output = fn(mlp_module, x_shard)
+                torch.autograd.backward(output, incoming_grad_shard)
 
         # unflatten
         x_grad = x_grad.view(x_shape_orig)
 
-        return (None, None, x_grad, None, None)
+        return (None, None, x_grad, None, None, *param_grads)
 
 
 def apply_tiled_mlp(
@@ -156,4 +208,6 @@ def apply_tiled_mlp(
         x,
         num_shards,
         compute_params,
+        # passed as explicit Function inputs so autograd accumulates each weight once per backward
+        *_autograd_input_params(compute_params),
     )


### PR DESCRIPTION
## Related issue

Closes #1081

## What does this PR do?

Makes the tiled MLP backward accumulate each weight gradient once per pass instead of once per shard, so DDP no longer fails with `Expected to mark a variable ready only once`.

## Motivation

The backward drives each shard with its own `torch.autograd.backward`, so `gate_proj.weight`, `up_proj.weight` and `down_proj.weight` each reach their `AccumulateGrad` node `num_shards` times in a single pass. DDP registers one hook per parameter and marks it ready on every firing, which is one-shot per pass, so any model with more than one tiled MLP dies in backward.

`ds_grad_is_ready` (#1000) defers DeepSpeed's *reduction* to the last shard, but the accumulations themselves still happen once per shard, so it does not help DDP.

Tiling is a memory optimization and should not change how gradients reach the parameters.

## Changes

- Pass the weights to `LigerTiledMLPFunction.apply` as explicit tensor inputs and return their gradients from `backward`, so autograd accumulates each one once, at the end of the pass.
- Use `torch.autograd.grad` instead of `torch.autograd.backward` on that path, summing the per-shard gradients locally. No `AccumulateGrad` node fires inside the loop, so DDP's per-parameter hook is untouched.
- Keep the existing per-shard path for ZeRO-3, selected on `hasattr(param, "ds_id")`. Partitioned weights are 0-sized placeholders outside their owning module's forward, so autograd would record `(0,)` as the expected gradient shape and the recompute would fail. Those still defer the reduction via `ds_grad_is_ready`.

## Testing

Ran the reporter's repro from #1081, reduced to 2 gloo/CPU ranks and a 2-layer `LlamaConfig` so it needs no GPU. Before this change both ranks raise `Expected to mark a variable ready only once`; after it, backward completes.

Also checked against an untiled reference in float64, single process, max abs gradient error:

| case | weight grads | input grads |
| --- | --- | --- |
| baseline `[2, 256, 64]`, 4 shards | 3.4e-14 | 0.0 |
| 2d input (moe experts) | 1.2e-14 | 0.0 |
| seqlen not divisible by shards | 1.2e-14 | 1.7e-16 |
| auto `num_shards` | 2.8e-14 | 0.0 |
| single shard | 0.0 | 0.0 |
| `out_features != in_features` | 2.3e-14 | 0.0 |
| `x.requires_grad=False` | 2.8e-14 | n/a |
| ZeRO-3 (`ds_id`) path | 2.5e-14 | 0.0 |
| ZeRO-3 + non-divisible seqlen | 1.4e-14 | 2.2e-16 |

And confirmed the accumulation count directly with a `register_post_accumulate_grad_hook` on each weight: one firing per weight per backward with 8 shards on the default path, `num_shards` firings on the ZeRO-3 path as intended.

`liger-kernels` has no test directory here, so the regression tests land upstream in linkedin/Liger-Kernel#1276 alongside the same fix.

## Checklist

- [x] This PR is linked to an issue that was discussed and approved
- [x] I have tested these changes locally
- [ ] New/changed functionality has test coverage
- LLM disclosure:
  - [ ] I did not use an LLM to create this PR.
  - [x] I used and LLM for assistance while creating this PR.
  - [ ] This PR was mostly or completely generated by an LLM.
