### PR TITLE
triton-kernels: publish an XPU build variant

### DIFF
--- a/triton-kernels/build.toml
+++ b/triton-kernels/build.toml
@@ -3,7 +3,7 @@ name = "triton-kernels"
 version = 1
 edition = 5
 license = "Apache-2.0"
-backends = ["cuda"]
+backends = ["cuda", "xpu"]
 
 [general.hub]
 repo-id = "kernels-community/triton-kernels"

--- a/triton-kernels/tests/test_ci.py
+++ b/triton-kernels/tests/test_ci.py
@@ -67,30 +67,30 @@ def test_compaction_ci(n_tokens, n_cols, k, p, device):
 
 
 @pytest.mark.kernels_ci
-def test_mxfp_rounding_ci():
-    test_mxfp.test_mxfp4_rounding_cases("bfloat16")
+def test_mxfp_rounding_ci(device):
+    test_mxfp.test_mxfp4_rounding_cases("bfloat16", device)
 
 
 @pytest.mark.kernels_ci
-def test_mxfp_quant_dequant_ci():
-    test_mxfp.test_mxfp_quant_dequant("float4_e2m1", "bfloat16")
+def test_mxfp_quant_dequant_ci(device):
+    test_mxfp.test_mxfp_quant_dequant("float4_e2m1", "bfloat16", device)
 
 
 @pytest.mark.kernels_ci
-def test_mxfp_casting_ci():
+def test_mxfp_casting_ci(device):
     test_mxfp.test_mxfp_casting((10, 254, 60), 0, "float4_e2m1", "bfloat16",
-                                test_mxfp.DequantScaleRoundingMode.ROUND_DOWN)
+                                test_mxfp.DequantScaleRoundingMode.ROUND_DOWN, device)
 
 
 @pytest.mark.kernels_ci
-def test_layout_blackwell_ci():
-    test_layout_blackwell.test_mxfp4_scale_roundtrip((10, 254, 60))
+def test_layout_blackwell_ci(device):
+    test_layout_blackwell.test_mxfp4_scale_roundtrip((10, 254, 60), device)
 
 
 @pytest.mark.kernels_ci
-def test_layout_hopper_ci():
-    test_layout_hopper.test_mxfp4_value_roundtrip((16, 32), False, 0, 2)
-    test_layout_hopper.test_mxfp4_scale_roundtrip((256, 64), 0, 4)
+def test_layout_hopper_ci(device):
+    test_layout_hopper.test_mxfp4_value_roundtrip((16, 32), False, 0, 2, device)
+    test_layout_hopper.test_mxfp4_scale_roundtrip((256, 64), 0, 4, device)
 
 
 @pytest.mark.kernels_ci

--- a/triton-kernels/tests/test_mxfp.py
+++ b/triton-kernels/tests/test_mxfp.py
@@ -11,6 +11,7 @@ downcast_to_mxfp_torch = triton_kernels.numerics_details.mxfp.downcast_to_mxfp_t
 get_max_quant_val = triton_kernels.numerics_details.mxfp.get_max_quant_val
 upcast_from_mxfp = triton_kernels.numerics_details.mxfp.upcast_from_mxfp
 upcast_from_mxfp_torch = triton_kernels.numerics_details.mxfp.upcast_from_mxfp_torch
+is_cuda = triton_kernels.target_info.is_cuda
 
 from .testing import assert_close, assert_equal
 
@@ -20,9 +21,9 @@ def dtype_str_to_torch(dtype_str: str) -> torch.dtype:
 
 
 @pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16"])
-def test_mxfp4_rounding_cases(dst_dtype):
+def test_mxfp4_rounding_cases(dst_dtype, device):
     dst_dtype = dtype_str_to_torch(dst_dtype)
-    x = torch.tensor([6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3]).cuda().bfloat16().view(1, -1, 1)
+    x = torch.tensor([6, 0, 0.24, 0.25, 0.75, 0.99, 1.2, 1.3], device=device).bfloat16().view(1, -1, 1)
     quant, scale = downcast_to_mxfp(x, torch.uint8, axis=1)
     dequant = upcast_from_mxfp(quant, scale, dst_dtype, axis=1)
     assert dequant.flatten().tolist() == [6, 0, 0, 0.5, 1.0, 1.0, 1.0, 1.5], f"{dequant=}"
@@ -37,8 +38,8 @@ def test_mxfp4_rounding_cases(dst_dtype):
 
 @pytest.mark.parametrize("src_dtype", ["float4_e2m1", "float8_e5m2", "float8_e4m3fn"])
 @pytest.mark.parametrize("dst_dtype", ["float16", "bfloat16"])
-def test_mxfp_quant_dequant(src_dtype, dst_dtype):
-    if "float8" in src_dtype and torch.cuda.get_device_capability()[0] < 9:
+def test_mxfp_quant_dequant(src_dtype, dst_dtype, device):
+    if "float8" in src_dtype and is_cuda() and torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("Float8 not tested on A100")
     limit_range = src_dtype == "float8_e5m2" and dst_dtype == "float16"
 
@@ -52,14 +53,14 @@ def test_mxfp_quant_dequant(src_dtype, dst_dtype):
         max_val = 128
 
     # These are all the valid mxfp4 positive values.
-    pos_vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device="cuda", dtype=dst_dtype)
+    pos_vals = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, max_val], device=device, dtype=dst_dtype)
     neg_vals = -pos_vals
     k_dim = torch.cat([pos_vals, neg_vals])
     k_dim = k_dim.reshape([k_dim.shape[0], 1])
 
     # We pick power of 2 scales since both the scales and their inverse only require exponent bits to be exactly
     # represented. This means we can store the scales exactly in the e8m0 format.
-    powers = torch.arange(-8, 8, device="cuda", dtype=dst_dtype)
+    powers = torch.arange(-8, 8, device=device, dtype=dst_dtype)
     scales = 2**powers
     scales = scales.reshape([1, powers.shape[0]])
     weight = k_dim * scales
@@ -89,13 +90,14 @@ def test_mxfp_casting(
     quant_dtype: str,
     dequant_dtype: str,
     rounding_mode: DequantScaleRoundingMode,
+    device,
 ):
-    if "float8" in quant_dtype and torch.cuda.get_device_capability()[0] < 9:
+    if "float8" in quant_dtype and is_cuda() and torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("Float8 not tested on A100")
     quant_torch_type = dtype_str_to_torch(quant_dtype)
     dequant_torch_type = dtype_str_to_torch(dequant_dtype)
     # Generate random input tensor that is contiguous once axis is the last dimension
-    x = torch.randn(shape, device="cuda", dtype=dequant_torch_type)
+    x = torch.randn(shape, device=device, dtype=dequant_torch_type)
 
     # Quantize and check equivalence
     quant, scale = downcast_to_mxfp(x, quant_torch_type, axis, DEQUANT_SCALE_ROUNDING_MODE=rounding_mode)

--- a/triton-kernels/tests/test_routing.py
+++ b/triton-kernels/tests/test_routing.py
@@ -11,7 +11,7 @@ routing_torch = triton_kernels.routing.routing_torch
 from .testing import assert_close, assert_equal
 
 
-def init_data(n_tokens, n_expts_tot, dtype=torch.float16, device="cuda"):
+def init_data(n_tokens, n_expts_tot, device, dtype=torch.float16):
     logits = torch.randn((n_tokens, n_expts_tot), dtype=dtype, device=device, requires_grad=True)
     return logits
 
@@ -38,7 +38,7 @@ def test_op(n_tokens_pad, n_tokens_raw, n_expts_tot, n_expts_act, sm_first, use_
     ref_logits = tri_logits.clone().detach().requires_grad_(True)
 
     if use_expt_indx:
-        rand_idx = lambda: torch.randperm(n_expts_tot, device="cuda", dtype=torch.int64)
+        rand_idx = lambda: torch.randperm(n_expts_tot, device=device, dtype=torch.int64)
         tri_expt_indx = torch.stack([rand_idx()[:n_expts_act] for _ in range(n_tokens_pad)])
         tri_expt_indx, _ = torch.sort(tri_expt_indx, dim=1)
         tri_expt_indx[n_tokens_raw:] = -99999  # should not be used

--- a/triton-kernels/tests/test_swiglu.py
+++ b/triton-kernels/tests/test_swiglu.py
@@ -38,7 +38,7 @@ def test_op(M, N, limit, device, alpha=0.5):
     # initialize expert data
     n_expts_tot = 6
     n_expts_act = 2
-    logits = init_routing_data(M, n_expts_tot).detach()
+    logits = init_routing_data(M, n_expts_tot, device).detach()
     routing_data, _, _ = routing_torch(logits, n_expts_act)
     n_tokens = routing_data.expt_hist.sum()
 

--- a/triton-kernels/tests/test_tensor_details/test_layout_blackwell.py
+++ b/triton-kernels/tests/test_tensor_details/test_layout_blackwell.py
@@ -22,8 +22,8 @@ BlackwellMXScaleLayout = triton_kernels.tensor_details.layout.BlackwellMXScaleLa
         (3, 2, 36),
     ],
 )
-def test_mxfp4_scale_roundtrip(shape):
-    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+def test_mxfp4_scale_roundtrip(shape, device):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device=device)
     layout = BlackwellMXScaleLayout(x.shape)
     res = layout.unswizzle_data(layout.swizzle_data(x))
     assert (res == x).all()

--- a/triton-kernels/tests/test_tensor_details/test_layout_hopper.py
+++ b/triton-kernels/tests/test_tensor_details/test_layout_hopper.py
@@ -28,8 +28,8 @@ cuda_capability_geq = triton_kernels.target_info.cuda_capability_geq
 @pytest.mark.parametrize("trans", [False, True])
 @pytest.mark.parametrize("mx_axis", [0, 1])
 @pytest.mark.parametrize("mma_version", [2, 3])
-def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version):
-    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version, device):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device=device)
     if trans:
         x = x.mT
     if x.shape[1 - mx_axis] < 32:
@@ -42,8 +42,8 @@ def test_mxfp4_value_roundtrip(shape, trans, mx_axis, mma_version):
 @pytest.mark.parametrize("mx_axis", [0, 1])
 @pytest.mark.parametrize("num_warps", [4, 8])
 @pytest.mark.parametrize("shape", [(256, 64), (256, 128), (256, 256)])
-def test_mxfp4_scale_roundtrip(shape, mx_axis, num_warps):
-    x = torch.randint(0, 256, shape, dtype=torch.uint8, device="cuda")
+def test_mxfp4_scale_roundtrip(shape, mx_axis, num_warps, device):
+    x = torch.randint(0, 256, shape, dtype=torch.uint8, device=device)
     layout = HopperMXScaleLayout(x.shape, mx_axis=mx_axis, num_warps=num_warps)
     res = layout.unswizzle_data(layout.swizzle_data(x))
     assert (res[:shape[0], :shape[1]] == x).all()


### PR DESCRIPTION
Follow-up to #1075. The Intel fixes landed there, but they are still unreachable through `kernels`.

`triton-kernels` is `[torch-noarch]`, yet `backends` decides which variant directories get published, and it lists only `cuda`. So the repo ships `build/torch-cuda` only and `get_kernel` fails on an Intel GPU:

```
FileNotFoundError: Cannot find a build variant for this system in kernels-community/triton-kernels
  torch-cuda: backend (cuda) does not match system backend (xpu) and is not universal
```

Adding `xpu` costs no compilation — being noarch, the variant has the same file set as `torch-cuda`. `liger-kernels` already publishes `torch-cuda`, `torch-rocm` and `torch-xpu` this way. `rocm` is left out here only because I cannot validate it.

The second commit lets the tests honour the existing `--device` fixture instead of hardcoding `device="cuda"` / `torch.cuda.*`; compute-capability checks move behind `is_cuda()`, and genuinely CUDA-only tests are untouched.

## Validation

Intel Arc Pro B60, `--device xpu`: 14 passed / 2 skipped for the `kernels_ci` subset, 131 passed / 9 skipped across the edited modules. `--device cuda` is unchanged, and the CUDA-only CI runner gains no new job.
