### PR TITLE
feat: implement validation of kernel versions in the tests

### DIFF
--- a/.github/scripts/check_kernel_test_versions.py
+++ b/.github/scripts/check_kernel_test_versions.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Check that kernel tests load the version declared in build.toml."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Kernel:
+    root: Path
+    repo_id: str
+    version: int
+
+
+@dataclass(frozen=True)
+class Problem:
+    path: Path
+    line: int
+    message: str
+
+    def render(self, repository_root: Path) -> str:
+        try:
+            path = self.path.relative_to(repository_root)
+        except ValueError:
+            path = self.path
+        return f"{path}:{self.line}: {self.message}"
+
+
+def discover_kernels(repository_root: Path) -> list[Kernel]:
+    """Return kernels that have both a manifest and a tests directory."""
+    kernels = []
+    for root in sorted(path for path in repository_root.iterdir() if path.is_dir()):
+        manifest = root / "build.toml"
+        if not manifest.is_file():
+            # Ported kernels keep generated sources and build.toml under src/.
+            manifest = root / "src" / "build.toml"
+        if not manifest.is_file() or not (root / "tests").is_dir():
+            continue
+
+        with manifest.open("rb") as handle:
+            config = tomllib.load(handle)
+        general = config.get("general", {})
+        repo_id = general.get("hub", {}).get("repo-id")
+        version = general.get("version")
+        if not isinstance(repo_id, str) or not repo_id:
+            raise ValueError(f"{manifest}: [general.hub].repo-id must be a string")
+        if type(version) is not int:
+            raise ValueError(f"{manifest}: [general].version must be an integer")
+        kernels.append(Kernel(root=root, repo_id=repo_id, version=version))
+    return kernels
+
+
+def _literal(node: ast.AST | None) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    return None
+
+
+def check_test_file(path: Path, kernel: Kernel) -> tuple[list[Problem], int]:
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (OSError, UnicodeError, SyntaxError) as error:
+        line = getattr(error, "lineno", None) or 1
+        return [Problem(path, line, f"could not parse test file: {error}")], 0
+
+    problems = []
+    checked = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        function = node.func
+        function_name = (
+            function.id
+            if isinstance(function, ast.Name)
+            else function.attr if isinstance(function, ast.Attribute) else None
+        )
+        if function_name != "get_kernel" or not node.args:
+            continue
+
+        # A test suite may load another kernel as a reference or dependency.
+        # Only calls targeting this kernel are governed by its build.toml.
+        if _literal(node.args[0]) != kernel.repo_id:
+            continue
+
+        checked += 1
+        expected = f'get_kernel("{kernel.repo_id}", version={kernel.version})'
+        if expected not in (ast.get_source_segment(source, node) or ""):
+            problems.append(
+                Problem(
+                    path,
+                    node.lineno,
+                    f"expected {expected}",
+                )
+            )
+    return problems, checked
+
+
+def check_repository(repository_root: Path) -> tuple[list[Problem], int, int]:
+    problems = []
+    checked_calls = 0
+    kernels_with_calls = 0
+    for kernel in discover_kernels(repository_root):
+        kernel_calls = 0
+        for path in sorted((kernel.root / "tests").rglob("*.py")):
+            file_problems, file_calls = check_test_file(path, kernel)
+            problems.extend(file_problems)
+            kernel_calls += file_calls
+        checked_calls += kernel_calls
+        kernels_with_calls += kernel_calls > 0
+    return problems, checked_calls, kernels_with_calls
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (default: inferred from this script).",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+
+    try:
+        problems, checked_calls, kernels_with_calls = check_repository(root)
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    for problem in problems:
+        print(problem.render(root), file=sys.stderr)
+    if problems:
+        print(
+            f"Found {len(problems)} problem(s) in {checked_calls} get_kernel call(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Checked {checked_calls} get_kernel call(s) across "
+        f"{kernels_with_calls} kernel test suite(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_kernel_test_versions.py
+++ b/.github/scripts/test_check_kernel_test_versions.py
@@ -1,0 +1,100 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check_kernel_test_versions.py")
+SPEC = importlib.util.spec_from_file_location("check_kernel_test_versions", SCRIPT)
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+def write_kernel(root, *, version=2, repo_id="kernels-community/example", nested=False):
+    kernel = root / "example"
+    manifest_root = kernel / "src" if nested else kernel
+    manifest_root.mkdir(parents=True)
+    (kernel / "tests").mkdir()
+    (manifest_root / "build.toml").write_text(
+        f"""[general]
+version = {version}
+
+[general.hub]
+repo-id = "{repo_id}"
+"""
+    )
+    return kernel
+
+
+def test_matching_module_call(tmp_path):
+    kernel = write_kernel(tmp_path)
+    (kernel / "tests" / "test_example.py").write_text(
+        "import kernels as loader\n"
+        'example = loader.get_kernel("kernels-community/example", version=2)\n'
+    )
+
+    assert checker.check_repository(tmp_path) == ([], 1, 1)
+
+
+def test_matching_import_with_nested_manifest(tmp_path):
+    kernel = write_kernel(tmp_path, nested=True)
+    (kernel / "tests" / "helper.py").write_text(
+        "from kernels import get_kernel\n"
+        'example = get_kernel("kernels-community/example", version=2)\n'
+    )
+
+    assert checker.check_repository(tmp_path) == ([], 1, 1)
+
+
+def test_reports_stale_version(tmp_path):
+    kernel = write_kernel(tmp_path, version=3)
+    test = kernel / "tests" / "test_example.py"
+    test.write_text(
+        "import kernels\n"
+        'example = kernels.get_kernel("kernels-community/example", version=2)\n'
+    )
+
+    problems, checked, suites = checker.check_repository(tmp_path)
+
+    assert (checked, suites) == (1, 1)
+    assert len(problems) == 1
+    assert problems[0].path == test
+    assert problems[0].line == 2
+    assert "version=3" in problems[0].message
+
+
+def test_reports_missing_version(tmp_path):
+    kernel = write_kernel(tmp_path)
+    (kernel / "tests" / "test_example.py").write_text(
+        "from kernels import get_kernel\n"
+        'example = get_kernel("kernels-community/example")\n'
+    )
+
+    problems, checked, suites = checker.check_repository(tmp_path)
+
+    assert (checked, suites) == (1, 1)
+    assert len(problems) == 1
+    assert 'get_kernel("kernels-community/example", version=2)' in problems[0].message
+
+
+def test_ignores_comments_unrelated_methods_and_suites_without_calls(tmp_path):
+    kernel = write_kernel(tmp_path)
+    (kernel / "tests" / "test_example.py").write_text(
+        """# kernels.get_kernel("kernels-community/example", version=1)
+class Timer:
+    def get_kernel(self):
+        return None
+
+Timer().get_kernel()
+"""
+    )
+
+    assert checker.check_repository(tmp_path) == ([], 0, 0)
+
+
+def test_skips_kernel_without_tests(tmp_path):
+    kernel = tmp_path / "example"
+    kernel.mkdir()
+    (kernel / "build.toml").write_text("this is not valid TOML")
+
+    assert checker.check_repository(tmp_path) == ([], 0, 0)

--- a/.github/workflows/check-kernel-test-versions.yaml
+++ b/.github/workflows/check-kernel-test-versions.yaml
@@ -1,0 +1,33 @@
+name: Check kernel test versions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/build.toml"
+      - "**/tests/**"
+      - ".github/scripts/check_kernel_test_versions.py"
+      - ".github/workflows/check-kernel-test-versions.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-kernel-test-versions-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check versions used by tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Check kernel versions used by tests
+        run: python .github/scripts/check_kernel_test_versions.py


### PR DESCRIPTION
We use `get_kernel()` in the tests that we run in our CI (and also more generally). 

We should check if the tests use the repo id and the version specified in the `build.toml` of the corresponding kernel being tested. 

I have not run the driver script yet as my plan for this PR is to just add the utilities. We can tackle the checks of the existing kernels in a follow-up PR or through a manually dispatched workflow.