### PR TITLE
CI: set the mode to `pr` on commands that don't upload

### DIFF
--- a/.github/scripts/pr_comment_kernel_bot.py
+++ b/.github/scripts/pr_comment_kernel_bot.py
@@ -891,6 +891,9 @@ def main(*, dry_run: bool = False):
         dispatch_upload = True
         dispatch_repo_prefix = "kernels-community"
 
+    # Commands that don't upload are PR-only.
+    dispatch_mode = "release" if dispatch_upload else "pr"
+
     mode_text = {
         "build": "build only",
         "security-and-build": "security audit + build",
@@ -1003,7 +1006,7 @@ def main(*, dry_run: bool = False):
             token=token,
             repo=repository,
             ref=default_branch,
-            mode="release",
+            mode=dispatch_mode,
             repo_prefix=dispatch_repo_prefix,
             dispatch_key_prefix=f"pr{issue_number}-",
             pr_number=dispatch_pr_number,

--- a/.github/scripts/test_pr_comment_kernel_bot.py
+++ b/.github/scripts/test_pr_comment_kernel_bot.py
@@ -253,5 +253,33 @@ def test_parse_error_dry_run_does_not_crash():
     assert "Parse error" in proc.stderr
 
 
+def _assert_dry_run_mode(comment, expected):
+    proc = _run_dry(comment)
+    assert proc.returncode == 0, proc.stderr
+    assert f'"mode": "{expected}"' in proc.stdout
+    other = {"pr", "release"} - {expected}
+    assert all(f'"mode": "{m}"' not in proc.stdout for m in other)
+
+
+def test_build_dispatches_pr_mode():
+    _assert_dry_run_mode("/kernel-bot build relu", "pr")
+
+
+def test_security_and_build_dispatches_pr_mode():
+    _assert_dry_run_mode("/kernel-bot security-and-build relu", "pr")
+
+
+def test_build_and_stage_dispatches_release_mode():
+    _assert_dry_run_mode("/kernel-bot build-and-stage relu", "release")
+
+
+def test_release_dispatches_release_mode():
+    _assert_dry_run_mode("/kernel-bot release relu", "release")
+
+
+def test_merge_and_upload_dispatches_release_mode():
+    _assert_dry_run_mode("/kernel-bot merge-and-upload relu", "release")
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
The dispatch mode was always set to `release`, which skips kernel tests.