### PR TITLE
(vllm-)flash-attn3: fix version bound

### DIFF
--- a/flash-attn3/build.toml
+++ b/flash-attn3/build.toml
@@ -7,7 +7,7 @@ backends = ["cuda"]
 
 [general.cuda]
 minver = "12.6"
-maxver = "13"
+maxver = "13.0"
 
 [general.hub]
 repo-id = "kernels-community/flash-attn3"

--- a/vllm-flash-attn3/build.toml
+++ b/vllm-flash-attn3/build.toml
@@ -7,7 +7,7 @@ backends = ["cuda"]
 
 [general.cuda]
 minver = "12.6"
-maxver = "13"
+maxver = "13.0"
 
 [general.hub]
 repo-id = "kernels-community/vllm-flash-attn3"


### PR DESCRIPTION
Seems to have broken with the automatic update.
