### PR TITLE
relu: load kernel via get_kernel in CI smoke tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,47 @@ The same applies for other registrations of ops, such as fake ops:
 @register_fake(add_op_namespace_prefix("single_marlin_gemm_moe"))
 ```
 
+## Tests
+
+Tests live in `tests/` and must load the kernel through `get_kernel` rather
+than importing the built package directly. This exercises the same code path
+that users take, so breakage in the loader, in variant resolution, or in a
+dependency version is caught by the tests:
+
+```python
+# Incorrect:
+import relu
+
+# Correct:
+import kernels
+
+relu = kernels.get_kernel("kernels-community/relu", version=1)
+```
+
+The repo id is the `repo-id` from the `[general.hub]` section of `build.toml`,
+and the version is the `version` from `[general]`. In CI (and in
+`kernel-builder devshell`/`testshell`) the `LOCAL_KERNELS` environment
+variable is set to point at the freshly built kernel, so `get_kernel` resolves
+to the local build instead of downloading from the Hub. This requires a
+`flake.lock` with a `kernel-builder` input recent enough that the `ci-test`
+derivation exports `LOCAL_KERNELS`; run `python3 scripts/update_flakes.py
+<kernel>` if the tests fail to find the kernel in CI.
+
+Running the full test suite in CI is usually too expensive, so mark a subset
+of cheap tests that together catch most error cases with the `kernels_ci`
+marker. Aim for a total runtime under 60 seconds:
+
+```python
+import pytest
+
+@pytest.mark.kernels_ci
+def test_relu():
+    ...
+```
+
+These are the tests run by `nix run .#ci-test` (`pytest -m kernels_ci`), which
+is what kernels-community CI executes on a GPU runner.
+
 # Kernel-specific instructions
 
 ## flash-attn3

--- a/relu/flake.lock
+++ b/relu/flake.lock
@@ -41,11 +41,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1783417137,
-        "narHash": "sha256-/iWe/m5ZACdb/DcXTrvXmbHS2QrzgGcGa7hPKi460tE=",
+        "lastModified": 1787146545,
+        "narHash": "sha256-BKV2ctn0PDlQVL/qYZHRfrHZvK5sduNJa/gOPntn748=",
         "owner": "huggingface",
         "repo": "kernels",
-        "rev": "81580bb92577f2f7228661ca2a221fc052375709",
+        "rev": "18c4d686a271ca6e56d0110fd36a9a5f58e86215",
         "type": "github"
       },
       "original": {
@@ -56,17 +56,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776927958,
-        "narHash": "sha256-XOzEtft7E0P6TgQViLUOQeGHlEYiQ0+FY24BPEksj6s=",
+        "lastModified": 1783284758,
+        "narHash": "sha256-tiQ8/qi8I45OOaBBYlVbXoAVkeQzvvTQOv5I45rMw5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fec2c46cca5bf9767486a290abae51200b656d69",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
+        "rev": "ec1a11210589d294f0ac99d3290a27e6c73dfa1d",
         "type": "github"
       }
     },
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776914043,
-        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
+        "lastModified": 1783320166,
+        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
+        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
         "type": "github"
       },
       "original": {

--- a/relu/tests/test_relu.py
+++ b/relu/tests/test_relu.py
@@ -1,35 +1,32 @@
-import platform
-
 import pytest
 import torch
 import torch.nn.functional as F
 
-import relu
+import kernels
+
+relu = kernels.get_kernel("kernels-community/relu", version=1)
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.device("xpu")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
 
 
 @pytest.mark.kernels_ci
 def test_relu():
-    if platform.system() == "Darwin":
-        device = torch.device("mps")
-    elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        device = torch.device("xpu")
-    elif torch.cuda.is_available():
-        device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
+    device = get_device()
     x = torch.randn(1024, 1024, dtype=torch.float32, device=device)
     torch.testing.assert_close(F.relu(x), relu.relu(x))
 
+
 @pytest.mark.kernels_ci
 def test_relu_layer():
-    if platform.system() == "Darwin":
-        device = torch.device("mps")
-    elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        device = torch.device("xpu")
-    elif torch.version.cuda is not None and torch.cuda.is_available():
-        device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
+    device = get_device()
     x = torch.randn(1024, 1024, dtype=torch.float32, device=device)
     layer = relu.layers.ReLU()
     torch.testing.assert_close(F.relu(x), layer(x))


### PR DESCRIPTION
Fixes https://github.com/huggingface/kernels-community/issues/1050

While working on this I also realized that kernel-bot commands doesn't account for testing. Should we add support for that? @drbh?