### PR TITLE
fix json decoding error in the hub comment.

### DIFF
--- a/.github/scripts/format_hub_upload_comment.py
+++ b/.github/scripts/format_hub_upload_comment.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # Input:
-#   [--base <comment-body>] <kernel> <repo-prefix> <upload-json-or-path>...
+#   [--base <comment-body>] <kernel> <repo-prefix>
+#   <upload-json-or-path-or-directory>...
 #
 # Output:
 #   A Hub upload section, or <comment-body> with that section updated.
 #
 # Example:
-#   python3 .github/scripts/format_hub_upload_comment.py msa kernels-community "$RUNNER_TEMP"/upload*.json
-#   python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" msa kernels-community "$RUNNER_TEMP"/upload*.json
+#   python3 .github/scripts/format_hub_upload_comment.py msa kernels-community "$RUNNER_TEMP"
+#   python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" msa kernels-community "$RUNNER_TEMP"
 #   python3 .github/scripts/format_hub_upload_comment.py msa kernels-community '{"pull_requests":[{"url":"https://hf.co/kernels/MiniMaxAI/msa/discussions/1"}]}'
 import argparse
 import json
@@ -27,6 +28,23 @@ def load_json(value):
     return json.loads(value)
 
 
+def expand_uploads(values):
+    for value in values:
+        if value.lstrip().startswith(("{", "[")):
+            yield value
+            continue
+
+        path = Path(value)
+        if path.is_dir():
+            yield from (
+                str(upload)
+                for upload in sorted(path.rglob("*.json"))
+                if upload.is_file()
+            )
+        else:
+            yield value
+
+
 def dedupe(lines):
     return list(dict.fromkeys(lines))
 
@@ -34,7 +52,7 @@ def dedupe(lines):
 def upload_lines(kernel, repo_prefix, uploads):
     urls = [
         pr["url"]
-        for upload in uploads
+        for upload in expand_uploads(uploads)
         for pr in load_json(upload).get("pull_requests", [])
     ]
     lines = [

--- a/.github/scripts/test_format_hub_upload_comment.py
+++ b/.github/scripts/test_format_hub_upload_comment.py
@@ -1,0 +1,42 @@
+import json
+
+import pytest
+
+from format_hub_upload_comment import upload_lines
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_upload_lines_discovers_json_in_directory(tmp_path, nested):
+    upload_dir = tmp_path / "hub-uploads"
+    if nested:
+        upload_dir /= "hub-upload-linux"
+    upload_dir.mkdir(parents=True)
+    (upload_dir / "upload.json").write_text(
+        json.dumps(
+            {
+                "pull_requests": [
+                    {"url": "https://huggingface.co/kernels/example/discussions/1"}
+                ]
+            }
+        )
+    )
+
+    assert upload_lines("example", "kernels-staging", [str(tmp_path / "hub-uploads")]) == [
+        "- Hub repo: https://huggingface.co/kernels/kernels-staging/example",
+        "- Hub pull request: https://huggingface.co/kernels/example/discussions/1",
+    ]
+
+
+def test_upload_lines_still_accepts_inline_json():
+    upload = json.dumps(
+        {
+            "pull_requests": [
+                {"url": "https://huggingface.co/kernels/example/discussions/1"}
+            ]
+        }
+    )
+
+    assert upload_lines("example", "kernels-community", [upload]) == [
+        "- Hub repo: https://huggingface.co/kernels/kernels-community/example",
+        "- Hub pull request: https://huggingface.co/kernels/example/discussions/1",
+    ]

--- a/.github/workflows/build-mac.yaml
+++ b/.github/workflows/build-mac.yaml
@@ -328,5 +328,5 @@ jobs:
           REPO_PREFIX: ${{ inputs.repo_prefix }}
         run: |
           BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$BOT_COMMENT_ID" --jq .body)
-          BODY=$(python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" "$KERNEL" "$REPO_PREFIX" hub-uploads/**/*.json)
+          BODY=$(python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" "$KERNEL" "$REPO_PREFIX" hub-uploads)
           gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$BOT_COMMENT_ID" -f body="$BODY"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -501,5 +501,5 @@ jobs:
           REPO_PREFIX: ${{ inputs.repo_prefix }}
         run: |
           BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$BOT_COMMENT_ID" --jq .body)
-          BODY=$(python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" "$KERNEL" "$REPO_PREFIX" hub-uploads/**/*.json)
+          BODY=$(python3 .github/scripts/format_hub_upload_comment.py --base "$BODY" "$KERNEL" "$REPO_PREFIX" hub-uploads)
           gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$BOT_COMMENT_ID" -f body="$BODY"


### PR DESCRIPTION
Fixes https://github.com/huggingface/kernels-community/actions/runs/33468086649/job/99738296263. 

In our upload logic, we expect the JSON file inside a subfolder: `hub-uploads/some-folder/upload.json. But the corresponding run placed it under `hub-uploads/upload.json`. Hence the mismatch. 