### PR TITLE
fix: allow comment bot to write so merge and upload works

### DIFF
--- a/.github/workflows/pr-comment-build.yaml
+++ b/.github/workflows/pr-comment-build.yaml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   actions: write
   issues: write
   pull-requests: write


### PR DESCRIPTION
this or should resolve the permission issue with the `merge-and-upload` kernel bot command