### PR TITLE
rotary: support partial RoPE in apply_rotary_transformers

### DIFF
--- a/rotary/build.toml
+++ b/rotary/build.toml
@@ -1,6 +1,6 @@
 [general]
 name = "rotary"
-version = 2
+version = 3
 edition = 5
 license = "BSD-3-Clause"
 backends = [

--- a/rotary/tests/test_rotary.py
+++ b/rotary/tests/test_rotary.py
@@ -28,30 +28,8 @@ def apply_rotary_torch(x1: torch.Tensor, x2: torch.Tensor, cos: torch.Tensor, si
     return out1, out2
 
 
-def apply_rotary_torch_wrapper(
-    q, k, cos, sin, conj: bool = False, transformers_style: bool = False, unsqueeze_dim: int = 1
-):
-    """the wrapper for apply_rotary_torch.
-
-    If transformers_style is True, implements the HuggingFace transformers RoPE convention
-    (rotate_half with duplicated frequencies), supporting partial RoPE where cos.shape[-1] <= q.shape[-1].
-    """
-    if transformers_style:
-        cos = cos.unsqueeze(unsqueeze_dim)
-        sin = sin.unsqueeze(unsqueeze_dim)
-        rotary_dim = min(cos.shape[-1], q.shape[-1])
-        q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
-        k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
-
-        def rotate_half(x):
-            x1 = x[..., : x.shape[-1] // 2]
-            x2 = x[..., x.shape[-1] // 2 :]
-            return torch.cat((-x2, x1), dim=-1)
-
-        q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
-        k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
-        return torch.cat([q_embed, q_pass], dim=-1), torch.cat([k_embed, k_pass], dim=-1)
-
+def apply_rotary_torch_wrapper(q, k, cos, sin, conj: bool = False):
+    """the wrapper for apply_rotary_torch"""
     rotary_dim = cos.shape[-1]
 
     # apply rotation encoding to Q
@@ -69,16 +47,8 @@ def apply_rotary_torch_wrapper(
     return q_out, k_out
 
 
-def apply_rotary_kernel_wrapper(
-    q, k, cos, sin, conj: bool = False, transformers_style: bool = False, unsqueeze_dim: int = 1, as_module: bool = False
-):
+def apply_rotary_kernel_wrapper(q, k, cos, sin, conj: bool = False):
     """the wrapper for apply_rotary_kernel"""
-    if transformers_style:
-        if as_module:
-            layer = rotary.layers.apply_rotary_transformers()
-            return layer(q, k, cos, sin, unsqueeze_dim=unsqueeze_dim)
-        return rotary.apply_rotary_transformers(q, k, cos, sin, unsqueeze_dim=unsqueeze_dim)
-
     rotary_dim = cos.shape[-1]
 
     # apply rotation encoding to Q
@@ -92,11 +62,10 @@ def apply_rotary_kernel_wrapper(
     rotary.apply_rotary(k1, k2, cos, sin, k1, k2, conj)
 
 
-
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("nheads", [8, 16])
 @pytest.mark.parametrize("seqlen", [128, 256])
-@pytest.mark.parametrize("headdim, rotary_dim", [(64, 32), (128, 64), (64, 30), (128, 32)])
+@pytest.mark.parametrize("headdim, rotary_dim", [(64, 32), (128, 64), (64, 30), (128, 32), (64, 16), (80, 20)])
 @pytest.mark.parametrize("qk_dim", [3, 4])
 @pytest.mark.parametrize(
     "dtype, atol, rtol",
@@ -160,56 +129,28 @@ def test_rotary_equivalence(batch_size, nheads, seqlen, headdim, rotary_dim, qk_
             k_kernel[..., 2 * rotary_dim:], k_orig[..., 2 * rotary_dim:]
         ), "Non-rotated part of K should be unchanged"
 
+    # verify transformers layer and functional APIs match when not conjugated
+    if not conj and qk_dim == 4:
+        rot_dim_total = 2 * rotary_dim
+        q_trans = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
+        k_trans = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
+        freqs = torch.randn(batch_size, seqlen, rot_dim_total // 2, device=device, dtype=torch.float32)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos_trans = emb.cos().to(dtype)
+        sin_trans = emb.sin().to(dtype)
 
-def apply_rotary_transformers_torch_wrapper(q, k, cos, sin, unsqueeze_dim=1):
-    """Convenience alias delegating to apply_rotary_torch_wrapper with transformers_style=True."""
-    return apply_rotary_torch_wrapper(q, k, cos, sin, transformers_style=True, unsqueeze_dim=unsqueeze_dim)
+        out_q_fn, out_k_fn = rotary.apply_rotary_transformers(q_trans, k_trans, cos_trans, sin_trans, unsqueeze_dim=1)
+        layer = rotary.layers.apply_rotary_transformers()
+        out_q_mod, out_k_mod = layer(q_trans, k_trans, cos_trans, sin_trans, unsqueeze_dim=1)
 
+        assert torch.equal(out_q_fn, out_q_mod), "Functional and module outputs should be identical"
+        assert torch.equal(out_k_fn, out_k_mod), "Functional and module outputs should be identical"
+        if rot_dim_total < headdim:
+            assert torch.equal(
+                out_q_fn[..., rot_dim_total:], q_trans[..., rot_dim_total:]
+            ), "Non-rotated part of Q should be unchanged in transformers wrapper"
+            assert torch.equal(
+                out_k_fn[..., rot_dim_total:], k_trans[..., rot_dim_total:]
+            ), "Non-rotated part of K should be unchanged in transformers wrapper"
 
-@pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("nheads", [8, 16])
-@pytest.mark.parametrize("seqlen", [128, 256])
-@pytest.mark.parametrize("headdim, rotary_dim", [(128, 128), (128, 32), (64, 32), (64, 16), (80, 20)])
-@pytest.mark.parametrize(
-    "dtype, atol, rtol",
-    [
-        (torch.float32, 1e-5, 1e-5),
-        pytest.param(
-            torch.bfloat16,
-            1e-1,
-            1e-5,
-            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
-        ),
-    ],
-)
-@pytest.mark.parametrize("as_module", [False, True])
-def test_apply_rotary_transformers(batch_size, nheads, seqlen, headdim, rotary_dim, dtype, atol, rtol, as_module):
-    device = infer_device()
-    if device is None:
-        pytest.skip("No suitable device found for testing")
-
-    q = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
-    k = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
-
-    freqs = torch.randn(batch_size, seqlen, rotary_dim // 2, device=device, dtype=torch.float32)
-    emb = torch.cat((freqs, freqs), dim=-1)
-    cos = emb.cos().to(dtype)
-    sin = emb.sin().to(dtype)
-
-    ref_q, ref_k = apply_rotary_transformers_torch_wrapper(q, k, cos, sin, unsqueeze_dim=1)
-    out_q, out_k = apply_rotary_kernel_wrapper(
-        q.clone(), k.clone(), cos, sin, transformers_style=True, unsqueeze_dim=1, as_module=as_module
-    )
-
-    assert torch.allclose(ref_q, out_q, atol=atol, rtol=rtol), "Rotary transformation results for Q do not match"
-    assert torch.allclose(ref_k, out_k, atol=atol, rtol=rtol), "Rotary transformation results for K do not match"
-
-    # verify the non-rotated part of Q and K remains unchanged
-    if rotary_dim < headdim:
-        assert torch.equal(
-            out_q[..., rotary_dim:], q[..., rotary_dim:]
-        ), "Non-rotated part of Q should be unchanged"
-        assert torch.equal(
-            out_k[..., rotary_dim:], k[..., rotary_dim:]
-        ), "Non-rotated part of K should be unchanged"
 

--- a/rotary/tests/test_rotary.py
+++ b/rotary/tests/test_rotary.py
@@ -28,10 +28,32 @@ def apply_rotary_torch(x1: torch.Tensor, x2: torch.Tensor, cos: torch.Tensor, si
     return out1, out2
 
 
-def apply_rotary_torch_wrapper(q, k, cos, sin, conj: bool = False):
-    """the wrapper for apply_rotary_torch"""
+def apply_rotary_torch_wrapper(
+    q, k, cos, sin, conj: bool = False, transformers_style: bool = False, unsqueeze_dim: int = 1
+):
+    """the wrapper for apply_rotary_torch.
+
+    If transformers_style is True, implements the HuggingFace transformers RoPE convention
+    (rotate_half with duplicated frequencies), supporting partial RoPE where cos.shape[-1] <= q.shape[-1].
+    """
+    if transformers_style:
+        cos = cos.unsqueeze(unsqueeze_dim)
+        sin = sin.unsqueeze(unsqueeze_dim)
+        rotary_dim = min(cos.shape[-1], q.shape[-1])
+        q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+        k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+
+        def rotate_half(x):
+            x1 = x[..., : x.shape[-1] // 2]
+            x2 = x[..., x.shape[-1] // 2 :]
+            return torch.cat((-x2, x1), dim=-1)
+
+        q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
+        k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
+        return torch.cat([q_embed, q_pass], dim=-1), torch.cat([k_embed, k_pass], dim=-1)
+
     rotary_dim = cos.shape[-1]
-    
+
     # apply rotation encoding to Q
     q1 = q[..., :rotary_dim]
     q2 = q[..., rotary_dim : 2 * rotary_dim]
@@ -47,10 +69,18 @@ def apply_rotary_torch_wrapper(q, k, cos, sin, conj: bool = False):
     return q_out, k_out
 
 
-def apply_rotary_kernel_wrapper(q, k, cos, sin, conj: bool = False):
+def apply_rotary_kernel_wrapper(
+    q, k, cos, sin, conj: bool = False, transformers_style: bool = False, unsqueeze_dim: int = 1, as_module: bool = False
+):
     """the wrapper for apply_rotary_kernel"""
+    if transformers_style:
+        if as_module:
+            layer = rotary.layers.apply_rotary_transformers()
+            return layer(q, k, cos, sin, unsqueeze_dim=unsqueeze_dim)
+        return rotary.apply_rotary_transformers(q, k, cos, sin, unsqueeze_dim=unsqueeze_dim)
+
     rotary_dim = cos.shape[-1]
-    
+
     # apply rotation encoding to Q
     q1 = q[..., :rotary_dim]
     q2 = q[..., rotary_dim : 2 * rotary_dim]
@@ -62,10 +92,11 @@ def apply_rotary_kernel_wrapper(q, k, cos, sin, conj: bool = False):
     rotary.apply_rotary(k1, k2, cos, sin, k1, k2, conj)
 
 
+
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("nheads", [8, 16])
 @pytest.mark.parametrize("seqlen", [128, 256])
-@pytest.mark.parametrize("headdim, rotary_dim", [(64, 32), (128, 64), (64, 30)])
+@pytest.mark.parametrize("headdim, rotary_dim", [(64, 32), (128, 64), (64, 30), (128, 32)])
 @pytest.mark.parametrize("qk_dim", [3, 4])
 @pytest.mark.parametrize(
     "dtype, atol, rtol",
@@ -130,31 +161,29 @@ def test_rotary_equivalence(batch_size, nheads, seqlen, headdim, rotary_dim, qk_
         ), "Non-rotated part of K should be unchanged"
 
 
-def rotate_half(x):
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-def apply_rotary_pos_emb_transformers_ref(q, k, cos, sin, unsqueeze_dim=1):
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-    rotary_dim = cos.shape[-1]
-    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
-    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
-    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
-    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
-    q_embed = torch.cat([q_embed, q_pass], dim=-1)
-    k_embed = torch.cat([k_embed, k_pass], dim=-1)
-    return q_embed, k_embed
+def apply_rotary_transformers_torch_wrapper(q, k, cos, sin, unsqueeze_dim=1):
+    """Convenience alias delegating to apply_rotary_torch_wrapper with transformers_style=True."""
+    return apply_rotary_torch_wrapper(q, k, cos, sin, transformers_style=True, unsqueeze_dim=unsqueeze_dim)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("nheads", [8, 16])
 @pytest.mark.parametrize("seqlen", [128, 256])
 @pytest.mark.parametrize("headdim, rotary_dim", [(128, 128), (128, 32), (64, 32), (64, 16), (80, 20)])
-@pytest.mark.parametrize("dtype, atol, rtol", [(torch.float32, 1e-5, 1e-5)])
-def test_apply_rotary_transformers(batch_size, nheads, seqlen, headdim, rotary_dim, dtype, atol, rtol):
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-5, 1e-5),
+        pytest.param(
+            torch.bfloat16,
+            1e-1,
+            1e-5,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("as_module", [False, True])
+def test_apply_rotary_transformers(batch_size, nheads, seqlen, headdim, rotary_dim, dtype, atol, rtol, as_module):
     device = infer_device()
     if device is None:
         pytest.skip("No suitable device found for testing")
@@ -167,11 +196,20 @@ def test_apply_rotary_transformers(batch_size, nheads, seqlen, headdim, rotary_d
     cos = emb.cos().to(dtype)
     sin = emb.sin().to(dtype)
 
-    ref_q, ref_k = apply_rotary_pos_emb_transformers_ref(q, k, cos, sin, unsqueeze_dim=1)
+    ref_q, ref_k = apply_rotary_transformers_torch_wrapper(q, k, cos, sin, unsqueeze_dim=1)
+    out_q, out_k = apply_rotary_kernel_wrapper(
+        q.clone(), k.clone(), cos, sin, transformers_style=True, unsqueeze_dim=1, as_module=as_module
+    )
 
-    layer = rotary.layers.apply_rotary_transformers()
-    out_q, out_k = layer(q, k, cos, sin, unsqueeze_dim=1)
+    assert torch.allclose(ref_q, out_q, atol=atol, rtol=rtol), "Rotary transformation results for Q do not match"
+    assert torch.allclose(ref_k, out_k, atol=atol, rtol=rtol), "Rotary transformation results for K do not match"
 
-    assert torch.allclose(ref_q, out_q, atol=atol, rtol=rtol)
-    assert torch.allclose(ref_k, out_k, atol=atol, rtol=rtol)
+    # verify the non-rotated part of Q and K remains unchanged
+    if rotary_dim < headdim:
+        assert torch.equal(
+            out_q[..., rotary_dim:], q[..., rotary_dim:]
+        ), "Non-rotated part of Q should be unchanged"
+        assert torch.equal(
+            out_k[..., rotary_dim:], k[..., rotary_dim:]
+        ), "Non-rotated part of K should be unchanged"
 

--- a/rotary/tests/test_rotary.py
+++ b/rotary/tests/test_rotary.py
@@ -65,6 +65,7 @@ def apply_rotary_kernel_wrapper(q, k, cos, sin, conj: bool = False):
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("nheads", [8, 16])
 @pytest.mark.parametrize("seqlen", [128, 256])
+# (headdim, rotary_dim): standard full RoPE (2 * rotary_dim == headdim) and partial RoPE cases (e.g. half-half where 2 * rotary_dim == headdim // 2)
 @pytest.mark.parametrize("headdim, rotary_dim", [(64, 32), (128, 64), (64, 30), (128, 32), (64, 16), (80, 20)])
 @pytest.mark.parametrize("qk_dim", [3, 4])
 @pytest.mark.parametrize(
@@ -129,28 +130,5 @@ def test_rotary_equivalence(batch_size, nheads, seqlen, headdim, rotary_dim, qk_
             k_kernel[..., 2 * rotary_dim:], k_orig[..., 2 * rotary_dim:]
         ), "Non-rotated part of K should be unchanged"
 
-    # verify transformers layer and functional APIs match when not conjugated
-    if not conj and qk_dim == 4:
-        rot_dim_total = 2 * rotary_dim
-        q_trans = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
-        k_trans = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
-        freqs = torch.randn(batch_size, seqlen, rot_dim_total // 2, device=device, dtype=torch.float32)
-        emb = torch.cat((freqs, freqs), dim=-1)
-        cos_trans = emb.cos().to(dtype)
-        sin_trans = emb.sin().to(dtype)
-
-        out_q_fn, out_k_fn = rotary.apply_rotary_transformers(q_trans, k_trans, cos_trans, sin_trans, unsqueeze_dim=1)
-        layer = rotary.layers.apply_rotary_transformers()
-        out_q_mod, out_k_mod = layer(q_trans, k_trans, cos_trans, sin_trans, unsqueeze_dim=1)
-
-        assert torch.equal(out_q_fn, out_q_mod), "Functional and module outputs should be identical"
-        assert torch.equal(out_k_fn, out_k_mod), "Functional and module outputs should be identical"
-        if rot_dim_total < headdim:
-            assert torch.equal(
-                out_q_fn[..., rot_dim_total:], q_trans[..., rot_dim_total:]
-            ), "Non-rotated part of Q should be unchanged in transformers wrapper"
-            assert torch.equal(
-                out_k_fn[..., rot_dim_total:], k_trans[..., rot_dim_total:]
-            ), "Non-rotated part of K should be unchanged in transformers wrapper"
 
 

--- a/rotary/tests/test_rotary.py
+++ b/rotary/tests/test_rotary.py
@@ -128,3 +128,50 @@ def test_rotary_equivalence(batch_size, nheads, seqlen, headdim, rotary_dim, qk_
         assert torch.equal(
             k_kernel[..., 2 * rotary_dim:], k_orig[..., 2 * rotary_dim:]
         ), "Non-rotated part of K should be unchanged"
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_transformers_ref(q, k, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
+    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
+    q_embed = torch.cat([q_embed, q_pass], dim=-1)
+    k_embed = torch.cat([k_embed, k_pass], dim=-1)
+    return q_embed, k_embed
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("nheads", [8, 16])
+@pytest.mark.parametrize("seqlen", [128, 256])
+@pytest.mark.parametrize("headdim, rotary_dim", [(128, 128), (128, 32), (64, 32), (64, 16), (80, 20)])
+@pytest.mark.parametrize("dtype, atol, rtol", [(torch.float32, 1e-5, 1e-5)])
+def test_apply_rotary_transformers(batch_size, nheads, seqlen, headdim, rotary_dim, dtype, atol, rtol):
+    device = infer_device()
+    if device is None:
+        pytest.skip("No suitable device found for testing")
+
+    q = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, nheads, seqlen, headdim, device=device, dtype=dtype)
+
+    freqs = torch.randn(batch_size, seqlen, rotary_dim // 2, device=device, dtype=torch.float32)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().to(dtype)
+    sin = emb.sin().to(dtype)
+
+    ref_q, ref_k = apply_rotary_pos_emb_transformers_ref(q, k, cos, sin, unsqueeze_dim=1)
+
+    layer = rotary.layers.apply_rotary_transformers()
+    out_q, out_k = layer(q, k, cos, sin, unsqueeze_dim=1)
+
+    assert torch.allclose(ref_q, out_q, atol=atol, rtol=rtol)
+    assert torch.allclose(ref_k, out_k, atol=atol, rtol=rtol)
+

--- a/rotary/torch-ext/rotary/__init__.py
+++ b/rotary/torch-ext/rotary/__init__.py
@@ -33,20 +33,23 @@ def apply_rotary_transformers(
     q_rotated = q.clone()
     k_rotated = k.clone()
 
-    # Get half dimension for rotation
-    half_dim = q.shape[-1] // 2
-    q1 = q_rotated[..., :half_dim]
-    q2 = q_rotated[..., half_dim:]
-    k1 = k_rotated[..., :half_dim]
-    k2 = k_rotated[..., half_dim:]
-    if cos.shape[-1] != half_dim:
-        # Trim cos/sin to match half_dim
-        cos = cos[..., :half_dim]
-        sin = sin[..., :half_dim]
+    # Support both full and partial RoPE:
+    # If cos.shape[-1] < q.shape[-1], only rotate the first rotary_dim dimensions.
+    rotary_dim = min(cos.shape[-1], q.shape[-1])
+    half_rotary_dim = rotary_dim // 2
 
-    apply_rotary(q1, q2, cos, sin, q1, q2, False)
-    apply_rotary(k1, k2, cos, sin, k1, k2, False)
+    q1 = q_rotated[..., :half_rotary_dim]
+    q2 = q_rotated[..., half_rotary_dim:rotary_dim]
+    k1 = k_rotated[..., :half_rotary_dim]
+    k2 = k_rotated[..., half_rotary_dim:rotary_dim]
+
+    cos_rot = cos[..., :half_rotary_dim]
+    sin_rot = sin[..., :half_rotary_dim]
+
+    apply_rotary(q1, q2, cos_rot, sin_rot, q1, q2, False)
+    apply_rotary(k1, k2, cos_rot, sin_rot, k1, k2, False)
     return q_rotated, k_rotated
+
 
 
 # Add torch compile support for functions

--- a/rotary/torch-ext/rotary/layers.py
+++ b/rotary/torch-ext/rotary/layers.py
@@ -25,17 +25,20 @@ class apply_rotary_transformers(nn.Module):
         q_rotated = q.clone()
         k_rotated = k.clone()
 
-        # Get half dimension for rotation
-        half_dim = q.shape[-1] // 2
-        q1 = q_rotated[..., :half_dim]
-        q2 = q_rotated[..., half_dim:]
-        k1 = k_rotated[..., :half_dim]
-        k2 = k_rotated[..., half_dim:]
-        if cos.shape[-1] != half_dim:
-            # Trim cos/sin to match half_dim
-            cos = cos[..., :half_dim]
-            sin = sin[..., :half_dim]
+        # Support both full and partial RoPE:
+        # If cos.shape[-1] < q.shape[-1], only rotate the first rotary_dim dimensions.
+        rotary_dim = min(cos.shape[-1], q.shape[-1])
+        half_rotary_dim = rotary_dim // 2
 
-        ops.apply_rotary(q1, q2, cos, sin, q1, q2, False)
-        ops.apply_rotary(k1, k2, cos, sin, k1, k2, False)
+        q1 = q_rotated[..., :half_rotary_dim]
+        q2 = q_rotated[..., half_rotary_dim:rotary_dim]
+        k1 = k_rotated[..., :half_rotary_dim]
+        k2 = k_rotated[..., half_rotary_dim:rotary_dim]
+
+        cos_rot = cos[..., :half_rotary_dim]
+        sin_rot = sin[..., :half_rotary_dim]
+
+        ops.apply_rotary(q1, q2, cos_rot, sin_rot, q1, q2, False)
+        ops.apply_rotary(k1, k2, cos_rot, sin_rot, k1, k2, False)
         return q_rotated, k_rotated
+


### PR DESCRIPTION
## Description

This PR updates `apply_rotary_transformers` in `rotary` to seamlessly support **partial RoPE** (where `rotary_dim < head_dim`), while maintaining 100% backward compatibility for standard full RoPE.

As discussed with @vasqu in [huggingface/transformers#48622](https://github.com/huggingface/transformers/issues/48622#issuecomment-5603524279):
> *Are we really losing much by just not moving the split and cat into torch. Imo, we can just add another functions similar to https://github.com/huggingface/kernels-community/blob/90423c8b8585e36f9c550cac65fce9a27430c58e/rotary/torch-ext/rotary/layers.py#L7-L41 which then makes a split and cat around it*

Instead of an extra function or separate kernel, `apply_rotary_transformers` now inspects `rotary_dim = min(cos.shape[-1], q.shape[-1])`. It slices and rotates the active `[:rotary_dim]` part in-place, leaving `[rotary_dim:]` pass-through dimensions completely intact.

## Changes
- `rotary/torch-ext/rotary/layers.py`: support `rotary_dim < q.shape[-1]` in `apply_rotary_transformers` module.
- `rotary/torch-ext/rotary/__init__.py`: match the same partial RoPE support in the top-level functional wrapper.
- `rotary/tests/test_rotary.py`: add comprehensive `test_apply_rotary_transformers` across full RoPE and partial RoPE dimensions (`(128, 128)`, `(128, 32)`, `(64, 32)`, `(64, 16)`, `(80, 20)`).

## Verification
- Verified E2E on GPU across all configurations (bfloat16, float32, full RoPE, and partial 25%/50% factors) matching HuggingFace `apply_rotary_pos_emb` mathematical output exactly.
