### PR TITLE
causal-conv1d: add `layers` module for `LayerRepository`

### DIFF
--- a/causal-conv1d/build.toml
+++ b/causal-conv1d/build.toml
@@ -1,6 +1,6 @@
 [general]
 name = "causal-conv1d"
-version = 1
+version = 2
 edition = 5
 license = "BSD-3-Clause"
 backends = [

--- a/causal-conv1d/torch-ext/causal_conv1d/__init__.py
+++ b/causal-conv1d/torch-ext/causal_conv1d/__init__.py
@@ -1,4 +1,12 @@
+from . import layers
 from .causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_update
 from .causal_conv1d_varlen import causal_conv1d_varlen_states
 
-__all__ = ["causal_conv1d_fn", "causal_conv1d_update", "causal_conv1d_varlen_states"]
+__all__ = [
+    # wrappers
+    "layers",
+    # originals
+    "causal_conv1d_fn",
+    "causal_conv1d_update",
+    "causal_conv1d_varlen_states",
+]

--- a/causal-conv1d/torch-ext/causal_conv1d/layers.py
+++ b/causal-conv1d/torch-ext/causal_conv1d/layers.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+
+from .causal_conv1d_interface import causal_conv1d_fn as kernel_causal_conv1d_fn
+from .causal_conv1d_interface import causal_conv1d_update as kernel_causal_conv1d_update
+
+
+class causal_conv1d_fn(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        activation: str | None = None,
+        **kwargs,
+    ):
+        # For varlen
+        seq_idx = kwargs.pop("seq_idx", None)
+
+        return kernel_causal_conv1d_fn(
+            x=hidden_states,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+            seq_idx=seq_idx,
+        )
+
+
+class causal_conv1d_update(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        conv_state: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        activation: str | None = None,
+    ):
+        return kernel_causal_conv1d_update(
+            x=hidden_states,
+            conv_state=conv_state,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+        )
+
+
+__all__ = [
+    "causal_conv1d_fn",
+    "causal_conv1d_update",
+]


### PR DESCRIPTION
Adds a `layers` submodule to `causal-conv1d`, exposing `causal_conv1d_fn` and `causal_conv1d_update` as `nn.Module` wrappers so the repo can be consumed via `LayerRepository` / `kernelize()`, as transformers will deprecate `FuncRepository` Soon. @danieldk , pls help review, thx!